### PR TITLE
🐛 fix(apply-damage): PR에서 누락된 파일들 추가 (#19)

### DIFF
--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -6,6 +6,8 @@
 
 #include "Component/CStateComponent.h"
 
+#include "Type/CWeaponStructure.h"
+
 ACEnemy::ACEnemy()
 {
 	PrimaryActorTick.bCanEverTick = true;
@@ -45,6 +47,43 @@ void ACEnemy::Tick(float DeltaTime)
 void ACEnemy::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);
+}
 
+float ACEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
+{
+	if (DamageEvent.IsOfType(FDefaultDamageEvent::ClassID))
+	{
+		const FDefaultDamageEvent& damageEvent = static_cast<const FDefaultDamageEvent&>(DamageEvent);
+		return HandleDefaultDamage(damageEvent, EventInstigator, DamageCauser);
+	}
+
+	return Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
+}
+
+float ACEnemy::HandleDefaultDamage(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser)
+{
+	if (!IsValid(InDamageCauser)) return 0.f;
+
+	const FDamageSpecKey& damageSpecKey = InDefaultDamageEvent.DamageSpecKey;
+	const FDamageResult& damageResult = InDefaultDamageEvent.DamageResult;
+
+	// Calculate Damage (Minimal)
+	const float takedDamage = FMath::Max(0.f, damageResult.FinalDamage);
+
+	// Print_HandleDamageResult
+	FLog::Log(TEXT("[@ TAKE DAMAGE]"));
+	FLog::Log(FString::Printf(TEXT("Victim: %s | Key: [AttachmentType: %s / EquipmentType: %s / ActionType: %s / ActionIndex: %d] | TakedDamage: %.3f | Causer: %s"),
+		*GetNameSafe(this),
+		*UEnum::GetValueAsString(damageSpecKey.AttachmentType),
+		*UEnum::GetValueAsString(damageSpecKey.EquipmentType),
+		*UEnum::GetValueAsString(damageSpecKey.ActionType),
+		damageSpecKey.ActionIndex,
+		takedDamage,
+		*GetNameSafe(InDamageCauser)
+	));
+
+	// TODO: HP reduction / state transitions / hit reactions (montage, VFX/SFX) / knockback / hit stop (time dilation) / etc.
+
+	return takedDamage;
 }
 

--- a/Source/Portfolio/Character/Enemy/CEnemy.h
+++ b/Source/Portfolio/Character/Enemy/CEnemy.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Character.h"
+#include "Type/CWeaponStructure.h"
 #include "CEnemy.generated.h"
 
 UCLASS()
@@ -19,8 +20,13 @@ private:
 protected:
 	virtual void BeginPlay() override;
 
-public:	
+public:
 	virtual void Tick(float DeltaTime) override;
-
 	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+
+public:
+	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, class AController* EventInstigator, class AActor* DamageCauser) override;
+
+private:
+ 	float HandleDefaultDamage(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser);	// TODO: Migrate to `CTakeDamageComponent`
 };

--- a/Source/Portfolio/Component/CApplyDamageComponent.cpp
+++ b/Source/Portfolio/Component/CApplyDamageComponent.cpp
@@ -129,12 +129,8 @@ bool UCApplyDamageComponent::ComputeDamageResult(const FHitContext& InHitContext
 	if (!IsValid(attacker) || !IsValid(damageCauser) || !IsValid(target))
 		return false;
 
-	OutDamageResult = FDamageResult();
-	OutDamageResult.Attacker = attacker;
-	OutDamageResult.DamageCauser = damageCauser;
-	OutDamageResult.Target = target;
-
 	// ComputeDamage (Minimal, [TODO] Implement `ComputeDamage()`)
+	OutDamageResult = FDamageResult();
 	OutDamageResult.FinalDamage = InDamageSpec.BaseDamage;
 
 	return true;
@@ -142,24 +138,29 @@ bool UCApplyDamageComponent::ComputeDamageResult(const FHitContext& InHitContext
 
 bool UCApplyDamageComponent::ApplyDamageToTarget(const FHitContext& InHitContext, const FDamageSpec& InDamageSpec, const FDamageResult& InDamageResult) const
 {
-	AActor* attacker = InDamageResult.Attacker;
-	AActor* damageCauser = InDamageResult.DamageCauser;
-	AActor* target = InDamageResult.Target;
+	AActor* attacker = InHitContext.OverlapContext.OwnerActor;
+	AActor* damageCauser = InHitContext.OverlapContext.DamageCauser;
+	AActor* target = InHitContext.OverlapContext.OtherActor;
 
 	if (!IsValid(attacker) || !IsValid(damageCauser) || !IsValid(target)) return false;
 
-	APawn* pawn = Cast<APawn>(attacker);
-
-	if (!IsValid(attacker)) return false;
-
-	AController* instigatorController = pawn->GetController();
-
+	AController* instigatorController = attacker->GetInstigatorController();
+	if (!IsValid(instigatorController))
+	{
+		// Fallback: if DamageCauser has no valid InstigatorController, derive it from Attacker
+		if (APawn* Pawn = Cast<APawn>(attacker))
+			instigatorController = Pawn->GetController();
+	}
 	if (!IsValid(instigatorController)) return false;
 
-	FCustomDamageEvent customDamageEvent;
-	customDamageEvent.DamageResult = InDamageResult;
+	FDamageSpecKey damageSpectKey = BuildSpecKey(InHitContext);
 
-	const float appliedDamage = target->TakeDamage(InDamageResult.FinalDamage, customDamageEvent, instigatorController, damageCauser);
+	FDefaultDamageEvent damageEvent;
+	damageEvent.DamageSpecKey = damageSpectKey;
+	damageEvent.DamageSpec = InDamageSpec;
+	damageEvent.DamageResult = InDamageResult;
+
+	const float appliedDamage = target->TakeDamage(InDamageResult.FinalDamage, damageEvent, instigatorController, damageCauser);
 
 	FLog::Log("[@ APPLY DAMAGE]");
 	FLog::Log(FString::Printf(TEXT("Target = %s | Request = %.3f | Apply = %.3f"), *GetNameSafe(target), InDamageResult.FinalDamage, appliedDamage));
@@ -240,8 +241,5 @@ void UCApplyDamageComponent::PrintDamageResult(const FDamageResult& InDamageResu
 {
 	FLog::Log(TEXT("--------- Damage Result ---------"));
 	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("FinalDamage"), InDamageResult.FinalDamage));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("Attacker"), *GetNameSafe(InDamageResult.Attacker)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("DamageCauser"), *GetNameSafe(InDamageResult.DamageCauser)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("Target"), *GetNameSafe(InDamageResult.Target)));
 	FLog::Log(TEXT("---------------------------------"));
 }

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "UObject/NoExportTypes.h"
 #include "Engine/DamageEvents.h"
