### PR TITLE
♻️ refactor: Damage Pipeline 공유 구조 구현 및 규칙 정리 (#34)

### DIFF
--- a/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (EN).md
+++ b/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (EN).md
@@ -1,0 +1,107 @@
+# UE5 Portfolio – Issue Checklist
+
+## Title
+
+**M03-03: Organize Combat Core Shared Rules**
+
+### Date
+
+- **Day 13**
+
+- **Date : 2026.04.01**
+
+
+---
+
+### Goals
+
+- Organize the combat core shared by attackers and receivers, and finalize the common damage processing rules.
+
+- Organize the responsibilities and minimum policies across the `HitContext -> ApplyDamage -> DefaultDamageEvent -> TakeDamage -> Health -> Reaction` flow.
+
+- Structure the system so damage is processed under the same rules regardless of whether the target is the player or an Enemy.
+
+
+---
+
+### Branch
+
+- `feature/combat-core-shared`
+
+
+---
+
+### TODO List
+
+#### 1. Organize ApplyDamage Responsibilities
+
+- [ ] Organize input/output responsibilities of the `ApplyDamage` stage
+
+- [ ] Finalize spec lookup policy based on `FApplyDamageSpecKey`
+
+- [ ] Organize spec miss handling policy
+
+- [ ] Organize minimal debug log flow
+
+
+#### 2. Organize Duplicate Hit and Attack Rules
+
+- [ ] Add duplicate hit prevention policy within the same attack window
+
+- [ ] Preserve self-hit prohibition rule
+
+- [ ] Organize duplicate target overlap handling policy
+
+- [ ] Organize follow-up policy for stop damage / overlap end
+
+
+#### 3. Organize Team / Friendly Fire Policy
+
+- [ ] Decide whether to introduce a team identification structure
+
+- [ ] Decide whether friendly fire is allowed
+
+- [ ] Apply stub policy if not implemented yet
+
+
+#### 4. Organize TakeDamage Responsibilities
+
+- [ ] Fix the meaning of `Requested / Mitigated / FinalTaken / FinalApplied`
+
+- [ ] Organize request reject conditions
+
+- [ ] Organize accepted / rejected follow-up direction
+
+- [ ] Organize dead target handling policy
+
+
+#### 5. Organize Reaction Connection Rules
+
+- [ ] Organize minimum conditions for reaction entry
+
+- [ ] Organize connection rules from damage result to reaction request
+
+- [ ] Organize priority between death transition and reaction
+
+
+#### 6. Integrated Validation
+
+- [ ] Scenario 1: confirm Player/Enemy damage processing under the same rules
+
+- [ ] Scenario 2: confirm duplicate hit prevention within the same attack window
+
+- [ ] Scenario 3: confirm invalid request rejection
+
+- [ ] Scenario 4: confirm additional damage handling policy on dead targets
+
+
+---
+
+### Notes
+
+- The goal of this issue is **to organize shared combat rules and minimum policies**, rather than advanced numeric design.
+
+- Later extensions such as Guard, Armor, Resistance, Team, and Friendly Fire should be designed to build on top of these rules.
+
+
+---

--- a/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (EN).md
+++ b/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (EN).md
@@ -1,4 +1,4 @@
-# UE5 Portfolio – Issue Checklist
+# UE5 Portfolio Issue Checklist
 
 ## Title
 
@@ -19,7 +19,7 @@
 
 - Organize the responsibilities and minimum policies across the `HitContext -> ApplyDamage -> DefaultDamageEvent -> TakeDamage -> Health -> Reaction` flow.
 
-- Structure the system so damage is processed under the same rules regardless of whether the target is the player or an Enemy.
+- Structure the system so damage is processed under the same rules regardless of whether the target is the Player or an Enemy.
 
 
 ---
@@ -35,64 +35,70 @@
 
 #### 1. Organize ApplyDamage Responsibilities
 
-- [ ] Organize input/output responsibilities of the `ApplyDamage` stage
+- [x] Organize input/output responsibilities of the `ApplyDamage` stage
 
-- [ ] Finalize spec lookup policy based on `FApplyDamageSpecKey`
+- [x] Finalize spec lookup policy based on `FApplyDamageSpecKey`
 
-- [ ] Organize spec miss handling policy
+- [x] Organize spec miss handling policy
 
-- [ ] Organize minimal debug log flow
-
-
-#### 2. Organize Duplicate Hit and Attack Rules
-
-- [ ] Add duplicate hit prevention policy within the same attack window
-
-- [ ] Preserve self-hit prohibition rule
-
-- [ ] Organize duplicate target overlap handling policy
-
-- [ ] Organize follow-up policy for stop damage / overlap end
+- [x] Organize minimal debug log flow
 
 
-#### 3. Organize Team / Friendly Fire Policy
+#### 2. Organize Hit Window and Duplicate Hit Rules
 
-- [ ] Decide whether to introduce a team identification structure
+- [x] Add hit window based attack window identification rules
 
-- [ ] Decide whether friendly fire is allowed
+- [x] Add duplicate hit prevention policy within the same attack window
 
-- [ ] Apply stub policy if not implemented yet
+- [x] Preserve self-hit prohibition rule
 
+- [x] Organize duplicate target overlap handling policy
 
-#### 4. Organize TakeDamage Responsibilities
-
-- [ ] Fix the meaning of `Requested / Mitigated / FinalTaken / FinalApplied`
-
-- [ ] Organize request reject conditions
-
-- [ ] Organize accepted / rejected follow-up direction
-
-- [ ] Organize dead target handling policy
+- [x] Organize hit window open / close follow-up policy
 
 
-#### 5. Organize Reaction Connection Rules
+#### 3. Organize TakeDamage Responsibilities
 
-- [ ] Organize minimum conditions for reaction entry
+- [x] Fix the meaning of `Requested / Mitigated / FinalTaken / Committed`
 
-- [ ] Organize connection rules from damage result to reaction request
+- [x] Organize request reject conditions
 
-- [ ] Organize priority between death transition and reaction
+- [x] Organize accepted / rejected follow-up direction
+
+- [x] Organize dead target handling policy
 
 
-#### 6. Integrated Validation
+#### 4. Organize Reaction Connection Rules
 
-- [ ] Scenario 1: confirm Player/Enemy damage processing under the same rules
+- [x] Organize minimum conditions for reaction entry
 
-- [ ] Scenario 2: confirm duplicate hit prevention within the same attack window
+- [x] Organize connection rules from damage result to reaction request
 
-- [ ] Scenario 3: confirm invalid request rejection
+- [x] Organize priority between death transition and reaction
 
-- [ ] Scenario 4: confirm additional damage handling policy on dead targets
+
+#### 5. Integrated Validation
+
+- [x] Scenario 1: confirm Player / Enemy damage processing under the same rules
+
+- [x] Scenario 2: confirm duplicate hit prevention within the same attack flow
+
+- [x] Scenario 3: confirm normal damage processing from attack start to first hit
+
+- [x] Scenario 4: confirm follow-up flow including reaction / death transition after damage
+
+- [x] Scenario 5: confirm additional damage handling policy on dead targets
+
+
+---
+
+### Current Outcome
+
+- Both `ApplyDamage` and `TakeDamage` have been organized into a shared `Payload / Context / Result` flow.
+
+- Hit window based duplicate-hit prevention, invalid request rejection, and dead target protection have been reflected in the current branch.
+
+- `Reaction` has been connected using `CommittedDamage` and dead-state before/after conditions.
 
 
 ---
@@ -101,7 +107,18 @@
 
 - The goal of this issue is **to organize shared combat rules and minimum policies**, rather than advanced numeric design.
 
-- Later extensions such as Guard, Armor, Resistance, Team, and Friendly Fire should be designed to build on top of these rules.
+- Later extensions such as Guard, Armor, and Resistance should be designed to build on top of the current shared combat core.
+
+
+---
+
+### Follow-Up TODO
+
+  - Decide whether to introduce a team identification structure
+
+  - Decide Friendly Fire allowance and resolution policy
+
+  - Connect extended receiver-side policies such as Guard / Armor / Resistance
 
 
 ---

--- a/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (KR).md
+++ b/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (KR).md
@@ -1,8 +1,8 @@
-# UE5 Portfolio – Issue Checklist
+# UE5 Portfolio Issue Checklist
 
 ## 제목
 
-**M03-03: Combat Core Shared 규약 정리**
+**M03-03: Combat Core Shared 규칙 정리**
 
 ### 날짜
 
@@ -15,17 +15,16 @@
 
 ### 목표
 
-- 공격자와 피격자가 공유하는 전투 코어를 정리하고, 공통 데미지 처리 규약을 확정함.
+- 공격자와 피격자가 공유하는 전투 코어를 정리하고, 공통 데미지 처리 규칙을 확정함.
 
 - `HitContext -> ApplyDamage -> DefaultDamageEvent -> TakeDamage -> Health -> Reaction` 흐름에서 각 단계의 책임과 최소 정책을 정리함.
 
-- 플레이어/Enemy 구분 없이 동일한 규칙으로 데미지가 처리되도록 구조를 정리함.
+- Player / Enemy 구분 없이 동일한 규칙으로 데미지가 처리되도록 구조를 정리함.
 
 
 ---
 
 ### 브랜치
-
 - `feature/combat-core-shared`
 
 
@@ -35,73 +34,88 @@
 
 #### 1. ApplyDamage 단계 책임 정리
 
-- [ ] `ApplyDamage` 단계 입력/출력 책임 정리
+- [x] `ApplyDamage` 단계 입력/출력 책임 정리
 
-- [ ] `FApplyDamageSpecKey` 기준 spec 조회 정책 확정
+- [x] `FApplyDamageSpecKey` 기반 spec 조회 정책 확정
 
-- [ ] spec miss 처리 정책 정리
+- [x] spec miss 처리 정책 정리
 
-- [ ] 최소 디버그 로그 흐름 정리
-
-
-#### 2. 중복 타격 및 공격 규칙 정리
-
-- [ ] 동일 공격 윈도우 내 중복 타격 방지 정책 추가
-
-- [ ] self-hit 금지 규칙 유지
-
-- [ ] target 중복 overlap 처리 정책 정리
-
-- [ ] stop damage / overlap end 후속 정책 정리
+- [x] 최소 디버그 로그 흐름 정리
 
 
-#### 3. Team / Friendly Fire 정책 정리
+#### 2. 공격 윈도우 및 중복 타격 규칙 정리
 
-- [ ] 팀 판정 구조 도입 여부 결정
+- [x] hit window 기반 공격 윈도우 식별 규칙 추가
 
-- [ ] friendly fire 허용 여부 결정
+- [x] 동일 공격 윈도우 내 중복 타격 방지 정책 추가
 
-- [ ] 미구현 시 stub 정책 반영
+- [x] self-hit 금지 규칙 유지
 
+- [x] target 중복 overlap 처리 정책 정리
 
-#### 4. TakeDamage 단계 책임 정리
-
-- [ ] `Requested / Mitigated / FinalTaken / FinalApplied` 의미 고정
-
-- [ ] request reject 조건 정리
-
-- [ ] accepted / rejected 후처리 방향 정리
-
-- [ ] dead 대상 처리 정책 정리
+- [x] hit window open / close 후속 정책 정리
 
 
-#### 5. Reaction 연결 규칙 정리
+#### 3. TakeDamage 단계 책임 정리
 
-- [ ] reaction 진입 최소 조건 정리
+- [x] `Requested / Mitigated / FinalTaken / Committed` 의미 확정
 
-- [ ] damage result -> reaction request 연결 규칙 정리
+- [x] request reject 조건 정리
 
-- [ ] dead 전이와 reaction 우선순위 기준 정리
+- [x] accepted / rejected 후처리 방향 정리
+
+- [x] dead target 처리 정책 정리
 
 
-#### 6. 통합 검증
+#### 4. Reaction 연결 규칙 정리
 
-- [ ] 시나리오 1: 동일 규칙으로 Player/Enemy 데미지 처리 확인
+- [x] reaction 진입 최소 조건 정리
 
-- [ ] 시나리오 2: 동일 공격 윈도우 중복 히트 방지 확인
+- [x] damage result -> reaction request 연결 규칙 정리
 
-- [ ] 시나리오 3: invalid request reject 확인
+- [x] death 전이와 reaction 우선순위 기준 정리
 
-- [ ] 시나리오 4: dead 대상 추가 데미지 처리 정책 확인
+
+#### 5. 통합 검증
+- [x] 시나리오 1: 동일 규칙으로 Player / Enemy 데미지 처리 확인
+
+- [x] 시나리오 2: 동일 공격 흐름 내 중복 타격 방지 확인
+
+- [x] 시나리오 3: 공격 시작부터 첫 타까지 데미지 처리 흐름 정상 동작 확인
+
+- [x] 시나리오 4: 피격 후 reaction / dead 전이 포함 후속 처리 흐름 확인
+
+- [x] 시나리오 5: dead target 추가 데미지 처리 정책 확인
+
+
+---
+
+### 현재 정리 결과
+
+- `ApplyDamage`와 `TakeDamage`는 공통적으로 `Payload / Context / Result` 흐름으로 정리되었음.
+
+- hit window 기반 중복 타격 방지, invalid request reject, dead target 방어 정책이 반영되었음.
+
+- `Reaction`은 `CommittedDamage`와 dead-state 전후 조건을 기준으로 연결되도록 정리되었음.
 
 
 ---
 
 ### Notes
 
-- 본 이슈는 고급 수치 설계보다 **전투 공통 규약과 최소 정책 정리**를 목표로 함.
+- 본 이슈는 고급 수치 설계보다 **전투 공통 규칙과 최소 정책 정리**를 목표로 함.
 
-- 이후 Guard, Armor, Resistance, Team, Friendly Fire 확장은 이 규약 위에서 확장 가능하도록 설계함.
+- 이후 Guard, Armor, Resistance 같은 수치 확장 요소는 현재 정리된 shared combat core 위에 확장 가능하도록 설계함.
+
+---
+
+### Follow-Up TODO
+
+  - Team 식별 구조 도입 여부 결정
+
+  - Friendly Fire 허용 여부 및 판정 정책 결정
+
+  - Guard / Armor / Resistance 등 receiver-side 확장 정책 연결
 
 
 ---

--- a/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (KR).md
+++ b/Docs/01_Issue_CheckList/D13_UE5_Portfolio_Issue_Checklist (KR).md
@@ -1,0 +1,107 @@
+# UE5 Portfolio – Issue Checklist
+
+## 제목
+
+**M03-03: Combat Core Shared 규약 정리**
+
+### 날짜
+
+- **Day 13**
+
+- **Date : 2026.04.01**
+
+
+---
+
+### 목표
+
+- 공격자와 피격자가 공유하는 전투 코어를 정리하고, 공통 데미지 처리 규약을 확정함.
+
+- `HitContext -> ApplyDamage -> DefaultDamageEvent -> TakeDamage -> Health -> Reaction` 흐름에서 각 단계의 책임과 최소 정책을 정리함.
+
+- 플레이어/Enemy 구분 없이 동일한 규칙으로 데미지가 처리되도록 구조를 정리함.
+
+
+---
+
+### 브랜치
+
+- `feature/combat-core-shared`
+
+
+---
+
+### TODO List
+
+#### 1. ApplyDamage 단계 책임 정리
+
+- [ ] `ApplyDamage` 단계 입력/출력 책임 정리
+
+- [ ] `FApplyDamageSpecKey` 기준 spec 조회 정책 확정
+
+- [ ] spec miss 처리 정책 정리
+
+- [ ] 최소 디버그 로그 흐름 정리
+
+
+#### 2. 중복 타격 및 공격 규칙 정리
+
+- [ ] 동일 공격 윈도우 내 중복 타격 방지 정책 추가
+
+- [ ] self-hit 금지 규칙 유지
+
+- [ ] target 중복 overlap 처리 정책 정리
+
+- [ ] stop damage / overlap end 후속 정책 정리
+
+
+#### 3. Team / Friendly Fire 정책 정리
+
+- [ ] 팀 판정 구조 도입 여부 결정
+
+- [ ] friendly fire 허용 여부 결정
+
+- [ ] 미구현 시 stub 정책 반영
+
+
+#### 4. TakeDamage 단계 책임 정리
+
+- [ ] `Requested / Mitigated / FinalTaken / FinalApplied` 의미 고정
+
+- [ ] request reject 조건 정리
+
+- [ ] accepted / rejected 후처리 방향 정리
+
+- [ ] dead 대상 처리 정책 정리
+
+
+#### 5. Reaction 연결 규칙 정리
+
+- [ ] reaction 진입 최소 조건 정리
+
+- [ ] damage result -> reaction request 연결 규칙 정리
+
+- [ ] dead 전이와 reaction 우선순위 기준 정리
+
+
+#### 6. 통합 검증
+
+- [ ] 시나리오 1: 동일 규칙으로 Player/Enemy 데미지 처리 확인
+
+- [ ] 시나리오 2: 동일 공격 윈도우 중복 히트 방지 확인
+
+- [ ] 시나리오 3: invalid request reject 확인
+
+- [ ] 시나리오 4: dead 대상 추가 데미지 처리 정책 확인
+
+
+---
+
+### Notes
+
+- 본 이슈는 고급 수치 설계보다 **전투 공통 규약과 최소 정책 정리**를 목표로 함.
+
+- 이후 Guard, Armor, Resistance, Team, Friendly Fire 확장은 이 규약 위에서 확장 가능하도록 설계함.
+
+
+---

--- a/Docs/03-01_Bug_Report/B05_UE5_Portfolio_Bug_Report (EN).md
+++ b/Docs/03-01_Bug_Report/B05_UE5_Portfolio_Bug_Report (EN).md
@@ -1,0 +1,267 @@
+# UE5 Portfolio Bug Report (EN)
+
+## Title
+
+**M3-B05: Fix first-hit `InvalidRequest` reject caused by `CurrentHitWindowId` increment timing issue**
+
+### Date
+
+- **Day 18**
+
+- **2026.04.06**
+
+### Type
+
+- Bug
+
+### Status
+
+- [x] Resolved
+
+### Branch
+
+- `feature/combat-core-shared`
+
+
+---
+
+## Summary
+
+- In `ACAttachment::CollisionEnabled()`, `UShapeComponent` could call `SetCollisionEnabled` and trigger an overlap before `CurrentHitWindowId` was incremented.
+
+- As a result, `BuildOverlapContext()` created an `FHitContext` with `HitWindowId = -1`, and `UCApplyDamageComponent::ValidateRequest()` immediately rejected it as `InvalidRequest`.
+
+- This bug was fixed by reorganizing `ACAttachment::CollisionEnabled()` so that a valid `HitWindowId` is prepared before `UShapeComponent` calls `SetCollisionEnabled`.
+
+
+---
+
+## Environment
+
+- Engine: Unreal Engine 5.4
+
+- Target: `ACAttachment` / `UCApplyDamageComponent`
+
+- Related Flow:
+
+  - Player or Enemy enables attachment collision through an attack animation notify
+
+  - The first overlap occurs immediately after activation
+
+  - `HitWindowId` is not yet set to a valid value at the overlap timing
+
+  - The first hit is rejected as `InvalidRequest` in the `ApplyDamage` stage
+
+
+---
+
+## Reproduction Steps
+
+1. Call `CollisionEnabled()` through an attack animation notify on a melee weapon attachment used by either the Player or an Enemy.
+
+2. Perform the attack at close range so that an overlap occurs immediately after collision is enabled.
+
+3. Check the `FOverlapContext.HitWindowId` value at the first overlap timing through logs.
+
+4. Verify that `UCApplyDamageComponent::ValidateRequest()` rejects the request because `HitWindowId == INDEX_NONE`.
+
+5. Confirm that the following log pattern is reproduced.
+
+```text
+RejectReason = EApplyDamageRejectReason::InvalidRequest
+HitWindowId = -1
+```
+
+
+---
+
+## Expected Result vs Actual Result
+
+**Expected Result**
+
+- A valid hit window id should be prepared before attachment collision can generate an overlap.
+
+- The first overlap should also be delivered as an `FHitContext` with a valid `HitWindowId`.
+
+- The `ApplyDamage -> TakeDamage` flow should proceed normally starting from the first hit.
+
+**Actual Result**
+
+- At the first overlap timing, `HitWindowId` was passed as `INDEX_NONE(-1)`.
+
+- `UCApplyDamageComponent::ValidateRequest()` rejected the request as `InvalidRequest`.
+
+- As a result, the first hit was not applied and the flow terminated early on the sender side.
+
+
+---
+
+## Cause
+
+```cpp
+bool bCollisionEnabled = false;
+
+if (!InName.IsNone()) 
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		if (collision->GetFName() == InName)
+		{
+			collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+			bCollisionEnabled = true;
+			break;
+		}
+	}
+}
+else
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+		bCollisionEnabled = true;
+	}
+}
+
+if (!bCollisionEnabled) return;
+
+if (!bHitWindowOpened)
+{
+	++CurrentHitWindowId; // Error Point
+
+	bHitWindowOpened = true;
+
+	if (IsValid(ApplyDamageComp_Cached))
+	{
+		ApplyDamageComp_Cached->NotifyHitWindowOpened(this, CurrentHitWindowId);
+	}
+}
+```
+
+- The core issue was the processing order inside `ACAttachment::CollisionEnabled()`.
+
+- In the previous structure, attachment collision activation and hit window initialization were separated, so the first overlap could arrive before the hit window id was ready.
+
+- The resulting flow was as follows.
+	
+	1. An attack notify calls `CollisionEnabled()`.
+	
+	2. The first overlap callback occurs immediately after attachment collision is enabled.
+	
+	3. `BuildOverlapContext()` reads `CurrentHitWindowId` before it has been updated.
+	
+	4. `HitWindowId = INDEX_NONE(-1)` is stored in `FHitContext`.
+	
+	5. `UCApplyDamageComponent::ValidateRequest()` interprets it as an invalid request.
+
+- The essence of this bug was that **a valid hit window id needed to be prepared before the first overlap occurred, but the overlap timing and hit window initialization timing were out of sync**.
+
+
+---
+
+## Fix
+
+```cpp
+TArray<UShapeComponent*> collisionsToEnable;
+
+if (!InName.IsNone())
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		if (collision->GetFName() == InName)
+		{
+			collisionsToEnable.Add(collision);
+			break;
+		}
+	}
+}
+else
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		collisionsToEnable.Add(collision);
+	}
+}
+
+// Early-Return
+if (collisionsToEnable.IsEmpty()) return;
+
+if (!bHitWindowOpened)
+{
+	++CurrentHitWindowId;
+	bHitWindowOpened = true;
+
+	if (IsValid(ApplyDamageComp_Cached))
+	{
+		ApplyDamageComp_Cached->NotifyHitWindowOpened(this, CurrentHitWindowId);
+	}
+}
+
+for (UShapeComponent* collision : collisionsToEnable)
+{
+	collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+}
+```
+
+- The flow of `ACAttachment::CollisionEnabled()` was corrected as follows.
+	
+	1. First, collect the `UShapeComponent` list that will actually be activated.
+	
+	2. If there is no collision to activate, return immediately.
+	
+	3. Open the hit window and increment `CurrentHitWindowId` only when there is a valid activation target.
+	
+	4. Perform the actual collision enable after that.
+
+- The intent of this fix was as follows.
+	
+	1. Prevent an invalid state where only the hit window opens without any valid collision.
+	
+	2. Guarantee that a valid `HitWindowId` is always ready before the first overlap.
+	
+	3. Stabilize sender-side input conditions so that `ApplyDamage` does not reject the first hit as `InvalidRequest`.
+
+
+---
+
+## Verification
+
+1. Repeatedly checked first-overlap logs immediately after attack start for both Player attacks and Enemy attacks.
+
+2. Verified that `HitWindowId` is no longer printed as `-1` at the first overlap timing.
+
+3. Verified that `UCApplyDamageComponent::ValidateRequest()` no longer rejects the first hit as `InvalidRequest`.
+
+4. Verified that `ApplyDamage` summary logs are printed normally starting from the first hit.
+
+5. Verified that a bad state where only the hit window opens does not occur when there is no collision to activate.
+
+
+---
+
+## Result
+
+```cpp
+===== Apply Damage Summary ======
+[@ APPLY DAMAGE]
+| DamageCauser = BP_CAttachment_Sword_C_1 
+| Target = BP_CEnemy_C_1 
+| HitWindowId = 0
+| Base = 10.000 
+| Request = 10.000 
+| Committed = 10.000
+=================================
+```
+
+
+---
+
+## Notes
+
+- Changing the initial value of `HitWindowId` to `0` was considered, but it was not applied because it would only hide the structural issue as a temporary workaround.
+
+- Keeping `INDEX_NONE(-1)` as the meaning of "no valid hit window has been opened yet" is structurally safer.
+
+- The key point of this fix was not changing the default value, but clearly reordering the flow as **check collision enable availability -> open hit window -> perform actual collision enable**.
+
+
+---

--- a/Docs/03-01_Bug_Report/B05_UE5_Portfolio_Bug_Report (KR).md
+++ b/Docs/03-01_Bug_Report/B05_UE5_Portfolio_Bug_Report (KR).md
@@ -1,0 +1,267 @@
+# UE5 Portfolio Bug Report (KR)
+
+## 제목
+
+**M3-B05: `CurrentHitWindowId` 증가 타이밍 문제로 인한 첫 타격 `InvalidRequest` 리젝트 버그 수정**
+
+### Date
+
+- **Day 18**
+
+- **2026.04.06**
+
+### Type
+
+- Bug
+
+### Status
+
+- [x] Resolved
+
+### Branch
+
+- `feature/combat-core-shared`
+
+
+---
+
+## 요약
+
+- `ACAttachment::CollisionEnabled()`에서 `CurrentHitWindowId`가 증가되기 전에 `UShapeComponent`가 먼저 `SetCollisionEnabled` 되어 overlap가 먼저 발생할 수 있었음.
+
+- 그 결과 `BuildOverlapContext()`가 `HitWindowId = -1`을 담은 `FHitContext`를 생성했고, `UCApplyDamageComponent::ValidateRequest()`에서 이를 `InvalidRequest`로 즉시 리젝트 처리하는 버그가 발생했음.
+
+- 해당 버그는 `UShapeComponent`가 `SetCollisionEnabled` 되기 이전에 유효한 `HitWindowId`가 먼저 준비되도록 `ACAttachment::CollisionEnabled()` 흐름을 재정리하여 수정함.
+
+
+---
+
+## 환경
+
+- Engine: Unreal Engine 5.4
+
+- 대상: `ACAttachment` / `UCApplyDamageComponent`
+
+- 관련 흐름:
+
+  - Player 또는 Enemy가 공격 애니메이션 notify를 통해 attachment collision을 활성화함
+
+  - 활성화 직후 첫 overlap가 발생함
+
+  - overlap 시점의 `HitWindowId`가 아직 유효하게 세팅되지 않음
+
+  - `ApplyDamage` 단계에서 첫 타가 `InvalidRequest`로 리젝트됨
+
+
+---
+
+## 재현 방법
+
+1. Player 또는 Enemy의 근접 무기 attachment에 대해 공격 애니메이션 notify로 `CollisionEnabled()`를 호출함.
+
+2. collision이 활성화되는 즉시 상대와 overlap가 발생하도록 근접 거리에서 공격을 수행함.
+
+3. 첫 overlap 시점의 `FOverlapContext.HitWindowId` 값을 로그로 확인함.
+
+4. `UCApplyDamageComponent::ValidateRequest()`에서 `HitWindowId == INDEX_NONE` 조건으로 인해 요청이 리젝트되는지 확인함.
+
+5. 로그에서 다음과 같은 패턴이 재현되는지 확인함.
+
+```text
+RejectReason = EApplyDamageRejectReason::InvalidRequest
+HitWindowId = -1
+```
+
+
+---
+
+## 기대 결과 vs 실제 결과
+
+**기대 결과**
+
+- attachment collision이 실제로 overlap를 발생시키기 전에 유효한 hit window id가 먼저 준비되어야 함.
+
+- 첫 overlap도 정상적인 `HitWindowId`를 가진 `FHitContext`로 전달되어야 함.
+
+- 첫 타부터 `ApplyDamage -> TakeDamage` 흐름이 정상적으로 진행되어야 함.
+
+**실제 결과**
+
+- 첫 overlap 시점에 `HitWindowId`가 `INDEX_NONE(-1)` 상태로 전달되었음.
+
+- `UCApplyDamageComponent::ValidateRequest()`가 해당 요청을 `InvalidRequest`로 리젝트했음.
+
+- 결과적으로 첫 타가 적용되지 않고 sender-side에서 조기 종료되었음.
+
+
+---
+
+## 원인
+
+```cpp
+bool bCollisionEnabled = false;
+
+if (!InName.IsNone()) 
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		if (collision->GetFName() == InName)
+		{
+			collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+			bCollisionEnabled = true;
+			break;
+		}
+	}
+}
+else
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+		bCollisionEnabled = true;
+	}
+}
+
+if (!bCollisionEnabled) return;
+
+if (!bHitWindowOpened)
+{
+	++CurrentHitWindowId; // Error Point
+
+	bHitWindowOpened = true;
+
+	if (IsValid(ApplyDamageComp_Cached))
+	{
+		ApplyDamageComp_Cached->NotifyHitWindowOpened(this, CurrentHitWindowId);
+	}
+}
+```
+
+- 문제의 핵심은 `ACAttachment::CollisionEnabled()`의 처리 순서였음.
+
+- 기존 구조에서는 attachment collision 활성화와 hit window 초기화 타이밍이 분리되어 있었고, 첫 overlap가 hit window id 준비 이전에 들어올 수 있었음.
+
+- 그 결과 흐름은 다음과 같았음.
+	
+	1. 공격 notify가 `CollisionEnabled()`를 호출함.
+	
+	2. attachment collision 활성화 직후 첫 overlap callback이 발생함.
+	
+	3. `BuildOverlapContext()`는 아직 갱신되지 않은 `CurrentHitWindowId`를 읽음.
+	
+	4. `HitWindowId = INDEX_NONE(-1)`가 `FHitContext`에 포함됨.
+	
+	5. `UCApplyDamageComponent::ValidateRequest()`가 이를 invalid request로 판단함.
+
+- 해당 버그의 본질은 **첫 overlap가 발생하기 전에 hit window id가 유효한 값으로 준비되어야 하는데, overlap 타이밍과 hit window 초기화 타이밍이 어긋나 있었던 것**임.
+
+
+---
+
+## 수정
+
+```cpp
+TArray<UShapeComponent*> collisionsToEnable;
+
+if (!InName.IsNone())
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		if (collision->GetFName() == InName)
+		{
+			collisionsToEnable.Add(collision);
+			break;
+		}
+	}
+}
+else
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		collisionsToEnable.Add(collision);
+	}
+}
+
+// Early-Return
+if (collisionsToEnable.IsEmpty()) return;
+
+if (!bHitWindowOpened)
+{
+	++CurrentHitWindowId;
+	bHitWindowOpened = true;
+
+	if (IsValid(ApplyDamageComp_Cached))
+	{
+		ApplyDamageComp_Cached->NotifyHitWindowOpened(this, CurrentHitWindowId);
+	}
+}
+
+for (UShapeComponent* collision : collisionsToEnable)
+{
+	collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+}
+```
+
+- `ACAttachment::CollisionEnabled()`의 흐름을 다음과 같이 보정함.
+	
+	1. 먼저 실제로 활성화할 `UShapeComponent` 목록을 수집함.
+	
+	2. 활성화할 collision이 하나도 없으면 즉시 종료함.
+	
+	3. 활성화 대상이 있을 때만 hit window를 열고 `CurrentHitWindowId`를 증가시킴.
+	
+	4. 그 이후에 실제 collision enable을 수행함.
+
+- 수정 의도는 다음과 같음.
+	
+	1. 유효한 collision 없이 hit window만 열리는 잘못된 상태를 방지함.
+	
+	2. 첫 overlap 이전에 항상 유효한 `HitWindowId`가 준비되도록 보장함.
+	
+	3. `ApplyDamage`가 첫 타를 `InvalidRequest`로 리젝트하지 않도록 sender-side 입력 조건을 안정화함.
+
+
+---
+
+## 검증
+
+1. Player 공격과 Enemy 공격 양쪽에서 공격 시작 직후 첫 overlap 로그를 반복 확인함.
+
+2. 첫 overlap 시점에 `HitWindowId`가 더 이상 `-1`로 출력되지 않는지 확인함.
+
+3. `UCApplyDamageComponent::ValidateRequest()`가 첫 타를 `InvalidRequest`로 리젝트하지 않는지 확인함.
+
+4. 첫 타부터 `ApplyDamage` summary 로그가 정상적으로 출력되는지 확인함.
+
+5. 활성화할 collision이 없는 경우 hit window만 열리는 잘못된 상태가 발생하지 않는지 확인함.
+
+
+---
+
+## 결과
+
+```cpp
+===== Apply Damage Summary ======
+[@ APPLY DAMAGE]
+| DamageCauser = BP_CAttachment_Sword_C_1 
+| Target = BP_CEnemy_C_1 
+| HitWindowId = 0
+| Base = 10.000 
+| Request = 10.000 
+| Committed = 10.000
+=================================
+```
+
+
+---
+
+## Notes
+
+- `HitWindowId`의 초기값을 `0`으로 바꾸는 방식도 고려했으나 구조적 문제를 숨기는 임시 대응에 가깝기 때문에 적용하지 않았음.
+
+- `INDEX_NONE(-1)`는 “아직 유효한 hit window가 열리지 않았다”는 의미로 유지하는 편이 구조적으로 더 안전함.
+
+- 이 수정의 핵심은 **collision enable 가능 여부 확인 -> hit window open -> 실제 collision enable** 순서로 흐름을 명확히 정렬한 것임.
+
+
+---

--- a/Source/Portfolio/Component/CApplyDamageComponent.cpp
+++ b/Source/Portfolio/Component/CApplyDamageComponent.cpp
@@ -24,6 +24,31 @@ void UCApplyDamageComponent::TickComponent(float DeltaTime, ELevelTick TickType,
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 }
 
+void UCApplyDamageComponent::NotifyHitWindowOpened(AActor* InDamageCauser, int32 InHitWindowId)
+{
+	if (!IsValid(InDamageCauser)) return;
+	if (InHitWindowId == INDEX_NONE) return;
+
+	FApplyDamageHitWindowKey applyDamageHitWindowKey;
+	applyDamageHitWindowKey.DamageCauser = InDamageCauser;
+	applyDamageHitWindowKey.HitWindowId = InHitWindowId;
+
+	DamagedTargetContainer.Remove(applyDamageHitWindowKey);
+	DamagedTargetContainer.FindOrAdd(applyDamageHitWindowKey);
+}
+
+void UCApplyDamageComponent::NotifyHitWindowClosed(AActor* InDamageCauser, int32 InHitWindowId)
+{
+	if (!IsValid(InDamageCauser)) return;
+	if (InHitWindowId == INDEX_NONE) return;
+
+	FApplyDamageHitWindowKey applyDamageHitWindowKey;
+	applyDamageHitWindowKey.DamageCauser = InDamageCauser;
+	applyDamageHitWindowKey.HitWindowId = InHitWindowId;
+
+	DamagedTargetContainer.Remove(applyDamageHitWindowKey);
+}
+
 void UCApplyDamageComponent::RequestApplyDamage(const FHitContext& InHitContext)
 {
 	ProcessApplyDamage(InHitContext);
@@ -71,6 +96,9 @@ bool UCApplyDamageComponent::ValidateRequest(const FHitContext& InHitContext) co
 	// V0: Validate Minimal actors (OwnerActor / DamageCauser / OtherActor)
 	if (!overlapContext.IsValidMinimal()) return false;
 
+	// V0-1: Hit window must be opened before overlap is processed
+	if (overlapContext.HitWindowId == INDEX_NONE) return false;
+
 	// V1: Request owner must match this component owner
 	AActor* myOwner = GetOwner();
 	if (!IsValid(myOwner) || myOwner != overlapContext.OwnerActor) return false;
@@ -108,6 +136,9 @@ bool UCApplyDamageComponent::CheckApplyDamageRule(const FHitContext& InHitContex
 	// TODO:
 	// P1: CheckAlreadyHit
 	// P2: CheckTeam
+
+	if (IsDuplicateHit(InHitContext))
+		return false;
 
 	return true;
 }
@@ -175,7 +206,32 @@ bool UCApplyDamageComponent::ApplyDamageToTarget(const FHitContext& InHitContext
 
 	const float appliedDamage = target->TakeDamage(InApplyDamageResult.RequestDamage, damageEvent, instigatorController, damageCauser);
 
+	if (appliedDamage > 0.f)
+	{
+		CacheDamagedTargetInWindow(InHitContext);
+	}
+
 	return true;
+}
+
+bool UCApplyDamageComponent::IsDuplicateHit(const FHitContext& InHitContext) const
+{
+	const FApplyDamageHitWindowKey applyDamageHitWindowKey = BuildHitWindowKey(InHitContext);
+	const TSet<AActor*>* foundTargets = DamagedTargetContainer.Find(applyDamageHitWindowKey);
+
+	if (!foundTargets) return false;
+
+	return foundTargets->Contains(InHitContext.OverlapContext.OtherActor);
+}
+
+FApplyDamageHitWindowKey UCApplyDamageComponent::BuildHitWindowKey(const FHitContext& InHitContext) const
+{
+	FApplyDamageHitWindowKey applyDamageWindowKey;
+
+	applyDamageWindowKey.DamageCauser = InHitContext.OverlapContext.DamageCauser;
+	applyDamageWindowKey.HitWindowId = InHitContext.OverlapContext.HitWindowId;
+
+	return applyDamageWindowKey;
 }
 
 FApplyDamageSpecKey UCApplyDamageComponent::BuildSpecKey(const FHitContext& InHitContext) const
@@ -188,6 +244,16 @@ FApplyDamageSpecKey UCApplyDamageComponent::BuildSpecKey(const FHitContext& InHi
 	applyDamageSpecKey.ActionIndex = InHitContext.ActionContext.ActionIndex;
 
 	return applyDamageSpecKey;
+}
+
+void UCApplyDamageComponent::CacheDamagedTargetInWindow(const FHitContext& InHitContext)
+{
+	AActor* targetActor = InHitContext.OverlapContext.OtherActor;
+	if (!IsValid(targetActor)) return;
+
+	const FApplyDamageHitWindowKey key = BuildHitWindowKey(InHitContext);
+	auto& damagedTargets = DamagedTargetContainer.FindOrAdd(key);
+	damagedTargets.Add(targetActor);
 }
 
 void UCApplyDamageComponent::PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const
@@ -228,6 +294,7 @@ void UCApplyDamageComponent::PrintOverlapContextInfo(const FOverlapContext& InOv
 	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("OtherComponent"), *GetNameSafe(InOverlapContext.OtherComponent)));
 	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("OtherBodyIndex"), InOverlapContext.OtherBodyIndex));
 	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("bFromSweep"), InOverlapContext.bFromSweep ? TEXT("true") : TEXT("false")));
+	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("HitWindowId"), InOverlapContext.HitWindowId));
 
 	if (InOverlapContext.bFromSweep)
 	{

--- a/Source/Portfolio/Component/CApplyDamageComponent.cpp
+++ b/Source/Portfolio/Component/CApplyDamageComponent.cpp
@@ -33,6 +33,7 @@ void UCApplyDamageComponent::NotifyHitWindowOpened(AActor* InDamageCauser, int32
 	applyDamageHitWindowKey.DamageCauser = InDamageCauser;
 	applyDamageHitWindowKey.HitWindowId = InHitWindowId;
 
+	// Reset stale record for the same hit window key
 	DamagedTargetContainer.Remove(applyDamageHitWindowKey);
 	DamagedTargetContainer.FindOrAdd(applyDamageHitWindowKey);
 }
@@ -54,66 +55,78 @@ void UCApplyDamageComponent::RequestApplyDamage(const FHitContext& InHitContext)
 	ProcessApplyDamage(InHitContext);
 }
 
-void UCApplyDamageComponent::RequestStopDamage(const FHitContext& InHitContext)
-{
-	// TODO Example:
-	// 1) Remove target from active overlap / active damage set
-	// 2) Cancel timers for repeated hits (DoT)
-	// 3) Remove sustained effects (slow, burning, etc.) if they depend on overlap
-}
-
 void UCApplyDamageComponent::ProcessApplyDamage(const FHitContext& InHitContext)
 {
-	// [Function Object]
-	// FApplyDamageContext -> 'FDefaultDamageEvent + @' and ApplyDamage to Target
+	if (!ValidateRequest(InHitContext))
+	{
+		PrintApplyDamageRejectedSummaryInfo(InHitContext, EApplyDamageRejectReason::InvalidRequest);
+		return;
+	}
 
-	// TODO:
-	// Implement FApplyDamageContext { InHitContext(DamagedActor / EventInstigator / DamageCauser ...), damageSpecKey, damageSpec, applyDamageResult }
-	// Refactor debug output to use FApplyDamageContext (Reference: CTakeDamageComponent)
+	FApplyDamagePayload applyDamagePayload = BuildPayload(InHitContext);
+	FApplyDamageContext applyDamageContext = BuildContext(applyDamagePayload);
 
-	// 1) Check Valid of Request
-	if (!ValidateRequest(InHitContext)) return;
+	if (!ValidateContext(applyDamageContext))
+	{
+		const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
+		PrintApplyDamageRejectedSummaryInfo(applyDamageContext.HitContext, applyDamageResult.RejectReason);
+		return;
+	}
 
-	// 2) Check ApplyDamage Rules
-	if (!CheckApplyDamageRule(InHitContext)) return;
+	if (!CanApplyDamage(applyDamageContext))
+	{
+		const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
+		PrintApplyDamageRejectedSummaryInfo(applyDamageContext.HitContext, applyDamageResult.RejectReason);
+		return;
+	}
 
-	// 3) Resolve ApplyDamage Spec
-	FApplyDamageSpec damageSpec = FApplyDamageSpec();
-	if (!ResolveApplyDamageSpec(InHitContext, damageSpec)) return;
+	ResolveApplyDamageSpec(applyDamageContext);
+	if (!applyDamageContext.bAccepted)
+	{
+		const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
+		PrintApplyDamageRejectedSummaryInfo(applyDamageContext.HitContext, applyDamageResult.RejectReason);
+		return;
+	}
 
-	// 4) Compute ApplyDamage Result
-	FApplyDamageResult applyDamageResult = FApplyDamageResult();
-	if (!ComputeApplyDamageResult(InHitContext, damageSpec, applyDamageResult)) return;
+	ComputeApplyDamage(applyDamageContext);
+	if (!applyDamageContext.bAccepted)
+	{
+		const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
+		PrintApplyDamageRejectedSummaryInfo(applyDamageContext.HitContext, applyDamageResult.RejectReason);
+		return;
+	}
 
-	// 5) Apply Damage (Call Target->TakeDamage)
-	if (!ApplyDamageToTarget(InHitContext, damageSpec, applyDamageResult)) return;
+	CommitApplyDamage(applyDamageContext);
+	if (!applyDamageContext.bAccepted)
+	{
+		const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
+		PrintApplyDamageRejectedSummaryInfo(applyDamageContext.HitContext, applyDamageResult.RejectReason);
+		return;
+	}
+
+	const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
+	PrintApplyDamageSummaryInfo(applyDamageContext.HitContext, applyDamageResult);
 }