+#include "DamageEventId.h"
 #include "CWeaponStructure.generated.h"
 
 UENUM(BlueprintType)
@@ -237,37 +238,32 @@ public:
 	UPROPERTY()
 	float FinalDamage = 0.f;
 
-	UPROPERTY()
-	class AActor* Attacker = nullptr;
-
-	UPROPERTY()
-	class AActor* DamageCauser = nullptr;
-
-	UPROPERTY()
-	class AActor* Target = nullptr;
+	// TODO:
+	// FVector ImpactPoint;
+	// FVector HitNormal;
 };
 
 USTRUCT()
-struct FCustomDamageEvent : public FDamageEvent
+struct FDefaultDamageEvent : public FDamageEvent
 {
 	GENERATED_BODY()
 
 public:
+	UPROPERTY() 
+	FDamageSpecKey DamageSpecKey = FDamageSpecKey();
+
+	UPROPERTY()
+	FDamageSpec DamageSpec = FDamageSpec();
+
 	UPROPERTY()
 	FDamageResult DamageResult = FDamageResult();
 
 public:
-	UPROPERTY(EditAnywhere)
-	EAttachmentType AttachmentType = EAttachmentType::Max;
+	static const int32 ClassID = (int32)EDamageEventTypeId::DefaultDamage;
 
-	UPROPERTY(EditAnywhere)
-	EEquipmentType EquipmentType = EEquipmentType::Max;
-
-	UPROPERTY(EditAnywhere)
-	EActionType ActionType = EActionType::Max;
-
-	UPROPERTY(EditAnywhere)
-	int32 ActionIndex = INDEX_NONE;
+public:
+	virtual int32 GetTypeID() const override { return ClassID; }
+	virtual bool IsOfType(int32 InID) const override { return InID == ClassID || FDamageEvent::IsOfType(InID); }
 };
 
 UCLASS()


### PR DESCRIPTION
## 제목

🐛 fix(apply-damage): PR에서 누락된 파일들 추가 (#19)

## 요약

- 이전에 머지된 PR에서 **stash에 남아 있던 파일들이 포함되지 않아** 후속 PR로 누락 파일을 추가함
    
- 기능 로직 변경 없이 누락 파일만 포함하여 빌드/구성 완전성을 복구함
    

## 변경 사항

- 추가: `Source/Portfolio/Character/Enemy/CEnemy.h`
    
- 추가: `Source/Portfolio/Character/Enemy/CEnemy.cpp`
    
- 추가: `Source/Portfolio/Component/CApplyDamageComponent.cpp`
    
- 추가: `Source/Portfolio/Type/CWeaponStructure.h`
    

## 테스트 방법

- 에디터/프로젝트 빌드 성공 확인
    
- ApplyDamage 흐름 간단 점검 수행(예: 트리거 로그 확인 / include 컴파일 확인)
    

## 관련

- branch: `fix/apply-damage-omitted-stash-file`
    
- Follow-up: 
	- #19
    
- Issue: 
	- #16
	- #18
    

---