+
 
 bool UCApplyDamageComponent::ValidateRequest(const FHitContext& InHitContext) const
 {
 	const FOverlapContext& overlapContext = InHitContext.OverlapContext;
 
-	// V0: Validate Minimal actors (OwnerActor / DamageCauser / OtherActor)
+	// V1: Validate core actors (OwnerActor / DamageCauser / OtherActor)
 	if (!overlapContext.IsValidMinimal()) return false;
 
-	// V0-1: Hit window must be opened before overlap is processed
+	// V2: Check Valid Hit Window
 	if (overlapContext.HitWindowId == INDEX_NONE) return false;
 
-	// V1: Request owner must match this component owner
-	AActor* myOwner = GetOwner();
-	if (!IsValid(myOwner) || myOwner != overlapContext.OwnerActor) return false;
-
-	// V2: Prevent self-hit
-	if (overlapContext.OtherActor == overlapContext.OwnerActor)
-		return false;
-
-	// V3: Check Valid
+	// V3: Check Valid Object
 	// 3-1): Validate Components (current policy)
 	if (!IsValid(overlapContext.OverlappedComponent) || !IsValid(overlapContext.OtherComponent))
 		return false;
 
 	// 3-2): Attack collision must be ShapeComponent (current policy)
-	if (!IsValid(overlapContext.OverlapShape)) return false;
+	if (!IsValid(overlapContext.OverlapShape))
+		return false;
 
 	// V4: Check ownership
 	 // 4-1) DamageCauser must be owned by the attacker
@@ -131,97 +144,176 @@ bool UCApplyDamageComponent::ValidateRequest(const FHitContext& InHitContext) co
 	return true;
 }
 
-bool UCApplyDamageComponent::CheckApplyDamageRule(const FHitContext& InHitContext) const
+bool UCApplyDamageComponent::ValidateContext(FApplyDamageContext& InOutApplyDamageContext) const
 {
-	// TODO:
-	// P1: CheckAlreadyHit
-	// P2: CheckTeam
-
-	if (IsDuplicateHit(InHitContext))
+	if (!IsValid(InOutApplyDamageContext.Attacker))
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::InvalidAttacker;
 		return false;
+	}
 
+	if (!IsValid(InOutApplyDamageContext.DamageCauser))
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::InvalidDamageCauser;
+		return false;
+	}
+
+	if (!IsValid(InOutApplyDamageContext.TargetActor))
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::InvalidTarget;
+		return false;
+	}
+
+	if (!IsValid(InOutApplyDamageContext.Instigator))
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::InvalidInstigator;
+		return false;
+	}
+
+	// Valid Context
+	InOutApplyDamageContext.bAccepted = true;
+	InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::None;
 	return true;
 }
 
-bool UCApplyDamageComponent::ResolveApplyDamageSpec(const FHitContext& InHitContext, FApplyDamageSpec& OutApplyDamageSpec) const
+bool UCApplyDamageComponent::CanApplyDamage(FApplyDamageContext& InOutApplyDamageContext) const
 {
-	const FApplyDamageSpecKey applyDamageSpectKey = BuildSpecKey(InHitContext);
+	const FOverlapContext& overlapContext = InOutApplyDamageContext.HitContext.OverlapContext;
 
-	if (const FApplyDamageSpec* foundApplyDamageSpec = ApplyDamageSpecContainer.Find(applyDamageSpectKey))
+	AActor* myOwner = GetOwner();
+	if (!IsValid(myOwner) || myOwner != overlapContext.OwnerActor)
 	{
-		OutApplyDamageSpec = FApplyDamageSpec();
-		OutApplyDamageSpec = *foundApplyDamageSpec;
-		return true;
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::InvalidOwner;
+		return false;
 	}
 
-	return false;
-}
-
-bool UCApplyDamageComponent::ComputeApplyDamageResult(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, FApplyDamageResult& OutApplyDamageResult) const
-{
-	const FOverlapContext& overlapContext = InHitContext.OverlapContext;
-
-	AActor* attacker = overlapContext.OwnerActor;
-	AActor* damageCauser = overlapContext.DamageCauser;
-	AActor* target = overlapContext.OtherActor;
-
-	if (!IsValid(attacker) || !IsValid(damageCauser) || !IsValid(target))
+	if (overlapContext.OtherActor == overlapContext.OwnerActor)
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::SelfTarget;
 		return false;
+	}
 
-	// ComputeDamage (Minimal):
-	// [TODO] Implement `ComputeDamage()`
-	OutApplyDamageResult = FApplyDamageResult();
-	OutApplyDamageResult.RequestDamage = InApplyDamageSpec.BaseDamage;
+	if (IsDuplicateHit(InOutApplyDamageContext))
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::DuplicateHitInWindow;
+		return false;
+	}
 
+	if (IsFriendlyTarget(InOutApplyDamageContext))
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::FriendlyTarget;
+		return false;
+	}
+
+	InOutApplyDamageContext.bAccepted = true;
+	InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::None;
 	return true;
 }
 
-bool UCApplyDamageComponent::ApplyDamageToTarget(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const
+void UCApplyDamageComponent::ResolveApplyDamageSpec(FApplyDamageContext& InOutApplyDamageContext) const
 {
-	AActor* attacker = InHitContext.OverlapContext.OwnerActor;
-	AActor* damageCauser = InHitContext.OverlapContext.DamageCauser;
-	AActor* target = InHitContext.OverlapContext.OtherActor;
+	const FApplyDamageSpec* foundApplyDamageSpec = ApplyDamageSpecContainer.Find(InOutApplyDamageContext.ApplyDamageSpecKey);
 
-	if (!IsValid(attacker) || !IsValid(damageCauser) || !IsValid(target)) return false;
-
-	AController* instigatorController = attacker->GetInstigatorController();
-	if (!IsValid(instigatorController))
+	if (!foundApplyDamageSpec)
 	{
-		// Fallback: if DamageCauser has no valid InstigatorController, derive it from Attacker
-		if (APawn* Pawn = Cast<APawn>(attacker))
-			instigatorController = Pawn->GetController();
+		InOutApplyDamageContext.ApplyDamageSpec = FApplyDamageSpec();
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::SpecNotFound;
+		return;
 	}
-	if (!IsValid(instigatorController)) return false;
 
-	FApplyDamageSpecKey applyDamageSpectKey = BuildSpecKey(InHitContext);
+	InOutApplyDamageContext.ApplyDamageSpec = *foundApplyDamageSpec;
+	InOutApplyDamageContext.bAccepted = true;
+	InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::None;
+}
+
+void UCApplyDamageComponent::ComputeApplyDamage(FApplyDamageContext& InOutApplyDamageContext) const
+{
+	if (!IsValid(InOutApplyDamageContext.Attacker) || !IsValid(InOutApplyDamageContext.DamageCauser) || !IsValid(InOutApplyDamageContext.TargetActor))
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::ComputeFailed;
+		return;
+	}
+
+	// [NOTE] Minimal sender-side request damage.
+	InOutApplyDamageContext.ApplyDamageAmount = FApplyDamageAmount();
+	InOutApplyDamageContext.ApplyDamageAmount.RequestDamage = InOutApplyDamageContext.ApplyDamageSpec.BaseDamage;
+
+	InOutApplyDamageContext.bAccepted = true;
+	InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::None;
+}
+
+void UCApplyDamageComponent::CommitApplyDamage(FApplyDamageContext& InOutApplyDamageContext)
+{
+	InOutApplyDamageContext.CommittedDamage = ApplyDamageToTarget(InOutApplyDamageContext);
+
+	if (InOutApplyDamageContext.CommittedDamage <= 0.f)
+	{
+		InOutApplyDamageContext.bAccepted = false;
+		InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::CommitFailed;
+		return;
+	}
+
+	InOutApplyDamageContext.bAccepted = true;
+	InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::None;
+
+	CacheDamagedTargetInWindow(InOutApplyDamageContext);
+}
+
+
+float UCApplyDamageComponent::ApplyDamageToTarget(const FApplyDamageContext& InApplyDamageContext) const
+{
+	if (!IsValid(InApplyDamageContext.TargetActor) || !IsValid(InApplyDamageContext.DamageCauser) || !IsValid(InApplyDamageContext.Instigator))
+		return 0.f;
 
 	FDefaultDamageEvent damageEvent;
-	damageEvent.ApplyDamageSpecKey = applyDamageSpectKey;
-	damageEvent.ApplyDamageSpec = InApplyDamageSpec;
-	damageEvent.ApplyDamageResult = InApplyDamageResult;
+	damageEvent.ApplyDamageSpecKey = InApplyDamageContext.ApplyDamageSpecKey;
+	damageEvent.ApplyDamageSpec = InApplyDamageContext.ApplyDamageSpec;
+	damageEvent.ApplyDamageAmount = InApplyDamageContext.ApplyDamageAmount;
 
-	// Debugging
-	PrintApplyDamageSummaryInfo(InHitContext, damageEvent.ApplyDamageSpec, damageEvent.ApplyDamageResult);
-	// PrintApplyDamageContextInfo(InHitContext, damageEvent.ApplyDamageSpec, damageEvent.ApplyDamageResult);
-
-	const float appliedDamage = target->TakeDamage(InApplyDamageResult.RequestDamage, damageEvent, instigatorController, damageCauser);
-
-	if (appliedDamage > 0.f)
-	{
-		CacheDamagedTargetInWindow(InHitContext);
-	}
-
-	return true;
+	return InApplyDamageContext.TargetActor->TakeDamage(InApplyDamageContext.ApplyDamageAmount.RequestDamage, damageEvent, InApplyDamageContext.Instigator, InApplyDamageContext.DamageCauser);
 }
 
-bool UCApplyDamageComponent::IsDuplicateHit(const FHitContext& InHitContext) const
+bool UCApplyDamageComponent::IsDuplicateHit(const FApplyDamageContext& InApplyDamageContext) const
 {
-	const FApplyDamageHitWindowKey applyDamageHitWindowKey = BuildHitWindowKey(InHitContext);
-	const TSet<AActor*>* foundTargets = DamagedTargetContainer.Find(applyDamageHitWindowKey);
+	const TSet<AActor*>* foundTargets = DamagedTargetContainer.Find(InApplyDamageContext.HitWindowKey);
 
 	if (!foundTargets) return false;
 
-	return foundTargets->Contains(InHitContext.OverlapContext.OtherActor);
+	return foundTargets->Contains(InApplyDamageContext.TargetActor);
+}
+
+bool UCApplyDamageComponent::IsFriendlyTarget(const FApplyDamageContext& InApplyDamageContext) const
+{
+	AActor* ownerActor = InApplyDamageContext.Attacker;
+	AActor* targetActor = InApplyDamageContext.TargetActor;
+
+	if (!IsValid(ownerActor) || !IsValid(targetActor)) return false;
+
+	// TODO:
+	// Team / Friendly Fire policy
+	//
+	// Suggested direction:
+	// 1. Resolve team source from ownerActor
+	// 2. Resolve team source from targetActor
+	// 3. Compare team ids or attitudes
+	// 4. Return true when friendly-fire should be blocked
+	//
+	// Example candidates:
+	// - Team component on character
+	// - Team interface on actor
+	// - Gameplay tag based faction policy
+
+	return false;
 }
 
 FApplyDamageHitWindowKey UCApplyDamageComponent::BuildHitWindowKey(const FHitContext& InHitContext) const
@@ -246,30 +338,113 @@ FApplyDamageSpecKey UCApplyDamageComponent::BuildSpecKey(const FHitContext& InHi
 	return applyDamageSpecKey;
 }
 
-void UCApplyDamageComponent::CacheDamagedTargetInWindow(const FHitContext& InHitContext)
+FApplyDamagePayload UCApplyDamageComponent::BuildPayload(const FHitContext& InHitContext) const
 {
-	AActor* targetActor = InHitContext.OverlapContext.OtherActor;
+	FApplyDamagePayload applyDamagePayload;
+
+	applyDamagePayload.HitContext = InHitContext;
+	applyDamagePayload.Attacker = InHitContext.OverlapContext.OwnerActor;
+	applyDamagePayload.DamageCauser = InHitContext.OverlapContext.DamageCauser;
+	applyDamagePayload.TargetActor = InHitContext.OverlapContext.OtherActor;
+	applyDamagePayload.HitWindowKey = BuildHitWindowKey(InHitContext);
+	applyDamagePayload.ApplyDamageSpecKey = BuildSpecKey(InHitContext);
+
+	return applyDamagePayload;
+}
+
+FApplyDamageContext UCApplyDamageComponent::BuildContext(const FApplyDamagePayload& InApplyDamagePayload) const
+{
+	FApplyDamageContext applyDamageContext;
+
+	applyDamageContext.HitContext = InApplyDamagePayload.HitContext;
+	applyDamageContext.Attacker = InApplyDamagePayload.Attacker;
+	applyDamageContext.DamageCauser = InApplyDamagePayload.DamageCauser;
+	applyDamageContext.TargetActor = InApplyDamagePayload.TargetActor;
+	applyDamageContext.HitWindowKey = InApplyDamagePayload.HitWindowKey;
+	applyDamageContext.ApplyDamageSpecKey = InApplyDamagePayload.ApplyDamageSpecKey;
+	applyDamageContext.Instigator = ResolveInstigatorController(InApplyDamagePayload.Attacker, InApplyDamagePayload.DamageCauser);
+
+	return applyDamageContext;
+}
+
+FApplyDamageResult UCApplyDamageComponent::BuildResult(const FApplyDamageContext& InApplyDamageContext) const
+{
+	FApplyDamageResult applyDamageResult;
+
+	applyDamageResult.bAccepted = InApplyDamageContext.bAccepted;
+	applyDamageResult.RejectReason = InApplyDamageContext.RejectReason;
+	applyDamageResult.HitWindowKey = InApplyDamageContext.HitWindowKey;
+	applyDamageResult.ApplyDamageSpecKey = InApplyDamageContext.ApplyDamageSpecKey;
+	applyDamageResult.BaseDamage = InApplyDamageContext.ApplyDamageSpec.BaseDamage;
+	applyDamageResult.RequestDamage = InApplyDamageContext.ApplyDamageAmount.RequestDamage;
+	applyDamageResult.CommittedDamage = InApplyDamageContext.CommittedDamage;
+
+	return applyDamageResult;
+}
+
+AController* UCApplyDamageComponent::ResolveInstigatorController(AActor* InAttacker, AActor* InDamageCauser) const
+{
+	if (IsValid(InAttacker))
+	{
+		// 1) Preferred: attacker-provided instigator
+		if (AController* attackerInstigator = InAttacker->GetInstigatorController())
+			return attackerInstigator;
+
+		// 2) Fallback: attacker is a pawn/character
+		if (APawn* attackerPawn = Cast<APawn>(InAttacker))
+		{
+			if (AController* attackerController = attackerPawn->GetController())
+				return attackerController;
+		}
+	}
+
+	if (IsValid(InDamageCauser))
+	{
+		// 3) Fallback: causer-provided instigator
+		if (AController* causerInstigator = InDamageCauser->GetInstigatorController())
+			return causerInstigator;
+
+		if (AActor* causerOwner = InDamageCauser->GetOwner())
+		{
+			// 4) Fallback: owner of the causer provides the instigator
+			if (AController* ownerInstigator = causerOwner->GetInstigatorController())
+				return ownerInstigator;
+
+			// 5) Final fallback: owner of the causer is a pawn/character
+			if (APawn* ownerPawn = Cast<APawn>(causerOwner))
+			{
+				if (AController* ownerController = ownerPawn->GetController())
+					return ownerController;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+void UCApplyDamageComponent::CacheDamagedTargetInWindow(const FApplyDamageContext& InApplyDamageContext)
+{
+	AActor* targetActor = InApplyDamageContext.TargetActor;
 	if (!IsValid(targetActor)) return;
 
-	const FApplyDamageHitWindowKey key = BuildHitWindowKey(InHitContext);
-	auto& damagedTargets = DamagedTargetContainer.FindOrAdd(key);
+	// Cached
+	auto& damagedTargets = DamagedTargetContainer.FindOrAdd(InApplyDamageContext.HitWindowKey);
 	damagedTargets.Add(targetActor);
 }
 
-void UCApplyDamageComponent::PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const
+void UCApplyDamageComponent::PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageResult& InApplyDamageResult) const
 {
 	FLog::Log(TEXT("===== Apply Damage Summary ======"));
 	FLog::Log(TEXT("[@ APPLY DAMAGE]"));
 
-	AActor* targetActor = InHitContext.OverlapContext.OtherActor;
-
-	const float baseDamage = InApplyDamageSpec.BaseDamage;
-	const float requestDamage = InApplyDamageResult.RequestDamage;
-
-	FLog::Log(FString::Printf(TEXT("Target = %s | Base = %.3f | Request = %.3f"),
-		*GetNameSafe(targetActor),
-		baseDamage,
-		requestDamage
+	FLog::Log(FString::Printf(
+		TEXT("DamageCauser = %s | Target = %s | HitWindowId = %d | Base = %.3f | Request = %.3f | Committed = %.3f"),
+		*GetNameSafe(InHitContext.OverlapContext.DamageCauser),
+		*GetNameSafe(InHitContext.OverlapContext.OtherActor),
+		InHitContext.OverlapContext.HitWindowId,
+		InApplyDamageResult.BaseDamage,
+		InApplyDamageResult.RequestDamage,
+		InApplyDamageResult.CommittedDamage
 	));
 	FLog::Log(TEXT("================================="));
 }
@@ -284,8 +459,33 @@ void UCApplyDamageComponent::PrintApplyDamageContextInfo(const FHitContext& InHi
 	FLog::Log(TEXT("/////////////////////////////////"));
 }
 
+void UCApplyDamageComponent::PrintApplyDamageRejectedSummaryInfo(const FHitContext& InHitContext, EApplyDamageRejectReason InRejectReason) const
+{
+	FLog::Log(TEXT("= Apply Damage Rejected Summary ="));
+	FLog::Log(TEXT("[@ REJECT DAMAGE]"));
+
+	FLog::Log(FString::Printf(
+		TEXT("RejectReason = %s | DamageCauser = %s | Target = %s | HitWindowId = %d"),
+		*UEnum::GetValueAsString(InRejectReason),
+		*GetNameSafe(InHitContext.OverlapContext.DamageCauser),
+		*GetNameSafe(InHitContext.OverlapContext.OtherActor),
+		InHitContext.OverlapContext.HitWindowId
+	));
+	FLog::Log(TEXT("================================="));
+}
+
+void UCApplyDamageComponent::PrintApplyDamageRejectedContextInfo(const FHitContext& InHitContext, EApplyDamageRejectReason InRejectReason) const
+{
+	FLog::Log(TEXT("////- Reject Damage Context -////"));
+	PrintRejectReasonInfo(InRejectReason);
+	PrintOverlapContextInfo(InHitContext.OverlapContext);
+	PrintHitContextInfo(InHitContext.AttachmentContext, InHitContext.EquipmentContext, InHitContext.ActionContext);
+	FLog::Log(TEXT("/////////////////////////////////"));
+}
+
 void UCApplyDamageComponent::PrintOverlapContextInfo(const FOverlapContext& InOverlapContext) const
 {
+	FLog::Log(TEXT("-------- Overlap Context --------"));
 	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("OwnerActor"), *GetNameSafe(InOverlapContext.OwnerActor)));
 	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("DamageCauser"), *GetNameSafe(InOverlapContext.DamageCauser)));
 	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("OverlappedComponent"), *GetNameSafe(InOverlapContext.OverlappedComponent)));
@@ -307,6 +507,7 @@ void UCApplyDamageComponent::PrintOverlapContextInfo(const FOverlapContext& InOv
 		FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("Sweep.ImpactPoint"), *hitResult.ImpactPoint.ToString()));
 		FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("Sweep.ImpactNormal"), *hitResult.ImpactNormal.ToString()));
 	}
+	FLog::Log(TEXT("---------------------------------"));
 }
 
 void UCApplyDamageComponent::PrintHitContextInfo(const FAttachmentContext& InAttachmentContext, const FEquipmentContext& InEquipmentContext, const FActionContext& InActionContext) const
@@ -334,6 +535,17 @@ void UCApplyDamageComponent::PrintDamageSpecInfo(const FApplyDamageSpec& InApply
 void UCApplyDamageComponent::PrintDamageResultInfo(const FApplyDamageResult& InApplyDamageResult) const
 {
 	FLog::Log(TEXT("--------- Damage Result ---------"));
+	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("BaseDamage"), InApplyDamageResult.BaseDamage));
 	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("RequestDamage"), InApplyDamageResult.RequestDamage));
+	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("CommittedDamage"), InApplyDamageResult.CommittedDamage));
+	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("bAccepted"), InApplyDamageResult.bAccepted ? TEXT("true") : TEXT("false")));
+	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("RejectReason"), *UEnum::GetValueAsString(InApplyDamageResult.RejectReason)));
+	FLog::Log(TEXT("---------------------------------"));
+}
+
+void UCApplyDamageComponent::PrintRejectReasonInfo(EApplyDamageRejectReason InRejectReason) const
+{
+	FLog::Log(TEXT("--------- Reject Reason ---------"));
+	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("RejectReason"), *UEnum::GetValueAsString(InRejectReason)));
 	FLog::Log(TEXT("---------------------------------"));
 }

--- a/Source/Portfolio/Component/CApplyDamageComponent.h
+++ b/Source/Portfolio/Component/CApplyDamageComponent.h
@@ -19,6 +19,9 @@ private:
 	TMap<FApplyDamageSpecKey, FApplyDamageSpec> ApplyDamageSpecContainer;	// TODO: Seperate DataAsset (DB)
 
 private:
+	TMap<FApplyDamageHitWindowKey, TSet<AActor*>> DamagedTargetContainer;
+
+private:
 	/* === Cached Objects === */
 	class ACharacter* OwnerCharacter_Cached;
 
@@ -27,6 +30,11 @@ protected:
 
 public:
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+public:
+	// HitWindow API
+	void NotifyHitWindowOpened(AActor* InDamageCauser, int32 InHitWindowId);
+	void NotifyHitWindowClosed(AActor* InDamageCauser, int32 InHitWindowId);
 
 public:
 	// Entry API
@@ -45,7 +53,14 @@ private:
 	bool ApplyDamageToTarget(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const;
 
 private:
+	bool IsDuplicateHit(const FHitContext& InHitContext) const;
+
+private:
+	FApplyDamageHitWindowKey BuildHitWindowKey(const FHitContext& InHitContext) const;
 	FApplyDamageSpecKey BuildSpecKey(const FHitContext& InHitContext) const;
+
+private:
+	void CacheDamagedTargetInWindow(const FHitContext& InHitContext);
 
 private:
 	void PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const;

--- a/Source/Portfolio/Component/CApplyDamageComponent.h
+++ b/Source/Portfolio/Component/CApplyDamageComponent.h
@@ -39,7 +39,6 @@ public:
 public:
 	// Entry API
 	void RequestApplyDamage(const FHitContext& InHitContext);
-	void RequestStopDamage(const FHitContext& InHitContext);
 
 private:
 	// Pipeline
@@ -47,28 +46,42 @@ private:
 
 private:
 	bool ValidateRequest(const FHitContext& InHitContext) const;
-	bool CheckApplyDamageRule(const FHitContext& InHitContext) const;
-	bool ResolveApplyDamageSpec(const FHitContext& InHitContext, FApplyDamageSpec& OutApplyDamageSpec) const;
-	bool ComputeApplyDamageResult(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, FApplyDamageResult& OutApplyDamageResult) const;
-	bool ApplyDamageToTarget(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const;
+	bool ValidateContext(FApplyDamageContext & InOutApplyDamageContext) const;
+	bool CanApplyDamage(FApplyDamageContext & InOutApplyDamageContext) const;
+	void ResolveApplyDamageSpec(FApplyDamageContext & InOutApplyDamageContext) const;
+	void ComputeApplyDamage(FApplyDamageContext & InOutApplyDamageContext) const;
+	void CommitApplyDamage(FApplyDamageContext & InOutApplyDamageContext);
 
 private:
-	bool IsDuplicateHit(const FHitContext& InHitContext) const;
+	float ApplyDamageToTarget(const FApplyDamageContext& InApplyDamageContext) const;
+
+private:
+	bool IsDuplicateHit(const FApplyDamageContext & InApplyDamageContext) const;
+	bool IsFriendlyTarget(const FApplyDamageContext & InApplyDamageContext) const;
 
 private:
 	FApplyDamageHitWindowKey BuildHitWindowKey(const FHitContext& InHitContext) const;
 	FApplyDamageSpecKey BuildSpecKey(const FHitContext& InHitContext) const;
+	FApplyDamagePayload BuildPayload(const FHitContext & InHitContext) const;
+	FApplyDamageContext BuildContext(const FApplyDamagePayload & InApplyDamagePayload) const;
+	FApplyDamageResult BuildResult(const FApplyDamageContext& InApplyDamageContext) const;
 
 private:
-	void CacheDamagedTargetInWindow(const FHitContext& InHitContext);
+	AController* ResolveInstigatorController(AActor* InAttacker, AActor* InDamageCauser) const;
 
 private:
-	void PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const;
+	void CacheDamagedTargetInWindow(const FApplyDamageContext& InApplyDamageContext);
+
+private:
+	void PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageResult& InApplyDamageResult) const;
 	void PrintApplyDamageContextInfo(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const;
+	void PrintApplyDamageRejectedSummaryInfo(const FHitContext& InHitContext, EApplyDamageRejectReason InRejectReason) const;
+	void PrintApplyDamageRejectedContextInfo(const FHitContext& InHitContext, EApplyDamageRejectReason InRejectReason) const;
 
 private:
 	void PrintOverlapContextInfo(const FOverlapContext& InOverlapContext) const;
 	void PrintHitContextInfo(const FAttachmentContext& InAttachmentContext, const FEquipmentContext& InEquipmentContext, const FActionContext& InActionContext) const;
 	void PrintDamageSpecInfo(const FApplyDamageSpec& InApplyDamageSpec) const;
 	void PrintDamageResultInfo(const FApplyDamageResult& InApplyDamageResult) const;
+	void PrintRejectReasonInfo(EApplyDamageRejectReason InRejectReason) const;
 };

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -258,7 +258,7 @@ EReactionType UCReactionComponent::ResolveReactionType(const FTakeDamageResult& 
 		return EReactionType::None;
 	}
 
-	if (InTakeDamageResult.FinalAppliedDamage > 0.f &&
+	if (InTakeDamageResult.CommittedDamage > 0.f &&
 		InTakeDamageResult.DeadState_Before == EDeadState::Alive &&
 		InTakeDamageResult.DeadState_After == EDeadState::Alive)
 	{

--- a/Source/Portfolio/Component/CTakeDamageComponent.cpp
+++ b/Source/Portfolio/Component/CTakeDamageComponent.cpp
@@ -45,7 +45,7 @@ float UCTakeDamageComponent::ProcessTakeDamage(float DamageAmount, FDamageEvent 
 		return HandleDefaultDamageEvent(DamageAmount, damageEvent, EventInstigator, DamageCauser);
 	}
 
-	return DamageAmount;
+	return 0.f;
 }
 
 float UCTakeDamageComponent::HandleDefaultDamageEvent(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser)
@@ -53,16 +53,38 @@ float UCTakeDamageComponent::HandleDefaultDamageEvent(float DamageAmount, const 
 	// [Function Object]
 	// 'FDefaultDamageEvent + @(FTakeDamagePayload) -> FTakeDamageContext' and TakeDamage it-self
 
-	// 1) Validate Request (Objects / Inputs)
+	// 1) Validate Request
 	if (!FMath::IsFinite(DamageAmount)) return 0.f;
 	if (!ValidateRequest(InDefaultDamageEvent, InDamageInstigator, InDamageCauser)) return 0.f;
 
-	// 2) Build Payload / Context (Snapshot: inputs)
+	// 2) Build Payload / Context
 	FTakeDamagePayload takeDamagePayload = BuildPayload(DamageAmount, InDefaultDamageEvent, InDamageInstigator, InDamageCauser);
 	FTakeDamageContext takeDamageContext = BuildContext(takeDamagePayload);
 
-	// 3) Evaluate (Gate + Compute: Query Accepted and Compute mitigationDamage & finalTakenDamage)
-	EvaluateTakeDamage(takeDamageContext);
+	// 3) Validate Context
+	if (!ValidateContext(takeDamageContext))
+	{
+		const FTakeDamageResult rejectedResult = BuildResult(takeDamageContext);
+		PrintTakeDamageSummaryInfo(takeDamagePayload, takeDamageContext, rejectedResult);
+		DispatchTakeDamageRejected(takeDamagePayload, takeDamageContext, rejectedResult);
+		return 0.f;
+	}
+
+	// 4) Take Pre-state Snapshot
+	takeDamageContext.DeadState_Before = HealthComp_Cached->GetDeadState();
+	takeDamageContext.HealthPointBefore = HealthComp_Cached->GetCurrentHP();
+
+	// 5) Validate Policy
+	if (!CanTakeDamage(takeDamageContext))
+	{
+		const FTakeDamageResult rejectedResult = BuildResult(takeDamageContext);
+		PrintTakeDamageSummaryInfo(takeDamagePayload, takeDamageContext, rejectedResult);
+		DispatchTakeDamageRejected(takeDamagePayload, takeDamageContext, rejectedResult);
+		return 0.f;
+	}
+
+	// 6) Compute TakeDamage
+	ComputeTakeDamage(takeDamageContext);
 
 	if (!takeDamageContext.bAccepted)
 	{
@@ -72,20 +94,17 @@ float UCTakeDamageComponent::HandleDefaultDamageEvent(float DamageAmount, const 
 		return 0.f;
 	}
 
-	// 4) Commit (Apply to health + post snapshot + build result)
+	// 7) Commit
 	CommitTakeDamage(takeDamageContext);
 
 	const FTakeDamageResult committedResult = BuildResult(takeDamageContext);
 	PrintTakeDamageSummaryInfo(takeDamagePayload, takeDamageContext, committedResult);
-	// PrintTakeDamageContextInfo(takeDamagePayload, takeDamageContext, takeDamageResult);
-
-	// 5) Dispatch
 	DispatchTakeDamageCommitted(takeDamagePayload, takeDamageContext, committedResult);
 
-	return committedResult.FinalTakenDamage;
+	return committedResult.CommittedDamage;
 }
 
-bool UCTakeDamageComponent::ValidateRequest(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const
+bool UCTakeDamageComponent::ValidateRequest(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser)
 {
 	if (!IsValid(OwnerActor_Cached)) return false;
 	if (!IsValid(HealthComp_Cached)) return false;
@@ -97,60 +116,79 @@ bool UCTakeDamageComponent::ValidateRequest(const FDefaultDamageEvent& InDefault
 	return true;
 }
 
-void UCTakeDamageComponent::EvaluateTakeDamage(FTakeDamageContext& InOutTakeDamageContext) const
+bool UCTakeDamageComponent::ValidateContext(FTakeDamageContext& InOutTakeDamageContext)
 {
-	// Process 1: Take Pre-state Snapshot
-	InOutTakeDamageContext.DeadState_Before = HealthComp_Cached->GetDeadState();
-	InOutTakeDamageContext.HealthPointBefore = HealthComp_Cached->GetCurrentHP();
-
-	// Gate 1: validate
 	if (!IsValid(InOutTakeDamageContext.DamagedActor))
 	{
 		InOutTakeDamageContext.bAccepted = false;
 		InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::InvalidTarget;
-		return;
+
+		return false;
 	}
 
 	if (!IsValid(InOutTakeDamageContext.DamageCauser))
 	{
 		InOutTakeDamageContext.bAccepted = false;
 		InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::InvalidCauser;
-		return;
+
+		return false;
 	}
 
 	if (!IsValid(InOutTakeDamageContext.Instigator))
 	{
 		InOutTakeDamageContext.bAccepted = false;
 		InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::InvalidInstigator;
-		return;
+
+		return false;
 	}
 
-	// Gate 2: already dead
+	InOutTakeDamageContext.bAccepted = true;
+	InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::None;
+
+	return true;
+}
+
+bool UCTakeDamageComponent::CanTakeDamage(FTakeDamageContext& InOutTakeDamageContext)
+{
+	// Gate 1: already dead
 	if (InOutTakeDamageContext.DeadState_Before != EDeadState::Alive)
 	{
 		InOutTakeDamageContext.bAccepted = false;
 		InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::AlreadyDead;
-		return;
+
+		return false;
 	}
 
 	// TODO:
-	// Gate 3: invulnerable / friendly fire / cooldown / self-damage...
+	// Gate 2: invulnerable / iframe / god-mode state
+	// Gate 3: defensive friendly-fire check on receiver side
+	// Gate 4: receiver-side damage cooldown / hit immunity window
+	// Gate 5: defensive self-damage policy
 
-	// Process 2: Compute Mitigation Damage
+	InOutTakeDamageContext.bAccepted = true;
+	InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::None;
+
+	return true;
+}
+
+void UCTakeDamageComponent::ComputeTakeDamage(FTakeDamageContext& InOutTakeDamageContext) const
+{
+	// Process 1: Compute Mitigation Damage
 	InOutTakeDamageContext.MitigatedDamage = ComputeMitigatedDamage(InOutTakeDamageContext);	// TODO
 
-	// Gate 4: Zero damage
+	// Gate 1: Zero damage
 	if (InOutTakeDamageContext.MitigatedDamage <= KINDA_SMALL_NUMBER)
 	{
 		InOutTakeDamageContext.bAccepted = false;
 		InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::ZeroDamage;
+
 		return;
 	}
 
 	InOutTakeDamageContext.bAccepted = true;
 	InOutTakeDamageContext.RejectReason = ETakeDamageRejectReason::None;
 
-	// Process 3: Compute FinalTaken Damage
+	// Process 2: Compute FinalTaken Damage
 	InOutTakeDamageContext.FinalTakenDamage = ComputeFinalTakenDamage(InOutTakeDamageContext);	// TODO
 }
 
@@ -159,7 +197,7 @@ void UCTakeDamageComponent::CommitTakeDamage(FTakeDamageContext& InOutTakeDamage
 	if (!IsValid(HealthComp_Cached)) return;
 
 	// Process 4: Apply Damage To Health
-	InOutTakeDamageContext.FinalAppliedDamage = ApplyDamageToHealth(InOutTakeDamageContext);
+	InOutTakeDamageContext.CommittedDamage = CommitDamageToHealth(InOutTakeDamageContext);
 
 	// TODO: Shield / Mana / Stemina etc + Commit Order
 
@@ -240,7 +278,7 @@ float UCTakeDamageComponent::ComputeFinalTakenDamage(FTakeDamageContext& InOutTa
 	return FMath::Max(0.f, finalTakenDamage);
 }
 
-float UCTakeDamageComponent::ApplyDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const
+float UCTakeDamageComponent::CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const
 {
 	if (!IsValid(HealthComp_Cached)) return 0.0;
 
@@ -289,17 +327,12 @@ FTakeDamageResult UCTakeDamageComponent::BuildResult(const FTakeDamageContext& I
 	takeDamageResult.RequestDamage = InTakeDamageContext.RequestedDamage;
 	takeDamageResult.MitigatedDamage = InTakeDamageContext.MitigatedDamage;
 	takeDamageResult.FinalTakenDamage = InTakeDamageContext.FinalTakenDamage;
-	takeDamageResult.FinalAppliedDamage = InTakeDamageContext.FinalAppliedDamage;
+	takeDamageResult.CommittedDamage = InTakeDamageContext.CommittedDamage;
 
 	takeDamageResult.DeadState_Before = InTakeDamageContext.DeadState_Before;
 	takeDamageResult.DeadState_After = InTakeDamageContext.DeadState_After;
 
 	return takeDamageResult;
-}
-
-void UCTakeDamageComponent::DispatchTakeDamageRejected(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
-{
-	// TODO: OnTakeDamageRejected broadcast
 }
 
 void UCTakeDamageComponent::DispatchTakeDamageCommitted(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
@@ -320,6 +353,11 @@ void UCTakeDamageComponent::DispatchTakeDamageCommitted(const FTakeDamagePayload
 	// - UI Damage Number
 }
 
+void UCTakeDamageComponent::DispatchTakeDamageRejected(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
+{
+	// TODO: OnTakeDamageRejected broadcast
+}
+
 void UCTakeDamageComponent::PrintTakeDamageSummaryInfo(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
 {
 	FLog::Log(TEXT("====== Take Damage Summary ======"));
@@ -331,11 +369,11 @@ void UCTakeDamageComponent::PrintTakeDamageSummaryInfo(const FTakeDamagePayload&
 		*GetNameSafe(InTakeDamageContext.DamageCauser)
 	));
 
-	FLog::Log(FString::Printf(TEXT("RequestDamage = %.3f | MitigatedDamage = %.3f | FinalTakenDamage = %.3f | FinalAppliedDamage = %.3f"),
+	FLog::Log(FString::Printf(TEXT("RequestDamage = %.3f | MitigatedDamage = %.3f | FinalTakenDamage = %.3f | CommittedDamage = %.3f"),
 		InTakeDamageResult.RequestDamage,
 		InTakeDamageResult.MitigatedDamage,
 		InTakeDamageResult.FinalTakenDamage,
-		InTakeDamageResult.FinalAppliedDamage
+		InTakeDamageResult.CommittedDamage
 	));
 	FLog::Log(TEXT("================================="));
 }

--- a/Source/Portfolio/Component/CTakeDamageComponent.cpp
+++ b/Source/Portfolio/Component/CTakeDamageComponent.cpp
@@ -92,7 +92,7 @@ bool UCTakeDamageComponent::ValidateRequest(const FDefaultDamageEvent& InDefault
 	if (!IsValid(InDamageCauser)) return false;
 
 	if (!FMath::IsFinite(InDefaultDamageEvent.ApplyDamageSpec.BaseDamage)) return false;
-	if (!FMath::IsFinite(InDefaultDamageEvent.ApplyDamageResult.RequestDamage)) return false;
+	if (!FMath::IsFinite(InDefaultDamageEvent.ApplyDamageAmount.RequestDamage)) return false;
 
 	return true;
 }
@@ -257,7 +257,7 @@ FTakeDamagePayload UCTakeDamageComponent::BuildPayload(float DamageAmount, const
 
 	takeDamagePayload.ApplyDamageSpecKey = InDefaultDamageEvent.ApplyDamageSpecKey;
 	takeDamagePayload.ApplyDamageSpec = InDefaultDamageEvent.ApplyDamageSpec;
-	takeDamagePayload.ApplyDamageResult = InDefaultDamageEvent.ApplyDamageResult;
+	takeDamagePayload.ApplyDamageAmount = InDefaultDamageEvent.ApplyDamageAmount;
 
 	takeDamagePayload.RequestedDamage = DamageAmount;
 
@@ -381,7 +381,7 @@ void UCTakeDamageComponent::PrintDamageAmountInfo(const FTakeDamagePayload& InTa
 	FLog::Log(TEXT("======= DamageAmount Info ======="));
 	FLog::Log(TEXT("--------- Payload Info ----------"));
 	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("BaseDamage"), InTakeDamagePayload.ApplyDamageSpec.BaseDamage));
-	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("RequestDamage"), InTakeDamagePayload.ApplyDamageResult.RequestDamage));
+	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("RequestDamage"), InTakeDamagePayload.ApplyDamageAmount.RequestDamage));
 	FLog::Log(TEXT("---------- Amount Info ----------"));
 	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("FinalTakenDamage"), InTakeDamageResult.FinalTakenDamage));
 	FLog::Log(TEXT("================================="));

--- a/Source/Portfolio/Component/CTakeDamageComponent.h
+++ b/Source/Portfolio/Component/CTakeDamageComponent.h
@@ -38,15 +38,17 @@ private:
 	float HandleDefaultDamageEvent(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, class AController* InDamageInstigator, class AActor* InDamageCauser);
 
 private:
-	bool ValidateRequest(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const;
-	void EvaluateTakeDamage(FTakeDamageContext& InOutTakeDamageContext) const;
+	bool ValidateRequest(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser);
+	bool ValidateContext(FTakeDamageContext& InOutTakeDamageContext);
+	bool CanTakeDamage(FTakeDamageContext& InOutTakeDamageContext);
+	void ComputeTakeDamage(FTakeDamageContext& InOutTakeDamageContext) const;
 	void CommitTakeDamage(FTakeDamageContext& InOutTakeDamageContext);
 
 private:
 	AController* ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const;
 	float ComputeMitigatedDamage(FTakeDamageContext& InOutTakeDamageContext) const;
 	float ComputeFinalTakenDamage(FTakeDamageContext& InOutTakeDamageContext) const;
-	float ApplyDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const;
+	float CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const;
 
 private:
 	FTakeDamagePayload BuildPayload(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const;
@@ -54,8 +56,8 @@ private:
 	FTakeDamageResult BuildResult(const FTakeDamageContext& InTakeDamageContext) const;
 
 private:
-	void DispatchTakeDamageRejected(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;
 	void DispatchTakeDamageCommitted(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;
+	void DispatchTakeDamageRejected(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;
 
 private:
 	void PrintTakeDamageSummaryInfo(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -47,16 +47,17 @@ enum class EApplyDamageRejectReason : uint8
 	None = 0,
 
 	InvalidRequest,
-
+	
 	InvalidAttacker,
 	InvalidDamageCauser,
 	InvalidTarget,
 	InvalidInstigator,
-
+	
 	SpecNotFound,
 	ComputeFailed,
 	CommitFailed,
 
+	// Reject Reason of 'CanApplyDamage'
 	InvalidOwner,
 	SelfTarget,
 	DuplicateHitInWindow,
@@ -74,7 +75,6 @@ enum class ETakeDamageRejectReason : uint8
 
 	AlreadyDead,
 	// Invulnerable,
-	// FriendlyFire,
 
 	// Blocked,
 	// Parried,
@@ -329,6 +329,7 @@ FORCEINLINE uint32 GetTypeHash(const FApplyDamageSpecKey& InOther)
 	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InOther.EquipmentType)));
 	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InOther.ActionType)));
 	H = HashCombine(H, GetTypeHash(InOther.ActionIndex));
+
 	return H;
 }
 
@@ -449,25 +450,25 @@ struct FApplyDamageResult
 	GENERATED_BODY()
 
 public:
-	UPROPERTY(VisibleAnywhere, Transient)
+	UPROPERTY(Transient)
 	bool bAccepted = true;
 
-	UPROPERTY(VisibleAnywhere, Transient)
+	UPROPERTY(Transient)
 	EApplyDamageRejectReason RejectReason = EApplyDamageRejectReason::None;
 
-	UPROPERTY(VisibleAnywhere, Transient)
+	UPROPERTY(Transient)
 	FApplyDamageHitWindowKey HitWindowKey = FApplyDamageHitWindowKey();
 
-	UPROPERTY(VisibleAnywhere, Transient)
+	UPROPERTY(Transient)
 	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
 
-	UPROPERTY(VisibleAnywhere, Transient)
+	UPROPERTY(Transient)
 	float BaseDamage = 0.f;
 
-	UPROPERTY(VisibleAnywhere, Transient)
+	UPROPERTY(Transient)
 	float RequestDamage = 0.f;
 
-	UPROPERTY(VisibleAnywhere, Transient)
+	UPROPERTY(Transient)
 	float CommittedDamage = 0.f;
 
 public:
@@ -480,10 +481,10 @@ struct FDefaultDamageEvent : public FDamageEvent
 	GENERATED_BODY()
 
 public:
-	UPROPERTY()
+	UPROPERTY(Transient)
 	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
 
-	UPROPERTY()
+	UPROPERTY(Transient)
 	FApplyDamageSpec ApplyDamageSpec = FApplyDamageSpec();
 
 	UPROPERTY(Transient)
@@ -507,27 +508,27 @@ struct FTakeDamagePayload
 
 public:
 	// ObjectData
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	class AActor* DamagedActor = nullptr;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	class AController* EventInstigator = nullptr;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	class AActor* DamageCauser = nullptr;
 
 	// Damage MetaData
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	FApplyDamageSpec ApplyDamageSpec = FApplyDamageSpec();
 
 	UPROPERTY(Transient)
 	FApplyDamageAmount ApplyDamageAmount = FApplyDamageAmount();
 
 	//Damage AmountData
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	float RequestedDamage = 0.f;
 
 public:
@@ -541,51 +542,51 @@ struct FTakeDamageContext
 
 public:
 	// Resolved objects [Set BuildContext]
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	class AActor* DamagedActor = nullptr;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	class AController* Instigator = nullptr;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	class AActor* DamageCauser = nullptr;
 
 	// Damage MetaData [Set BuildContext]
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
 
-	// Query Acceptable [Set EvaluateTakeDamage]
-	UPROPERTY(VisibleAnywhere)
+	// Query Acceptable [Set ValidateContext / CanTakeDamage / ComputeTakeDamage]
+	UPROPERTY(Transient)
 	bool bAccepted = true;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	ETakeDamageRejectReason RejectReason = ETakeDamageRejectReason::None;
 
-	// Pre-state Snapshot [Set EvaluateTakeDamage]
-	UPROPERTY(VisibleAnywhere)
+	// Pre-state Snapshot [Set HandleDefaultDamageEvent before ValidatePolicy]
+	UPROPERTY(Transient)
 	float HealthPointBefore = 0.f;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	EDeadState DeadState_Before = EDeadState::Alive;
 
-	// DamageAmounts [Set EvaluateTakeDamage & CommitTakeDamage]
-	UPROPERTY(VisibleAnywhere)
+	// DamageAmounts [Set ComputeTakeDamage & CommitTakeDamage]
+	UPROPERTY(Transient)
 	float RequestedDamage = 0.f;		// Raw incoming damage requested by Apply pipeline. (ex. [skill] 100)
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	float MitigatedDamage = 0.f;		// Post-mitigation damage after target defenses. (ex. [guard/resistance] 100 -> 70)
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	float FinalTakenDamage = 0.f;		// Final damage decided by Take evaluation rules. (ex. [clamp max/min damage-limit] 70 -> 60)
 
-	UPROPERTY(VisibleAnywhere)
-	float FinalAppliedDamage = 0.f;		// Actual HP loss committed to Health. (ex. [shield absorbs] 60 -> HP: -30 / SP: -30)
+	UPROPERTY(Transient)
+	float CommittedDamage = 0.f;		// Actual HP loss committed to Health. (ex. [shield absorbs] 60 -> HP: -30 / SP: -30)
 
 	// Post-state Snapshot [Set BuildResult]
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	float HealthPointAfter = 0.f;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	EDeadState DeadState_After = EDeadState::Alive;
 
 	// TODO:
@@ -605,33 +606,34 @@ struct FTakeDamageResult
 {
 	GENERATED_BODY()
 
-	UPROPERTY(VisibleAnywhere)
+public:
+	UPROPERTY(Transient)
 	bool bAccepted = true;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	ETakeDamageRejectReason RejectReason = ETakeDamageRejectReason::None;
 
 	// Damage MetaData
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
 
 	// Damage Amount
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	float RequestDamage = 0.f;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	float MitigatedDamage = 0.f;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	float FinalTakenDamage = 0.f;
 
-	UPROPERTY(VisibleAnywhere)
-	float FinalAppliedDamage = 0.f;
+	UPROPERTY(Transient)
+	float CommittedDamage = 0.f;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	EDeadState DeadState_Before = EDeadState::Alive;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(Transient)
 	EDeadState DeadState_After = EDeadState::Alive;
 
 public:

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -210,6 +210,9 @@ public:
 	UPROPERTY(Transient)
 	FHitResult SweepResult;
 
+	UPROPERTY(Transient)
+	int32 HitWindowId = INDEX_NONE;
+
 public:
 	FOverlapContext() = default;
 
@@ -238,6 +241,33 @@ public:
 public:
 	FHitContext() = default;
 };
+
+USTRUCT()
+struct FApplyDamageHitWindowKey
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Transient)
+	class AActor* DamageCauser = nullptr;
+
+	UPROPERTY(Transient)
+	int32 HitWindowId = INDEX_NONE;
+
+	bool operator==(const FApplyDamageHitWindowKey& InOther) const
+	{
+		return DamageCauser == InOther.DamageCauser
+			&& HitWindowId == InOther.HitWindowId;
+	}
+};
+
+FORCEINLINE uint32 GetTypeHash(const FApplyDamageHitWindowKey& InOther)
+{
+	uint32 H = 0;
+	H = HashCombine(H, GetTypeHash(InOther.DamageCauser));
+	H = HashCombine(H, GetTypeHash(InOther.HitWindowId));
+	return H;
+}
 
 USTRUCT(BlueprintType)
 struct FApplyDamageSpecKey

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -38,7 +38,29 @@ UENUM(BlueprintType)
 enum class EReactionType : uint8
 {
 	None = 0,
-	Hit
+	Hit,
+};
+
+UENUM(BlueprintType)
+enum class EApplyDamageRejectReason : uint8
+{
+	None = 0,
+
+	InvalidRequest,
+
+	InvalidAttacker,
+	InvalidDamageCauser,
+	InvalidTarget,
+	InvalidInstigator,
+
+	SpecNotFound,
+	ComputeFailed,
+	CommitFailed,
+
+	InvalidOwner,
+	SelfTarget,
+	DuplicateHitInWindow,
+	FriendlyTarget,
 };
 
 UENUM(BlueprintType)
@@ -300,13 +322,13 @@ public:
 	}
 };
 
-FORCEINLINE uint32 GetTypeHash(const FApplyDamageSpecKey& InKey)
+FORCEINLINE uint32 GetTypeHash(const FApplyDamageSpecKey& InOther)
 {
 	uint32 H = 0;
-	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InKey.AttachmentType)));
-	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InKey.EquipmentType)));
-	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InKey.ActionType)));
-	H = HashCombine(H, GetTypeHash(InKey.ActionIndex));
+	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InOther.AttachmentType)));
+	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InOther.EquipmentType)));
+	H = HashCombine(H, GetTypeHash(static_cast<uint8>(InOther.ActionType)));
+	H = HashCombine(H, GetTypeHash(InOther.ActionIndex));
 	return H;
 }
 
@@ -335,17 +357,118 @@ public:
 };
 
 USTRUCT(BlueprintType)
+struct FApplyDamageAmount
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Transient)
+	float RequestDamage = 0.f;
+
+public:
+	FApplyDamageAmount() = default;
+};
+
+USTRUCT(BlueprintType)
+struct FApplyDamagePayload
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Transient)
+	FHitContext HitContext = FHitContext();
+
+	UPROPERTY(Transient)
+	AActor* Attacker = nullptr;
+
+	UPROPERTY(Transient)
+	AActor* DamageCauser = nullptr;
+
+	UPROPERTY(Transient)
+	AActor* TargetActor = nullptr;
+
+	UPROPERTY(Transient)
+	FApplyDamageHitWindowKey HitWindowKey = FApplyDamageHitWindowKey();
+
+	UPROPERTY(Transient)
+	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
+
+public:
+	FApplyDamagePayload() = default;
+};
+
+USTRUCT(BlueprintType)
+struct FApplyDamageContext
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Transient)
+	bool bAccepted = true;
+
+	UPROPERTY(Transient)
+	EApplyDamageRejectReason RejectReason = EApplyDamageRejectReason::None;
+
+	UPROPERTY(Transient)
+	FHitContext HitContext = FHitContext();
+
+	UPROPERTY(Transient)
+	AActor* Attacker = nullptr;
+
+	UPROPERTY(Transient)
+	AController* Instigator = nullptr;
+
+	UPROPERTY(Transient)
+	AActor* DamageCauser = nullptr;
+
+	UPROPERTY(Transient)
+	AActor* TargetActor = nullptr;
+
+	UPROPERTY(Transient)
+	FApplyDamageHitWindowKey HitWindowKey = FApplyDamageHitWindowKey();
+
+	UPROPERTY(Transient)
+	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
+
+	UPROPERTY(Transient)
+	FApplyDamageSpec ApplyDamageSpec = FApplyDamageSpec();
+
+	UPROPERTY(Transient)
+	FApplyDamageAmount ApplyDamageAmount = FApplyDamageAmount();
+
+	UPROPERTY(Transient)
+	float CommittedDamage = 0.f;
+
+public:
+	FApplyDamageContext() = default;
+};
+
+USTRUCT(BlueprintType)
 struct FApplyDamageResult
 {
 	GENERATED_BODY()
 
 public:
-	UPROPERTY()
+	UPROPERTY(VisibleAnywhere, Transient)
+	bool bAccepted = true;
+
+	UPROPERTY(VisibleAnywhere, Transient)
+	EApplyDamageRejectReason RejectReason = EApplyDamageRejectReason::None;
+
+	UPROPERTY(VisibleAnywhere, Transient)
+	FApplyDamageHitWindowKey HitWindowKey = FApplyDamageHitWindowKey();
+
+	UPROPERTY(VisibleAnywhere, Transient)
+	FApplyDamageSpecKey ApplyDamageSpecKey = FApplyDamageSpecKey();
+
+	UPROPERTY(VisibleAnywhere, Transient)
+	float BaseDamage = 0.f;
+
+	UPROPERTY(VisibleAnywhere, Transient)
 	float RequestDamage = 0.f;
 
-	// TODO:
-	// FVector ImpactPoint;
-	// FVector HitNormal;
+	UPROPERTY(VisibleAnywhere, Transient)
+	float CommittedDamage = 0.f;
 
 public:
 	FApplyDamageResult() = default;
@@ -363,8 +486,8 @@ public:
 	UPROPERTY()
 	FApplyDamageSpec ApplyDamageSpec = FApplyDamageSpec();
 
-	UPROPERTY()
-	FApplyDamageResult ApplyDamageResult = FApplyDamageResult();
+	UPROPERTY(Transient)
+	FApplyDamageAmount ApplyDamageAmount = FApplyDamageAmount();
 
 public:
 	static const int32 ClassID = (int32)EDamageEventTypeId::DefaultDamage;
@@ -400,8 +523,8 @@ public:
 	UPROPERTY(VisibleAnywhere)
 	FApplyDamageSpec ApplyDamageSpec = FApplyDamageSpec();
 
-	UPROPERTY(VisibleAnywhere)
-	FApplyDamageResult ApplyDamageResult = FApplyDamageResult();
+	UPROPERTY(Transient)
+	FApplyDamageAmount ApplyDamageAmount = FApplyDamageAmount();
 
 	//Damage AmountData
 	UPROPERTY(VisibleAnywhere)

--- a/Source/Portfolio/Weapon/CAttachment.cpp
+++ b/Source/Portfolio/Weapon/CAttachment.cpp
@@ -163,6 +163,30 @@ void ACAttachment::OnEquipmentBeginUnequip()
 
 void ACAttachment::CollisionEnabled(FName InName)
 {
+	TArray<UShapeComponent*> collisionsToEnable;
+
+	if (!InName.IsNone())
+	{
+		for (UShapeComponent* collision : Collisions_Cached)
+		{
+			if (collision->GetFName() == InName)
+			{
+				collisionsToEnable.Add(collision);
+				break;
+			}
+		}
+	}
+	else
+	{
+		for (UShapeComponent* collision : Collisions_Cached)
+		{
+			collisionsToEnable.Add(collision);
+		}
+	}
+
+	// Early-Return
+	if (collisionsToEnable.IsEmpty()) return;
+
 	if (!bHitWindowOpened)
 	{
 		++CurrentHitWindowId;
@@ -174,30 +198,10 @@ void ACAttachment::CollisionEnabled(FName InName)
 		}
 	}
 
-	bool bCollisionEnabled = false;
-
-	if (!InName.IsNone())
+	for (UShapeComponent* collision : collisionsToEnable)
 	{
-		for (UShapeComponent* collision : Collisions_Cached)
-		{
-			if (collision->GetFName() == InName)
-			{
-				collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-				bCollisionEnabled = true;
-				break;
-			}
-		}
+		collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 	}
-	else
-	{
-		for (UShapeComponent* collision : Collisions_Cached)
-		{
-			collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-			bCollisionEnabled = true;
-		}
-	}
-
-	if (!bCollisionEnabled) return;
 
 	if (OnAttachmentCollisionEnabled.IsBound())
 		OnAttachmentCollisionEnabled.Broadcast();

--- a/Source/Portfolio/Weapon/CAttachment.cpp
+++ b/Source/Portfolio/Weapon/CAttachment.cpp
@@ -10,7 +10,7 @@
 
 ACAttachment::ACAttachment()
 {
-	PrimaryActorTick.bCanEverTick = true;
+	PrimaryActorTick.bCanEverTick = false;
 
 	Root = CreateDefaultSubobject<USceneComponent>("Root");
 	check(Root);
@@ -117,56 +117,38 @@ void ACAttachment::OnComponentBeginOverlap(UPrimitiveComponent* OverlappedCompon
 {
 	UShapeComponent* overlapComp = Cast<UShapeComponent>(OverlappedComponent);
 	if (!IsValid(overlapComp)) return;
-	
+
 	if (!IsValid(OwnerCharacter_Cached) || !IsValid(OtherActor)) return;
 	if (OwnerCharacter_Cached == OtherActor) return;
-	
+
 	if (!IsValid(ApplyDamageComp_Cached)) return;
 
-	FOverlapContext lastOverlapContext = BuildOverlapContext(OwnerCharacter_Cached, this, OverlappedComponent, OtherActor, OtherComp, OtherBodyIndex, bFromSweep, SweepResult);
+	FOverlapContext overlapContext = BuildOverlapContext(OwnerCharacter_Cached, this, OverlappedComponent, OtherActor, OtherComp, OtherBodyIndex, bFromSweep, SweepResult);
+	FHitContext hitContext = BuildHitContext(overlapContext);
 
-	FHitContext hitContext;
-
-	hitContext.OverlapContext = lastOverlapContext;
-	hitContext.AttachmentContext = LastAttachmentContext;
-	hitContext.EquipmentContext = LastEquipmentContext;
-	hitContext.ActionContext = LastActionContext;
+	PrintBeginOverlapContextInfo(hitContext);
 
 	// Legacy delegate
 	if (OnAttachmentBeginOverlap.IsBound())
 		OnAttachmentBeginOverlap.Broadcast(OwnerCharacter_Cached, this, overlapComp, OtherActor, OtherComp, OtherBodyIndex, bFromSweep, SweepResult);
 
-	PrintBeginOverlapContextInfo(hitContext);
-
 	ApplyDamageComp_Cached->RequestApplyDamage(hitContext);
-	LastOverlapContext = lastOverlapContext;
+	LastOverlapContext = overlapContext;
 }
 
 void ACAttachment::OnComponentEndOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex)
 {
 	UShapeComponent* overlapComp = Cast<UShapeComponent>(OverlappedComponent);
 	if (!IsValid(overlapComp)) return;
+
 	if (!IsValid(OwnerCharacter_Cached) || !IsValid(OtherActor)) return;
 	if (OwnerCharacter_Cached == OtherActor) return;
+
 	if (!IsValid(ApplyDamageComp_Cached)) return;
-
-	FOverlapContext lastOverlapContext = BuildOverlapContext(OwnerCharacter_Cached, this, OverlappedComponent, OtherActor, OtherComp, OtherBodyIndex, false, FHitResult());
-
-	FHitContext hitContext;
-
-	hitContext.OverlapContext = lastOverlapContext;
-	hitContext.AttachmentContext = LastAttachmentContext;
-	hitContext.EquipmentContext = LastEquipmentContext;
-	hitContext.ActionContext = LastActionContext;
 
 	// Legacy delegate
 	if (OnAttachmentEndOverlap.IsBound())
 		OnAttachmentEndOverlap.Broadcast(OwnerCharacter_Cached, OtherActor);
-
-	// PrintEndOverlapContextInfo(hitContext);
-
-	ApplyDamageComp_Cached->RequestStopDamage(hitContext); // Not implemented
-	LastOverlapContext = lastOverlapContext;
 }
 
 void ACAttachment::OnEquipmentBeginEquip()
@@ -181,6 +163,19 @@ void ACAttachment::OnEquipmentBeginUnequip()
 
 void ACAttachment::CollisionEnabled(FName InName)
 {
+	if (!bHitWindowOpened)
+	{
+		++CurrentHitWindowId;
+		bHitWindowOpened = true;
+
+		if (IsValid(ApplyDamageComp_Cached))
+		{
+			ApplyDamageComp_Cached->NotifyHitWindowOpened(this, CurrentHitWindowId);
+		}
+	}
+
+	bool bCollisionEnabled = false;
+
 	if (!InName.IsNone())
 	{
 		for (UShapeComponent* collision : Collisions_Cached)
@@ -188,25 +183,41 @@ void ACAttachment::CollisionEnabled(FName InName)
 			if (collision->GetFName() == InName)
 			{
 				collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-				return;
+				bCollisionEnabled = true;
+				break;
 			}
 		}
 	}
-	else // InName == None: OnCollision_ALL
+	else
 	{
 		for (UShapeComponent* collision : Collisions_Cached)
+		{
 			collision->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+			bCollisionEnabled = true;
+		}
 	}
 
-	// Legacy delegate
+	if (!bCollisionEnabled) return;
+
 	if (OnAttachmentCollisionEnabled.IsBound())
 		OnAttachmentCollisionEnabled.Broadcast();
 }
 
 void ACAttachment::CollisionDisabled()
 {
+	if (!bHitWindowOpened) return;
+
 	for (UShapeComponent* collision : Collisions_Cached)
+	{
 		collision->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	}
+
+	bHitWindowOpened = false;
+
+	if (IsValid(ApplyDamageComp_Cached) && CurrentHitWindowId != INDEX_NONE)
+	{
+		ApplyDamageComp_Cached->NotifyHitWindowClosed(this, CurrentHitWindowId);
+	}
 
 	// Legacy delegate
 	if (OnAttachmentCollisionDisabled.IsBound())
@@ -225,10 +236,22 @@ FOverlapContext ACAttachment::BuildOverlapContext(AActor* InOwnerActor, AActor* 
 	overlapContext.OtherComponent = OtherComp;
 	overlapContext.OtherBodyIndex = OtherBodyIndex;
 	overlapContext.bFromSweep = bFromSweep;
-
 	overlapContext.SweepResult = bFromSweep ? SweepResult : FHitResult();
+	overlapContext.HitWindowId = CurrentHitWindowId;
 
 	return overlapContext;
+}
+
+FHitContext ACAttachment::BuildHitContext(const FOverlapContext& InOverlapContext) const
+{
+	FHitContext hitContext;
+
+	hitContext.OverlapContext = InOverlapContext;
+	hitContext.AttachmentContext = LastAttachmentContext;
+	hitContext.EquipmentContext = LastEquipmentContext;
+	hitContext.ActionContext = LastActionContext;
+
+	return hitContext;
 }
 
 void ACAttachment::PrintBeginOverlapContextInfo(const FHitContext& InHitContext)

--- a/Source/Portfolio/Weapon/CAttachment.h
+++ b/Source/Portfolio/Weapon/CAttachment.h
@@ -52,6 +52,13 @@ public:
 	FActionContext LastActionContext;
 
 private:
+	UPROPERTY(Transient)
+	bool bHitWindowOpened = false;
+
+	UPROPERTY(Transient)
+	int32 CurrentHitWindowId = INDEX_NONE;
+
+private:
 	/* === Cached Objects === */
 	class ACharacter* OwnerCharacter_Cached;
 	class UCApplyDamageComponent* ApplyDamageComp_Cached;
@@ -127,6 +134,7 @@ public:
 
 private:
 	FOverlapContext BuildOverlapContext(AActor* InOwnerActor, AActor* InDamageCauser, UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult) const;
+	FHitContext BuildHitContext(const FOverlapContext& InOverlapContext) const;
 
 private:
 	void PrintBeginOverlapContextInfo(const FHitContext& InHitContext);


### PR DESCRIPTION
# Damage Pipeline 공유 구조 구현 및 규칙 정리

## 1. 제목

♻️ refactor: Damage Pipeline 공유 구조 구현 및 규칙 정리 (#34)

---
## 2. 관련 브랜치

- `feature/combat-core-shared`

---
## 3. 요약

### 작업 요약

본 PR은 공격자와 피격자가 공유하는 damage 처리 흐름을 **ApplyDamage -> DefaultDamageEvent -> TakeDamage -> Health -> Reaction** 기준으로 정리한 작업임.

### 작업 배경

Player와 Enemy가 같은 전투 규칙을 사용하려면, 공격자 쪽 damage 송신과 피격자 쪽 damage 수신을 공통 pipeline으로 분리할 필요가 있었음.

또한 동일 공격 window 안에서 같은 target이 여러 번 overlap될 수 있으므로, hit window 기반 중복 타격 방지 규칙이 필요했음.

### 안정성 보완

#### 첫 overlap HitWindowId 전달 안정화 (#35 / M03-B03)

첫 overlap 시점에 `HitWindowId`가 `INDEX_NONE`으로 전달되어 첫 타격이 `InvalidRequest`로 reject되는 문제가 있었음.

해당 브랜치에서는 collision 활성화 전에 hit window context를 먼저 준비하도록 순서를 보정함.

### 구현 방향

이를 다음 네 가지 축으로 정리했음.

```yaml
1. Sender-side damage pipeline 정리
- ApplyDamage 단계에서 hit context를 payload / context / result로 변환
- damage spec resolve와 duplicate hit filtering 처리

2. Receiver-side damage pipeline 정리
- TakeDamage 단계에서 damage 수신 / 계산 / health commit 처리
- Requested / Mitigated / FinalTaken / Committed 의미 분리

3. Hit window 기반 중복 타격 방지
- hit window id를 기준으로 동일 공격 window 안의 duplicate hit 차단

4. Reaction 연결 규칙 정리
- CommittedDamage와 dead-state 전후 조건을 기준으로 hit / dead reaction 연결
```

---
## 4. 변경 범위

### Damage Pipeline

#### A. Attachment Hit Window 규칙 정리

- weapon collision window를 hit window로 식별하고, 동일 window 내 target 중복 타격을 방지하도록 구성함.

**Flow**
```yaml
CollisionEnabled
-> HitWindowOpened
-> CurrentHitWindowId 증가
-> overlap metadata에 HitWindowId 전달
-> CollisionDisabled
-> HitWindowClosed
```

**Structure**
```yaml
HitWindow
- CurrentHitWindowId : 현재 공격 window 식별자
- DamageCauser       : damage를 발생시킨 weapon / actor
- DamagedTargetSet   : 해당 window 안에서 이미 맞은 target 목록
```

**Rule**
```yaml
Allow
- 같은 hit window 안에서 처음 맞은 target

Reject
- HitWindowId == INDEX_NONE
- 같은 hit window 안에서 이미 맞은 target
- self-hit target
```

#### B. ApplyDamage Pipeline 정리

- 공격자 쪽 damage 송신 흐름을 `Payload / Context / Result` 기준으로 정리함.

**Flow**
```yaml
HitContext
-> ValidateRequest
-> BuildPayload
-> BuildContext
-> ValidateContext
-> CanApplyDamage
-> ResolveApplyDamageSpec
-> ComputeApplyDamage
-> CommitApplyDamage
-> BuildResult
```

**Structure**
```yaml
FApplyDamagePayload
- hit에서 전달된 원본 요청 데이터
- target / damage causer / spec key / hit window metadata

FApplyDamageContext
- ApplyDamage 처리 중 사용하는 runtime context
- resolved spec / computed damage / reject reason

FApplyDamageResult
- ApplyDamage 호출 결과
- accepted 여부 / reject reason / committed damage
```

#### C. ApplyDamage 정책 정리

- sender-side에서 처리해야 하는 최소 damage gate와 spec resolve 정책을 정리함.

**Rule**
```yaml
Validate
- valid target
- valid damage causer
- valid hit window id

Policy
- self-hit reject
- duplicate-hit reject
- spec miss reject

Commit
- resolved spec 기준으로 UGameplayStatics::ApplyDamage 호출
```

#### D. TakeDamage Pipeline 정리

- 피격자 쪽 damage 수신 흐름을 `Payload / Context / Result` 기준으로 정리함.

**Flow**
```yaml
DefaultDamageEvent
-> ValidateRequest
-> BuildPayload
-> BuildContext
-> ValidateContext
-> CanTakeDamage
-> ComputeTakeDamage
-> CommitTakeDamage
-> BuildResult
```

**Structure**
```yaml
FTakeDamagePayload
- TakeDamage로 들어온 원본 damage event 데이터
- event instigator / damage causer / spec / requested damage

FTakeDamageContext
- TakeDamage 처리 중 사용하는 receiver-side context
- health snapshot / dead state / computed damage / reject reason

FTakeDamageResult
- TakeDamage 처리 결과
- accepted 여부 / committed damage / dead state before-after
```

#### E. TakeDamage Damage Amount 의미 정리

- receiver-side damage 계산 값을 단계별로 구분함.

**Structure**
```yaml
Requested
- attacker가 요청한 damage amount

Mitigated
- 방어 / 감소 계산 이후 damage

FinalTaken
- 실제 health commit 직전 damage

Committed
- UCHealthComponent에 실제 반영된 HP 감소량
```

#### F. Dead Target 보호 및 후처리 규칙 정리

- dead / dying 상태 이후 추가 damage가 health에 다시 반영되지 않도록 처리함.

**Rule**
```yaml
Alive Target
- damage 계산과 health commit 허용

Dead / Dying Target
- 추가 damage reject 또는 CommittedDamage = 0 처리
- 추가 HP 감소 방지
```

#### G. Reaction 연결 규칙 정리

- damage commit 결과를 기준으로 reaction request가 연결되도록 정리함.

**Rule**
```yaml
Hit Reaction
- CommittedDamage > 0
- DeadState_After == Alive

Dead Reaction
- DeadState_Before == Alive
- DeadState_After != Alive

No Reaction
- damage rejected
- CommittedDamage <= 0
- already dead target
```

---
## 5. 안정성 보완

### 첫 overlap HitWindowId 전달 안정화 (#35 / M03-B03)

#### A. Collision 활성화 전 hit window context 준비

- 첫 overlap callback이 발생하기 전에 `CurrentHitWindowId`와 hit window state가 먼저 준비되도록 처리 순서를 보정함.
- 자세한 재현 조건과 원인은 `M03-B03` bug report에서 분리하여 정리함.

**Before**
```yaml
CollisionEnabled 호출
-> collision 먼저 활성화
-> 첫 overlap 발생
-> HitWindowId == INDEX_NONE
-> InvalidRequest reject
```

**After**
```yaml
CollisionEnabled 호출
-> HitWindowId 증가
-> hit window state 준비
-> collision 활성화
-> 첫 overlap에도 유효한 HitWindowId 전달
```

---
## 6. 주요 Pipeline

### Shared Damage Pipeline

```yaml
HitContext
-> ApplyDamage
-> DefaultDamageEvent
-> TakeDamage
-> Health
-> Reaction
```

### ApplyDamage Pipeline

```yaml
HitContext
-> FApplyDamagePayload
-> FApplyDamageContext
-> FApplyDamageResult
-> UGameplayStatics::ApplyDamage
```

### TakeDamage Pipeline

```yaml
DefaultDamageEvent
-> FTakeDamagePayload
-> FTakeDamageContext
-> Health Commit
-> FTakeDamageResult
```

### Hit Window Pipeline

```yaml
CollisionEnabled
-> HitWindowOpened
-> Overlap
-> Duplicate Hit Check
-> CollisionDisabled
-> HitWindowClosed
```

---
## 7. 테스트 방법

### Shared Damage Flow

- Player와 Enemy 양쪽에서 동일한 공격 흐름으로 `ApplyDamage -> TakeDamage`가 동작하는지 확인
- `ApplyDamageResult`와 `TakeDamageResult`의 request / final / committed 값이 로그 기준으로 일관되게 연결되는지 확인

### Hit Window

- 동일 공격 window 안에서 target 중복 타격이 방지되는지 확인
- 첫 overlap 시점에 `HitWindowId`가 유효하게 전달되어 첫 타가 `InvalidRequest`로 reject되지 않는지 확인

### Health / Dead Policy

- HP가 0에 도달했을 때 `CommittedDamage`가 남은 HP만큼만 반영되는지 확인
- dead / dying 이후 추가 hit은 `CommittedDamage = 0`으로 처리되고 추가 HP 감소가 발생하지 않는지 확인

### Reaction

- `CommittedDamage > 0`인 경우 hit reaction이 연결되는지 확인
- death 전이 시 hit reaction보다 dead reaction이 우선되는지 확인

---
## 8. 검증 결과

- Player / Enemy 공통 `ApplyDamage -> TakeDamage` pipeline 동작 확인
- hit window 기반 duplicate hit 방지 동작 확인
- 첫 overlap 시점 `HitWindowId` 전달 문제 수정 확인
- `Requested / Mitigated / FinalTaken / Committed` 로그 기준 정합성 확인
- dead target 추가 damage 차단 확인
- damage result 기반 hit / dead reaction 연결 확인

---
## 9. 관련 문서

### 이슈 체크리스트

- #34

### 버그 리포트

- #35

---
## 10. 정리

이 PR의 핵심은 damage를 단순히 health를 감소시키는 함수 호출로 두지 않고, sender-side `ApplyDamage`와 receiver-side `TakeDamage`를 분리된 pipeline으로 정리한 것임.

변경 후 공격자는 hit context를 기반으로 damage payload / context / result를 구성하고, 피격자는 damage event를 수신한 뒤 receiver-side context에서 damage 계산과 health commit을 수행함.

또한 hit window 기반 중복 타격 방지와 dead target 보호 규칙을 추가하여, Player와 Enemy가 같은 shared combat core 위에서 damage와 reaction을 처리할 수 있도록 정리했음.

---
