### PR TITLE
P21: Combat Signal Boundary v1 분리

### DIFF
--- a/Docs/01_Work_List/00_Work_List_Index.md
+++ b/Docs/01_Work_List/00_Work_List_Index.md
@@ -9,6 +9,6 @@
 | W01 | AI Workflow 운영 체계 및 Prompt Library v1 초안 구성 | `W01_Codex_Workflow/W01_UE5_Portfolio_Work_List.md` | `feature/codex-workflow` | P18 | 완료 |
 | W02 | AI 협업 기반 문서 운영 체계 정리 | `W02_Documentation_Update/W02_UE5_Portfolio_Work_List.md` | `docs/portfolio-documentation-update` | P19 | 완료 |
 | W03 | Guard / Parry Action v1 구현 | `W03_Parry/W03_UE5_Portfolio_Work_List.md` | `feature/combat-guard-parry` | P20 | 완료 |
-| W04 | Combat Signal Boundary 재정의 | `W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md` | `refactor/combat-signal-boundary` | TBD | 진행 중 |
+| W04 | Combat Signal Boundary v1 | `W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md` | `refactor/combat-signal-boundary` | P21 | 완료 |
 
 ---

--- a/Docs/01_Work_List/00_Work_List_Index.md
+++ b/Docs/01_Work_List/00_Work_List_Index.md
@@ -1,6 +1,6 @@
 # Work List Index
 
-이 문서는 Work List 문서의 목록과 브랜치 / 관련 문서 연결을 관리한다.
+이 문서는 Work List 문서 목록과 브랜치 / 관련 PR / 상태를 관리한다.
 
 ---
 
@@ -9,5 +9,6 @@
 | W01 | AI Workflow 운영 체계 및 Prompt Library v1 초안 구성 | `W01_Codex_Workflow/W01_UE5_Portfolio_Work_List.md` | `feature/codex-workflow` | P18 | 완료 |
 | W02 | AI 협업 기반 문서 운영 체계 정리 | `W02_Documentation_Update/W02_UE5_Portfolio_Work_List.md` | `docs/portfolio-documentation-update` | P19 | 완료 |
 | W03 | Guard / Parry Action v1 구현 | `W03_Parry/W03_UE5_Portfolio_Work_List.md` | `feature/combat-guard-parry` | P20 | 완료 |
+| W04 | Combat Signal Boundary 재정의 | `W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md` | `refactor/combat-signal-boundary` | TBD | 진행 중 |
 
 ---

--- a/Docs/01_Work_List/W03_Parry/W03_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W03_Parry/W03_UE5_Portfolio_Work_List.md
@@ -309,7 +309,7 @@ TakeDamagePacket
 
 #### 현재 코드 기준 Combat pipeline 분리 작업 후보
 
-- [x] `ApplyDamageComponent`와 `TakeDamageComponent`의 현재 책임을 `N05` 기준으로 분석한다.
+- [x] `ApplyDamageComponent`와 `TakeDamageComponent`의 현재 책임을 archived `NA01` 기준으로 분석한다.
   - 현재 `ApplyDamageComponent`는 source-side damage 적용자가 아니라 hit context를 combat request로 구성하고 target에게 전달하는 requester 성격이 강하다.
   - 현재 `TakeDamageComponent`는 receiver adapter, resolution, damage apply, consequence coordination을 모두 가진 압축형 컴포넌트다.
 - [ ] `TakeDamageComponent`를 우선 `Receive / Resolve / Apply / Coordinate` 단계로 함수 경계를 정리한다.
@@ -471,7 +471,7 @@ TakeDamagePacket
 - [x] 검증 과정에서 Editor / Asset 확인이 불완전하면 PR 문서의 미검증 항목에 남긴다.
 - [x] TakeDamage 내부 defensive resolution 규칙이 Guard / Counter 확장 기준으로 의미가 생기면 System Architecture 후속 보완 후보로 기록한다.
 - [x] Attacker 측 counter signal / Blink / Repulse / cue packet 전달 구조는 `Docs/06_notes/N04_Blink_Repulse_Combat_Packet_Design_Note.md`에 후속 판단 기록으로 분리한다.
-- [x] Combat intent / request / resolution / routing 계층 구조는 `Docs/06_notes/N05_Combat_Intent_Request_Resolution_Routing_Design_Note.md`에 후속 판단 기록으로 분리한다.
+- [x] Combat intent / request / resolution / routing 계층 구조는 `Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md`에 후속 판단 기록으로 분리한다.
 
 ---
 
@@ -530,7 +530,7 @@ TakeDamagePacket
 - [x] `P20_UE5_Portfolio_Pull_Request.md`에 Guard / Parry v1 변경 흐름과 최종 검증 결과를 정리했다.
 - [x] `N03_Guard_Hold_Overlay_Layer_Design_Note.md`에 Observable Overlay Layer, dirty flag registry, API naming 기준을 반영했다.
 - [x] `N04_Blink_Repulse_Combat_Packet_Design_Note.md`에 Blink / Repulse / cue packet 책임 분리 기준을 분리했다.
-- [x] `N05_Combat_Intent_Request_Resolution_Routing_Design_Note.md`에 Combat Request / Resolution / Routing 후속 구조를 정리했다.
+- [x] `NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md`에 Combat Request / Resolution / Routing 후속 구조를 정리했다.
 - [x] `B12_UE5_Portfolio_Bug_Report.md`에 Guard Out 중 Hit reaction overlay handling 실패와 dirty flag 해결 기준을 기록했다.
 
 ---

--- a/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
@@ -1,41 +1,205 @@
-# W04 Combat Signal Boundary Work List
+# UE5 Portfolio - Work List
 
-## 1. 목표
+## 제목
 
-이번 작업은 W03 이후 논의된 `Combat Resolution / Request / Routing` 구조를 다시 검토하고, 현재 프로젝트에 필요한 최소 전투 파이프라인 경계를 `CombatSignal Source / Target` 기준으로 재정의한다.
+**W04: Combat Signal Boundary v1 정리**
 
-핵심은 공용 `Intent Gateway / Coordinator`를 먼저 만드는 것이 아니라, 실제로 책임이 압축되어 있는 `ApplyDamageComponent`와 `TakeDamageComponent`의 장기 대체 축을 명확히 정하는 것이다.
+## 날짜
+
+**2026.06.22**
+
+## 상태
+
+- [x] **완료**
+
+---
+
+## 브랜치
+
+- `refactor/combat-signal-boundary`
+
+---
+
+## 1. Branch 목표
+
+이번 작업은 W03 Guard / Parry 이후 커진 combat 송수신 책임을 바로 리팩터링하지 않고, 후속 작업의 기준이 될 **Combat Signal Boundary v1**을 문서와 타입으로 먼저 고정한다.
+
+현재 브랜치의 핵심 산출물은 다음과 같다.
 
 ```text
-기존 압축 구조
--> ApplyDamageComponent
--> TakeDamageComponent
-
-새 기준
--> CombatSignalSource
--> CombatSignal
--> CombatSignalTarget
--> Evaluate
--> Apply
--> Notify Result
+1. Combat Signal Boundary 설계 기준 정리
+2. 이전 Request / Routing 설계 문서 archive
+3. Combat Signal 타입 vocabulary 추가
+4. W04 작업 기록 / prompt update 후보 정리
+5. P21 PR 문서 작성
 ```
 
-## 2. 방향 전환 결정
+이번 브랜치에서는 기존 gameplay 흐름을 변경하지 않는다.
+
+```text
+변경하지 않는 것
+-> ApplyDamageComponent
+-> TakeDamageComponent
+-> Guard / Parry / Hit / Dead runtime flow
+-> 기존 damage packet 연결
+```
+
+---
+
+## 2. 완료 기준
+
+이 Branch는 다음 조건을 만족하면 PR 가능한 상태로 본다.
+
+```yaml
+완료 기준
+- N05 Combat Signal Boundary 설계 노트가 작성되어 있다
+- N06 Combat Signal Branch 구현 계획이 작성되어 있다
+- 기존 Request / Receiver / Resolution / Coordinator 중심 문서가 archive로 이동되어 있다
+- Combat Signal 최소 타입 vocabulary가 추가되어 있다
+- 기존 ApplyDamageComponent / TakeDamageComponent / Guard / Parry runtime flow가 변경되지 않는다
+- W04 task brief, work journal, prompt update note가 정리되어 있다
+- P21 PR 문서가 현재 브랜치 산출물 중심으로 작성되어 있다
+- Unreal build가 성공한다
+```
+
+---
+
+## 3. 필수 산출물
+
+```yaml
+Work List / PR
+- Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
+- Docs/01_Work_List/00_Work_List_Index.md
+- Docs/04_Pull_Request/P21_UE5_Portfolio_Pull_Request.md
+- Docs/04_Pull_Request/00_Pull_Request_Index.md
+```
+
+```yaml
+Design Notes
+- Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md
+- Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md
+- Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md
+- Docs/06_notes/archive/README.md
+```
+
+```yaml
+Task Brief / Journal / Prompt Update
+- Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+- Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_01_Combat_Signal_Boundary_Rescope.md
+- Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_02_Combat_Signal_Types_v1.md
+- Docs/06_notes/work_journal/J01_Combat_Signal_Boundary_Work_Journal.md
+- Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md
+```
+
+```yaml
+Code
+- Source/Portfolio/Type/CCombatSignalStructure.h
+- Source/Portfolio/Type/CCombatSignalStructure.cpp
+```
+
+---
+
+## 4. 완료된 작업 범위
+
+### 4.1 Combat Signal Boundary 설계 기준 정리
+
+**완료**
+
+- `N05_Combat_Signal_Boundary_Design_Note.md` 작성
+- `N06_Combat_Signal_Branch_Implementation_Plan.md` 작성
+- `CombatSignal Source / Target` 기준 확정
+- branch 분할 기준을 feature 이름이 아니라 behavior / risk 축으로 정리
+
+**핵심 결정**
+
+```text
+공용 상태 변경 파이프라인을 먼저 만들지 않는다.
+입력 데이터 처리 축, combat 데이터 처리 축, timing cue 처리 축을 분리해서 본다.
+현재 브랜치에서는 가장 직접적인 문제인 combat source / target 책임 경계를 먼저 안정화한다.
+```
 
 이전 후보였던 `GameplayIntentGateway / GameplayCoordinator` 구조는 이번 W04의 주도 구조로 사용하지 않는다.
 
-보류 이유는 다음과 같다.
+**보류 이유**
 
-- 현재 문제는 공용 intent routing 부재보다 전투 송수신 경계의 이름과 책임 혼재가 더 직접적이다.
-- Gateway / Coordinator를 먼저 만들면 God Object가 될 가능성이 크다.
-- `Request`는 request-response 흐름을 암시하지만, 현재 전투 흐름은 source가 signal을 전달하고 target이 자체 상태로 outcome을 판단하는 구조에 가깝다.
-- Blink / Repulse 같은 cue 기반 defensive outcome은 `Damage`나 `Attack`보다 넓은 전투 신호 개념이 필요하다.
+- 입력, damage, timing cue, system event는 발생 원인과 해석 기준이 서로 다르다.
+- 이를 하나의 공용 Gateway / Coordinator가 판정하면 God Object 위험이 커진다.
+- 반대로 모든 축을 세밀하게 나누면 현재 규모에 비해 계층과 adapter가 과도해진다.
 
-따라서 이번 W04는 `CombatSignal` vocabulary와 Source / Target 책임 경계를 먼저 확정한다.
+따라서 공용 파이프라인 일반화는 뒤로 미루고, 먼저 입력 처리 축 / combat 처리 축 / timing cue 처리 축을 분리해서 바라보기로 했다.
 
-## 3. 권장 이름
+### 4.2 이전 Request / Routing 설계 archive
 
-### 3.1 컴포넌트
+**완료**
+
+- 기존 `Combat Intent / Request / Resolution / Routing` 설계 노트를 archive로 이동
+- active note와 충돌하지 않도록 참조 갱신
+- archive index 추가
+
+**Archive 문서**
+
+```text
+Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md
+```
+
+### 4.3 Combat Signal 타입 vocabulary 추가
+
+**완료**
+
+- `Source/Portfolio/Type/CCombatSignalStructure.h` 추가
+- `Source/Portfolio/Type/CCombatSignalStructure.cpp` 추가
+- 각 struct에 `IsValidMinimal()` 추가
+- `AActor` 전방 선언 추가
+- Unreal build 성공
+
+**추가 타입**
+
+```text
+ECombatSignalType
+ECombatSignalOutcome
+ECombatSignalResultType
+FCombatSignalHeader
+FCombatSignal
+FCombatSignalContext
+FCombatSignalEvaluation
+FCombatSignalApplyResult
+FCombatSignalResult
+```
+
+**제한**
+
+```text
+CombatSignal 타입은 아직 기존 damage flow에 연결하지 않는다.
+actor 유효성이나 combat rule 검증은 이후 target-side refactor에서 다룬다.
+```
+
+### 4.4 작업 기록 문서 정리
+
+**완료**
+
+- `TB_W04_01_Combat_Signal_Boundary_Rescope.md`
+- `TB_W04_02_Combat_Signal_Types_v1.md`
+- `J01_Combat_Signal_Boundary_Work_Journal.md`
+- `PU01_Combat_Signal_Boundary_Prompt_Update_Note.md`
+
+**프롬프트 업데이트 후보**
+
+```text
+Request / Attack / Damage 명명 기준
+CombatSignal vocabulary 우선 검토 기준
+branch split을 behavior / risk 축으로 나누는 기준
+```
+
+### 4.5 PR 문서 정리
+
+- [x] `P21_UE5_Portfolio_Pull_Request.md`를 작성했다.
+- [x] Pull Request Index에 P21 항목을 추가했다.
+- [x] PR 문서는 현재 Branch 산출물 중심으로 정리했다.
+- [x] 이전 `Intent / Request / Receiver / Resolution / Coordinator` 구조는 배경 수준으로만 언급했다.
+
+### 4.6 확정 vocabulary
+
+#### 컴포넌트
 
 ```text
 UCCombatSignalSourceComponent
@@ -46,7 +210,7 @@ UCCombatSignalTargetComponent
 
 `Target`은 전투 신호를 받는 쪽이다. 자신의 guard / parry / dead / invincible / cue timing 상태를 바탕으로 outcome을 평가하고 결과 적용과 후속 통지를 수행한다.
 
-### 3.2 구조체
+#### 구조체
 
 ```text
 FCombatSignalHeader
@@ -57,7 +221,7 @@ FCombatSignalApplyResult
 FCombatSignalResult
 ```
 
-### 3.3 열거형
+#### 열거형
 
 ```text
 ECombatSignalType
@@ -84,9 +248,9 @@ ECombatSignalResultType
 - Rejected
 ```
 
-## 4. 책임 경계
+### 4.7 책임 경계
 
-### 4.1 CombatSignalSource
+#### CombatSignalSource
 
 책임:
 
@@ -102,7 +266,7 @@ ECombatSignalResultType
 - HP를 직접 감소시키지 않는다.
 - defender reaction / feedback을 직접 실행하지 않는다.
 
-### 4.2 CombatSignalTarget
+#### CombatSignalTarget
 
 책임:
 
@@ -119,7 +283,7 @@ ECombatSignalResultType
 - target discovery를 수행하지 않는다.
 - source actor의 공격 판정을 대신 결정하지 않는다.
 
-## 5. 내부 흐름
+### 4.8 장기 내부 흐름
 
 ```text
 1. Source 준비
@@ -149,9 +313,9 @@ TargetComponent
 -> 필요 시 SourceComponent 또는 attacker-side result receiver에 CombatSignalResult 전달
 ```
 
-## 6. API 후보
+### 4.9 API 후보
 
-### Source
+#### Source
 
 ```cpp
 void OpenSignalWindow(...);
@@ -162,7 +326,7 @@ FCombatSignalResult SendCombatSignal(const FCombatSignal& InSignal);
 void NotifyCombatSignalResult(const FCombatSignalResult& InResult);
 ```
 
-### Target
+#### Target
 
 ```cpp
 FCombatSignalResult ReceiveCombatSignal(const FCombatSignal& InSignal);
@@ -171,14 +335,14 @@ FCombatSignalApplyResult ApplyCombatSignalOutcome(const FCombatSignalEvaluation&
 void NotifyCombatSignalResult(const FCombatSignalResult& InResult);
 ```
 
-### Legacy Adapter
+#### Legacy Adapter
 
 ```cpp
 FCombatSignal BuildSignalFromDamageEvent(...);
 FCombatSignalResult ReceiveEngineDamage(...);
 ```
 
-## 7. 인터페이스 구성
+### 4.10 인터페이스 구성
 
 v1에서는 interface를 최소화한다.
 
@@ -202,9 +366,9 @@ class ICCombatSignalSource
 
 Target interface가 먼저 필요한 이유는 수신 경계가 반드시 필요하기 때문이다. 반면 source result notify는 ParryStack / Stagger / debug / network 요구가 정리된 후 추가해도 된다.
 
-## 8. 현재 컴포넌트와의 관계
+### 4.11 현재 컴포넌트와의 관계
 
-### 8.1 ApplyDamageComponent
+#### ApplyDamageComponent
 
 현재 `UCApplyDamageComponent`는 이름과 달리 HP를 직접 적용하지 않는다.
 
@@ -226,7 +390,7 @@ UCApplyDamageComponent
 -> UCCombatSignalSourceComponent
 ```
 
-### 8.2 TakeDamageComponent
+#### TakeDamageComponent
 
 현재 `UCTakeDamageComponent`는 수신, 평가, 적용, 후속 분배를 모두 가진다.
 
@@ -249,116 +413,104 @@ UCTakeDamageComponent
 -> UCCombatSignalTargetComponent
 ```
 
-## 9. 작업 분할 계획
+---
 
-### W04-01 Combat Signal Boundary Re-scope
+## 5. 비범위
 
-브랜치:
-
-```text
-refactor/combat-signal-boundary
+```yaml
+비범위
+- TakeDamageComponent 내부 책임 분리
+- ApplyDamageComponent 내부 책임 분리
+- UCCombatSignalSourceComponent / UCCombatSignalTargetComponent rename
+- CombatSignal 타입을 기존 damage flow에 연결
+- 기존 FApplyDamagePayload / FTakeDamagePacket / FCombatResultPacket 교체
+- Blink / Repulse timing cue 구현
+- 공용 Gateway / Coordinator 구현
+- gameplay behavior 변경
 ```
 
-목표:
+---
+
+## 6. 검증 기준
+
+### 문서 존재 / 연결 확인
+
+- [x] Work List Index에서 W04 항목 확인
+- [x] Pull Request Index에서 P21 항목 확인
+- [x] N05 / N06 문서 존재 확인
+- [x] NA01 archive 문서와 archive README 존재 확인
+- [x] TB_W04_01 / TB_W04_02 존재 확인
+- [x] Work Journal / Prompt Update Note 존재 확인
+
+### 구조 참조 확인
+
+- [x] `GameplayIntentGateway / GameplayCoordinator`는 active 구현 대상으로 등장하지 않는다.
+- [x] 이전 Request / Routing 문서는 archive 문서로 추적된다.
+- [x] W04 문서에서 공용 상태 변경 파이프라인은 보류 / 재검토 대상으로 설명된다.
+- [x] `CombatSignal Source / Target`이 현재 Branch의 기준 구조로 설명된다.
+
+### 코드 연결 확인
+
+- [x] `CCombatSignalStructure.h/.cpp` 외 기존 combat runtime code 변경 없음
+- [x] `FCombatSignal` 계열 타입이 기존 gameplay flow에 연결되지 않음
+- [x] 신규 타입 header는 `CoreMinimal.h`, generated header, `AActor` 전방 선언만 사용
+
+### 빌드 확인
 
 ```text
-Intent Gateway / Coordinator 중심 계획을 보류하고 CombatSignal Source / Target 기준을 문서로 확정한다.
+PortfolioEditor Win64 Development
 ```
 
-핵심 범위:
+- [x] UnrealHeaderTool 통과
+- [x] `CCombatSignalStructure.cpp` 컴파일 통과
+- [x] Editor target 빌드 성공
 
-- W04 work list 작성
-- N05 Combat Signal Boundary 설계 노트 작성
-- N06 branch implementation plan 작성
-- task brief / work journal / prompt update note 작성
-- 코드 변경 없음
+---
 
-완료조건:
+## 7. 후속 작업
 
-- 같은 브랜치에서 Combat Signal 타입 추가 작업으로 바로 착수 가능하다.
-- 문서에서 `Attack`, `Request`, `Damage`가 핵심 파이프라인 이름으로 남지 않는다.
-- Source / Target 책임 경계가 문서만 보고 판단 가능하다.
+### 7.1 W04-04 Combat Signal Target Boundary v1
 
-### W04-02 Combat Signal Types
-
-브랜치:
-
-```text
-refactor/combat-signal-boundary
-```
-
-커밋 단위:
-
-```text
-feat(combat): add combat signal type vocabulary
-```
-
-목표:
-
-```text
-CombatSignal 파이프라인의 최소 타입을 추가한다.
-```
-
-핵심 범위:
-
-- `FCombatSignalHeader`
-- `FCombatSignal`
-- `FCombatSignalContext`
-- `FCombatSignalEvaluation`
-- `FCombatSignalApplyResult`
-- `FCombatSignalResult`
-- `ECombatSignalType`
-- `ECombatSignalOutcome`
-- `ECombatSignalResultType`
-
-완료조건:
-
-- 기존 `ApplyDamageComponent` / `TakeDamageComponent` 동작 변화 없음
-- 타입만 추가
-- Unreal build 성공
-
-### W04-03 Combat Signal Target Boundary v1
-
-브랜치:
+**브랜치**
 
 ```text
 refactor/combat-signal-target-v1
 ```
 
-목표:
+**목표**
 
 ```text
 UCTakeDamageComponent 내부 흐름을 CombatSignalTarget 책임 기준으로 정리한다.
 ```
 
-핵심 범위:
+**핵심 범위**
 
 - Receive / Evaluate / Apply / Notify 단계 메서드 분리
 - 기존 `RequestTakeDamage` 흐름 유지
 - UE `TakeDamage()` adapter 유지
 - 클래스명 rename은 아직 하지 않음
 
-완료조건:
+**완료조건**
 
 - 기존 Guard / Parry / Hit / Dead 동작 유지
 - target-side 책임 단계가 코드에서 명확히 보임
 - Unreal build 성공
 
-### W04-04 Combat Signal Source Boundary v1
+### 7.2 W04-05 Combat Signal Source Boundary v1
 
-브랜치:
+**브랜치**
 
 ```text
 refactor/combat-signal-source-v1
 ```
 
-목표:
+**목표**
 
 ```text
 UCApplyDamageComponent 내부 흐름을 CombatSignalSource 책임 기준으로 정리한다.
 ```
 
-핵심 범위:
+**핵심 범위**
 
 - hit window tracking
 - duplicate target tracking
@@ -366,65 +518,65 @@ UCApplyDamageComponent 내부 흐름을 CombatSignalSource 책임 기준으로 �
 - target delivery 경계
 - `RequestApplyDamage` API rename 후보 준비
 
-완료조건:
+**완료조건**
 
 - 기존 weapon overlap damage 동작 유지
 - source-side 책임 단계가 코드에서 명확히 보임
 - Unreal build 성공
 
-### W04-05 Combat Signal Component Rename
+### 7.3 W04-06 Combat Signal Component Rename
 
-브랜치:
+**브랜치**
 
 ```text
 refactor/combat-signal-component-rename
 ```
 
-목표:
+**목표**
 
 ```text
 책임 정리가 끝난 뒤 ApplyDamage / TakeDamage 명칭을 CombatSignalSource / Target으로 교체한다.
 ```
 
-핵심 범위:
+**핵심 범위**
 
 - `UCApplyDamageComponent` -> `UCCombatSignalSourceComponent`
 - `UCTakeDamageComponent` -> `UCCombatSignalTargetComponent`
 - Character / Weapon 참조 갱신
 - Blueprint 영향 확인
 
-완료조건:
+**완료조건**
 
 - 이름만 바꾼 것이 아니라 이전 브랜치의 책임 정리가 선행되어 있다.
 - 기존 전투 회귀 통과
 - Unreal build 성공
 
-### W04-06 Combat Signal Cue v1
+### 7.4 W04-07 Combat Signal Cue v1
 
-브랜치:
+**브랜치**
 
 ```text
 feature/combat-signal-cue-v1
 ```
 
-목표:
+**목표**
 
 ```text
 Blink / Repulse 같은 collision 없는 timing cue를 CombatSignal 흐름에 연결한다.
 ```
 
-핵심 범위:
+**핵심 범위**
 
 - `ECombatSignalType::TimingCue` 사용
 - target discovery 방식 정리
 - Blink / Repulse evaluation hook 추가
 
-완료조건:
+**완료조건**
 
 - collision hit와 timing cue가 같은 target receive 흐름을 공유한다.
 - cue 전용 예외 파이프라인을 만들지 않는다.
 
-## 10. 관련 문서
+## 8. 관련 문서
 
 - `Docs/06_notes/N03_Guard_Hold_Overlay_Layer_Design_Note.md`
 - `Docs/06_notes/N04_Blink_Repulse_Combat_Packet_Design_Note.md`

--- a/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
@@ -1,0 +1,433 @@
+# W04 Combat Signal Boundary Work List
+
+## 1. 목표
+
+이번 작업은 W03 이후 논의된 `Combat Resolution / Request / Routing` 구조를 다시 검토하고, 현재 프로젝트에 필요한 최소 전투 파이프라인 경계를 `CombatSignal Source / Target` 기준으로 재정의한다.
+
+핵심은 공용 `Intent Gateway / Coordinator`를 먼저 만드는 것이 아니라, 실제로 책임이 압축되어 있는 `ApplyDamageComponent`와 `TakeDamageComponent`의 장기 대체 축을 명확히 정하는 것이다.
+
+```text
+기존 압축 구조
+-> ApplyDamageComponent
+-> TakeDamageComponent
+
+새 기준
+-> CombatSignalSource
+-> CombatSignal
+-> CombatSignalTarget
+-> Evaluate
+-> Apply
+-> Notify Result
+```
+
+## 2. 방향 전환 결정
+
+이전 후보였던 `GameplayIntentGateway / GameplayCoordinator` 구조는 이번 W04의 주도 구조로 사용하지 않는다.
+
+보류 이유는 다음과 같다.
+
+- 현재 문제는 공용 intent routing 부재보다 전투 송수신 경계의 이름과 책임 혼재가 더 직접적이다.
+- Gateway / Coordinator를 먼저 만들면 God Object가 될 가능성이 크다.
+- `Request`는 request-response 흐름을 암시하지만, 현재 전투 흐름은 source가 signal을 전달하고 target이 자체 상태로 outcome을 판단하는 구조에 가깝다.
+- Blink / Repulse 같은 cue 기반 defensive outcome은 `Damage`나 `Attack`보다 넓은 전투 신호 개념이 필요하다.
+
+따라서 이번 W04는 `CombatSignal` vocabulary와 Source / Target 책임 경계를 먼저 확정한다.
+
+## 3. 권장 이름
+
+### 3.1 컴포넌트
+
+```text
+UCCombatSignalSourceComponent
+UCCombatSignalTargetComponent
+```
+
+`Source`는 전투 신호를 만드는 쪽이다. 무기 overlap, montage notify, timing cue, lock-on cue 등에서 target에게 보낼 전투 신호를 구성하고 전달한다.
+
+`Target`은 전투 신호를 받는 쪽이다. 자신의 guard / parry / dead / invincible / cue timing 상태를 바탕으로 outcome을 평가하고 결과 적용과 후속 통지를 수행한다.
+
+### 3.2 구조체
+
+```text
+FCombatSignalHeader
+FCombatSignal
+FCombatSignalContext
+FCombatSignalEvaluation
+FCombatSignalApplyResult
+FCombatSignalResult
+```
+
+### 3.3 열거형
+
+```text
+ECombatSignalType
+- None
+- HitEvidence
+- TimingCue
+- DirectDamage
+- System
+
+ECombatSignalOutcome
+- None
+- Hit
+- Blocked
+- Parried
+- Blink
+- Repulse
+- Staggered
+- Dead
+
+ECombatSignalResultType
+- None
+- Handled
+- Ignored
+- Rejected
+```
+
+## 4. 책임 경계
+
+### 4.1 CombatSignalSource
+
+책임:
+
+- hit window open / close 상태를 추적한다.
+- 동일 hit window 안에서 duplicate target을 거른다.
+- overlap / cue / timing signal을 `FCombatSignal`로 구성한다.
+- target actor의 `CombatSignalTarget` 경계를 찾아 signal을 전달한다.
+- 필요 시 target에서 돌아온 result를 받아 ParryStack, debug, result out에 연결한다.
+
+하지 않는 일:
+
+- defender의 Guard / Parry / Blink / Repulse 성공 여부를 결정하지 않는다.
+- HP를 직접 감소시키지 않는다.
+- defender reaction / feedback을 직접 실행하지 않는다.
+
+### 4.2 CombatSignalTarget
+
+책임:
+
+- `FCombatSignal`을 수신한다.
+- signal 유효성과 target-side context를 검증한다.
+- Guard / Parry / Hit / Blink / Repulse / Dead outcome을 평가한다.
+- Health / Reaction / Feedback / ResultOut으로 넘길 apply/result 자료를 만든다.
+- 필요한 후속 domain 호출 순서를 관리한다.
+- UE `TakeDamage()`는 장기적으로 이쪽으로 들어오는 legacy adapter로 축소한다.
+
+하지 않는 일:
+
+- source-side hit window를 관리하지 않는다.
+- target discovery를 수행하지 않는다.
+- source actor의 공격 판정을 대신 결정하지 않는다.
+
+## 5. 내부 흐름
+
+```text
+1. Source 준비
+Weapon overlap / montage notify / cue window 발생
+
+2. Signal 생성
+UCCombatSignalSourceComponent
+-> FCombatSignal 구성
+
+3. Signal 전달
+SourceComponent
+-> TargetActor의 UCCombatSignalTargetComponent 탐색
+-> ReceiveCombatSignal 호출
+
+4. Target 평가
+TargetComponent
+-> EvaluateCombatSignal
+-> Guard / Parry / Hit / Blink / Repulse / Dead 판단
+
+5. 결과 적용
+TargetComponent
+-> ApplyCombatSignalOutcome
+-> Health / Reaction / Feedback / ResultOut으로 분배
+
+6. 결과 통지
+TargetComponent
+-> 필요 시 SourceComponent 또는 attacker-side result receiver에 CombatSignalResult 전달
+```
+
+## 6. API 후보
+
+### Source
+
+```cpp
+void OpenSignalWindow(...);
+void CloseSignalWindow(...);
+FCombatSignal BuildHitSignal(...);
+FCombatSignal BuildCueSignal(...);
+FCombatSignalResult SendCombatSignal(const FCombatSignal& InSignal);
+void NotifyCombatSignalResult(const FCombatSignalResult& InResult);
+```
+
+### Target
+
+```cpp
+FCombatSignalResult ReceiveCombatSignal(const FCombatSignal& InSignal);
+FCombatSignalEvaluation EvaluateCombatSignal(const FCombatSignal& InSignal);
+FCombatSignalApplyResult ApplyCombatSignalOutcome(const FCombatSignalEvaluation& InEvaluation);
+void NotifyCombatSignalResult(const FCombatSignalResult& InResult);
+```
+
+### Legacy Adapter
+
+```cpp
+FCombatSignal BuildSignalFromDamageEvent(...);
+FCombatSignalResult ReceiveEngineDamage(...);
+```
+
+## 7. 인터페이스 구성
+
+v1에서는 interface를 최소화한다.
+
+우선 후보:
+
+```cpp
+class ICCombatSignalTarget
+{
+    ReceiveCombatSignal(...);
+};
+```
+
+후속 후보:
+
+```cpp
+class ICCombatSignalSource
+{
+    NotifyCombatSignalResult(...);
+};
+```
+
+Target interface가 먼저 필요한 이유는 수신 경계가 반드시 필요하기 때문이다. 반면 source result notify는 ParryStack / Stagger / debug / network 요구가 정리된 후 추가해도 된다.
+
+## 8. 현재 컴포넌트와의 관계
+
+### 8.1 ApplyDamageComponent
+
+현재 `UCApplyDamageComponent`는 이름과 달리 HP를 직접 적용하지 않는다.
+
+현재 책임:
+
+```text
+hit window 관리
+duplicate target 관리
+hit context validate
+damage spec 조회
+requested damage 계산
+target TakeDamage 호출
+```
+
+장기 위치:
+
+```text
+UCApplyDamageComponent
+-> UCCombatSignalSourceComponent
+```
+
+### 8.2 TakeDamageComponent
+
+현재 `UCTakeDamageComponent`는 수신, 평가, 적용, 후속 분배를 모두 가진다.
+
+현재 책임:
+
+```text
+UE TakeDamage 수신
+payload / context 구성
+defensive outcome 판단
+damage 계산
+Health commit
+reaction / feedback dispatch
+attacker result packet dispatch
+```
+
+장기 위치:
+
+```text
+UCTakeDamageComponent
+-> UCCombatSignalTargetComponent
+```
+
+## 9. 작업 분할 계획
+
+### W04-01 Combat Signal Boundary Re-scope
+
+브랜치:
+
+```text
+refactor/combat-signal-boundary
+```
+
+목표:
+
+```text
+Intent Gateway / Coordinator 중심 계획을 보류하고 CombatSignal Source / Target 기준을 문서로 확정한다.
+```
+
+핵심 범위:
+
+- W04 work list 작성
+- N05 Combat Signal Boundary 설계 노트 작성
+- N06 branch implementation plan 작성
+- task brief / work journal / prompt update note 작성
+- 코드 변경 없음
+
+완료조건:
+
+- 같은 브랜치에서 Combat Signal 타입 추가 작업으로 바로 착수 가능하다.
+- 문서에서 `Attack`, `Request`, `Damage`가 핵심 파이프라인 이름으로 남지 않는다.
+- Source / Target 책임 경계가 문서만 보고 판단 가능하다.
+
+### W04-02 Combat Signal Types
+
+브랜치:
+
+```text
+refactor/combat-signal-boundary
+```
+
+커밋 단위:
+
+```text
+feat(combat): add combat signal type vocabulary
+```
+
+목표:
+
+```text
+CombatSignal 파이프라인의 최소 타입을 추가한다.
+```
+
+핵심 범위:
+
+- `FCombatSignalHeader`
+- `FCombatSignal`
+- `FCombatSignalContext`
+- `FCombatSignalEvaluation`
+- `FCombatSignalApplyResult`
+- `FCombatSignalResult`
+- `ECombatSignalType`
+- `ECombatSignalOutcome`
+- `ECombatSignalResultType`
+
+완료조건:
+
+- 기존 `ApplyDamageComponent` / `TakeDamageComponent` 동작 변화 없음
+- 타입만 추가
+- Unreal build 성공
+
+### W04-03 Combat Signal Target Boundary v1
+
+브랜치:
+
+```text
+refactor/combat-signal-target-v1
+```
+
+목표:
+
+```text
+UCTakeDamageComponent 내부 흐름을 CombatSignalTarget 책임 기준으로 정리한다.
+```
+
+핵심 범위:
+
+- Receive / Evaluate / Apply / Notify 단계 메서드 분리
+- 기존 `RequestTakeDamage` 흐름 유지
+- UE `TakeDamage()` adapter 유지
+- 클래스명 rename은 아직 하지 않음
+
+완료조건:
+
+- 기존 Guard / Parry / Hit / Dead 동작 유지
+- target-side 책임 단계가 코드에서 명확히 보임
+- Unreal build 성공
+
+### W04-04 Combat Signal Source Boundary v1
+
+브랜치:
+
+```text
+refactor/combat-signal-source-v1
+```
+
+목표:
+
+```text
+UCApplyDamageComponent 내부 흐름을 CombatSignalSource 책임 기준으로 정리한다.
+```
+
+핵심 범위:
+
+- hit window tracking
+- duplicate target tracking
+- signal build 후보 경계
+- target delivery 경계
+- `RequestApplyDamage` API rename 후보 준비
+
+완료조건:
+
+- 기존 weapon overlap damage 동작 유지
+- source-side 책임 단계가 코드에서 명확히 보임
+- Unreal build 성공
+
+### W04-05 Combat Signal Component Rename
+
+브랜치:
+
+```text
+refactor/combat-signal-component-rename
+```
+
+목표:
+
+```text
+책임 정리가 끝난 뒤 ApplyDamage / TakeDamage 명칭을 CombatSignalSource / Target으로 교체한다.
+```
+
+핵심 범위:
+
+- `UCApplyDamageComponent` -> `UCCombatSignalSourceComponent`
+- `UCTakeDamageComponent` -> `UCCombatSignalTargetComponent`
+- Character / Weapon 참조 갱신
+- Blueprint 영향 확인
+
+완료조건:
+
+- 이름만 바꾼 것이 아니라 이전 브랜치의 책임 정리가 선행되어 있다.
+- 기존 전투 회귀 통과
+- Unreal build 성공
+
+### W04-06 Combat Signal Cue v1
+
+브랜치:
+
+```text
+feature/combat-signal-cue-v1
+```
+
+목표:
+
+```text
+Blink / Repulse 같은 collision 없는 timing cue를 CombatSignal 흐름에 연결한다.
+```
+
+핵심 범위:
+
+- `ECombatSignalType::TimingCue` 사용
+- target discovery 방식 정리
+- Blink / Repulse evaluation hook 추가
+
+완료조건:
+
+- collision hit와 timing cue가 같은 target receive 흐름을 공유한다.
+- cue 전용 예외 파이프라인을 만들지 않는다.
+
+## 10. 관련 문서
+
+- `Docs/06_notes/N03_Guard_Hold_Overlay_Layer_Design_Note.md`
+- `Docs/06_notes/N04_Blink_Repulse_Combat_Packet_Design_Note.md`
+- `Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md`
+- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
+- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -26,5 +26,6 @@
 | P18 | AI Workflow / Prompt Library v1 | `P18_UE5_Portfolio_Pull_Request.md` | `feature/ai-workflow` |  | W01, W03 |
 | P19 | Documentation Workflow Update | `P19_UE5_Portfolio_Pull_Request.md` | `docs/portfolio-documentation-update` |  | W02, N01 |
 | P20 | Guard / Parry Action v1 | `P20_UE5_Portfolio_Pull_Request.md` | `feature/combat-guard-parry` |  | W03, B11, B12, N02, N03, N04, N05 |
+| P21 | Combat Signal Boundary v1 | `P21_UE5_Portfolio_Pull_Request.md` | `refactor/combat-signal-boundary` |  | W04, N05, N06, NA01 |
 
 ---

--- a/Docs/04_Pull_Request/P21_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P21_UE5_Portfolio_Pull_Request.md
@@ -32,7 +32,9 @@
 
 Guard / Parry v1 이후 damage 처리 흐름에는 hit 전달, 수신 측 방어 판정, damage commit, reaction / feedback, attacker result 전달 책임이 함께 모여 있었다.
 
-초기에는 이를 일반화된 `Intent / Request / Receiver / Resolution / Coordinator` 구조로 분리하는 방향을 검토했다. 하지만 현재 브랜치에서는 해당 기획을 구현하지 않고, 후속 리팩터링의 기준으로 사용할 `CombatSignal Source / Target` 경계만 정리했다.
+초기에는 이를 일반화된 `Intent / Request / Receiver / Resolution / Coordinator` 구조로 분리하는 방향을 검토했다. 하지만 입력, damage, timing cue, system event는 발생 원인과 해석 기준이 달라 하나의 공용 `Request` 파이프라인으로 먼저 묶기에는 범위가 넓었다.
+
+따라서 현재 브랜치에서는 공용 상태 변경 파이프라인 일반화를 보류하고, 후속 리팩터링의 기준으로 사용할 `CombatSignal Source / Target` 경계만 정리했다.
 
 ---
 

--- a/Docs/04_Pull_Request/P21_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P21_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,172 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P21: Combat Signal Boundary v1 정리**
+
+## 날짜
+
+**2026.06.22**
+
+## 상태
+
+- [x] **완료**
+
+---
+
+## 브랜치
+
+- `refactor/combat-signal-boundary`
+
+---
+
+## 요약
+
+이번 PR에서는 이후 combat 송수신 책임을 정리하기 위한 기준으로 **Combat Signal Boundary v1**을 문서화하고, 다음 리팩터링에서 공유할 최소 타입 vocabulary를 추가했다.
+
+기존 gameplay 흐름은 변경하지 않았다. `ApplyDamageComponent`, `TakeDamageComponent`, Guard / Parry / Hit / Dead 흐름은 그대로 두고, 후속 브랜치에서 Target / Source 책임을 나눌 수 있도록 설계 기준과 타입만 마련했다.
+
+---
+
+## 변경 배경
+
+Guard / Parry v1 이후 damage 처리 흐름에는 hit 전달, 수신 측 방어 판정, damage commit, reaction / feedback, attacker result 전달 책임이 함께 모여 있었다.
+
+초기에는 이를 일반화된 `Intent / Request / Receiver / Resolution / Coordinator` 구조로 분리하는 방향을 검토했다. 하지만 현재 브랜치에서는 해당 기획을 구현하지 않고, 후속 리팩터링의 기준으로 사용할 `CombatSignal Source / Target` 경계만 정리했다.
+
+---
+
+## 변경 범위
+
+### 1. Combat Signal 설계 기준 정리
+
+- `N05_Combat_Signal_Boundary_Design_Note.md` 추가 및 정리
+- `N06_Combat_Signal_Branch_Implementation_Plan.md` 추가 및 정리
+- branch 분할 기준을 feature 단위가 아니라 behavior / risk 축 기준으로 정리
+
+### 2. 기존 Request Routing 설계 문서 archive
+
+- 기존 Request / Receiver / Resolution / Coordinator 중심 문서를 archive로 이동
+- active note와 충돌하지 않도록 관련 참조 갱신
+
+```text
+Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md
+```
+
+### 3. Combat Signal 타입 vocabulary 추가
+
+새 타입 파일을 추가했다.
+
+```text
+Source/Portfolio/Type/CCombatSignalStructure.h
+Source/Portfolio/Type/CCombatSignalStructure.cpp
+```
+
+추가된 주요 타입:
+
+```text
+ECombatSignalType
+ECombatSignalOutcome
+ECombatSignalResultType
+FCombatSignalHeader
+FCombatSignal
+FCombatSignalContext
+FCombatSignalEvaluation
+FCombatSignalApplyResult
+FCombatSignalResult
+```
+
+각 struct에는 최소 유효성 검사용 `IsValidMinimal()`을 두었다. 이번 단계에서는 actor 유효성이나 domain별 rule을 강제하지 않고, signal/result 타입의 기본 상태만 확인한다.
+
+### 4. 작업 기록 체계 정리
+
+- W04 작업 리스트 갱신
+- task brief 추가
+- work journal 정리
+- prompt update note 정리
+
+---
+
+## 구현 범위
+
+이번 PR에서 실제 runtime 연결은 하지 않았다.
+
+- `ApplyDamageComponent` 변경 없음
+- `TakeDamageComponent` 변경 없음
+- Guard / Parry / Hit / Dead 동작 변경 없음
+- CombatSignal 타입은 아직 기존 damage packet 흐름에 연결하지 않음
+
+이번 PR의 구현 범위는 다음으로 제한했다.
+
+- Combat Signal 타입 파일 추가
+- 타입별 최소 유효성 검사 추가
+- 관련 문서와 작업 기록 갱신
+
+---
+
+## 검증
+
+### 빌드
+
+```text
+PortfolioEditor Win64 Development
+```
+
+- UnrealHeaderTool 통과
+- `CCombatSignalStructure.cpp` 컴파일 통과
+- Editor target 빌드 성공
+
+### 정적 확인
+
+- 기존 gameplay component 변경 없음
+- 기존 damage / guard / parry runtime 연결 없음
+- 신규 타입 파일은 `CoreMinimal.h`와 generated header만 포함
+
+---
+
+## 제외 범위
+
+이번 PR에서는 다음 작업을 의도적으로 제외했다.
+
+- `TakeDamageComponent`의 Target 내부 경계 정리
+- `ApplyDamageComponent`의 Source 내부 경계 정리
+- 컴포넌트 rename
+- CombatSignal 타입을 기존 damage 흐름에 연결
+- Blink / Repulse cue 구현
+- 별도 Coordinator / Gateway 계층 구현
+
+---
+
+## 후속 작업
+
+권장 후속 브랜치는 다음과 같다.
+
+```text
+refactor/combat-signal-target-v1
+```
+
+후속 작업 목표:
+
+- `TakeDamageComponent` 내부를 Target 관점으로 정리
+- Receive / Evaluate / Apply / Notify 단계 명시
+- 기존 Guard / Parry / Hit / Dead 동작 유지
+- CombatSignal 타입 연결 여부는 필요한 지점에서만 검토
+
+그 다음 후보:
+
+```text
+refactor/combat-signal-source-v1
+refactor/combat-signal-component-rename
+feature/combat-signal-cue-v1
+```
+
+---
+
+## 관련 문서
+
+- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
+- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`
+- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_01_Combat_Signal_Boundary_Rescope.md`
+- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_02_Combat_Signal_Types_v1.md`
+- `Docs/06_notes/work_journal/J01_Combat_Signal_Boundary_Work_Journal.md`
+- `Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md`

--- a/Docs/06_notes/N04_Blink_Repulse_Combat_Packet_Design_Note.md
+++ b/Docs/06_notes/N04_Blink_Repulse_Combat_Packet_Design_Note.md
@@ -1,5 +1,7 @@
 # Blink / Repulse Combat Packet Design Note
 
+> Status update: W04에서 전투 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의했다. 이 문서의 `Combat packet`, `Request`, `Receiver`, `Resolution` 표현은 후속 작업에서 `CombatSignal`, `CombatSignalSource`, `CombatSignalTarget`, target-side evaluation 기준으로 재해석한다. 최신 기준은 `N05_Combat_Signal_Boundary_Design_Note.md`를 따른다.
+
 ## 1. 목적
 
 본 문서는 Blink / Repulse와 cue 기반 combat packet 전달 구조를 정리한다.
@@ -231,7 +233,7 @@ W03에서는 Guard / Parry v1만 마무리한다.
 
 - `Docs/01_Work_List/W03_Parry/W03_UE5_Portfolio_Work_List.md`
 - `Docs/06_notes/N03_Guard_Hold_Overlay_Layer_Design_Note.md`
-- `Docs/06_notes/N05_Combat_Intent_Request_Resolution_Routing_Design_Note.md`
+- `Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md`
 - `Docs/05_System_Architecture/S27_UE5_Portfolio_System_Architecture.md`
 
 ---

--- a/Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md
+++ b/Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md
@@ -1,0 +1,316 @@
+# N05 Combat Signal Boundary Design Note
+
+## 1. 목적
+
+이 문서는 W03 이후 전투 처리 구조를 `CombatSignal` 기준으로 다시 정리한다.
+
+기존 논의에서는 `Intent -> Request -> Resolution -> Routing -> Domain` 또는 공용 `GameplayIntentGateway / GameplayCoordinator`가 후보였다. 
+
+그러나 현재 코드의 직접적인 문제는 공용 routing 계층 부재가 아니라, `ApplyDamageComponent`와 `TakeDamageComponent` 안에 전투 신호 생성 / 전달 / 수신 / 판정 / 적용 / 결과 통지가 압축되어 있다는 점이다.
+
+따라서 이번 설계 기준은 다음과 같다.
+
+```text
+CombatSignalSource
+-> CombatSignal
+-> CombatSignalTarget
+-> Evaluate
+-> Apply
+-> Notify Result
+```
+
+## 2. 핵심 판단
+
+### 2.1 Request 용어를 핵심 이름에서 제외한다
+
+`Request`는 보통 요청과 응답의 결합을 암시한다.
+
+하지만 현재 전투 흐름은 source가 "이 신호를 처리해 달라"고 보내고, target이 자신의 상태를 기준으로 outcome을 판단하는 구조다. 결과가 source에게 돌아갈 수는 있지만, 모든 signal이 request-response API로 닫혀야 하는 것은 아니다.
+
+따라서 핵심 파이프라인 이름에는 `Request`를 쓰지 않는다.
+
+### 2.2 Attack 용어를 핵심 이름에서 제외한다
+
+`Attack`은 공격 행위 쪽으로 의미가 좁다.
+
+현재 파이프라인은 단순 공격만이 아니라 다음을 모두 다룬다.
+
+- collision hit
+- guard / block hit
+- parry
+- blink cue
+- repulse cue
+- attacker-side result
+- defender-side reaction / feedback
+
+이 흐름은 source와 target 사이의 전투 공방 전체에 가깝다. 따라서 `Attack`보다 `CombatSignal`이 더 적절하다.
+
+### 2.3 Damage 용어를 핵심 이름에서 제외한다
+
+`Damage`는 결과 적용 중 하나다.
+
+Parry, Guard, Blink, Repulse처럼 damage commit이 없거나 조건부인 outcome도 같은 파이프라인에서 처리되어야 한다. 따라서 핵심 파이프라인 이름을 `Damage`로 두면 방어 성공, cue, result notification이 부자연스러워진다.
+
+## 3. 용어 정의
+
+### CombatSignal
+
+아직 판정 전인 전투 입력 / 증거 / cue다.
+
+예:
+
+- weapon overlap hit evidence
+- montage timing cue
+- lock-on target cue
+- UE `TakeDamage()`에서 변환된 legacy damage signal
+
+### CombatSignalSource
+
+전투 신호를 만드는 actor-side component다.
+
+주요 책임:
+
+- hit window 추적
+- duplicate target 관리
+- hit / cue signal 구성
+- target에게 signal 전달
+- optional result 수신
+
+### CombatSignalTarget
+
+전투 신호를 받는 actor-side component다.
+
+주요 책임:
+
+- signal 수신
+- target-side context 검증
+- guard / parry / hit / blink / repulse / dead 평가
+- health / reaction / feedback / result out 적용 자료 구성
+- 후속 domain 호출 또는 통지
+
+### CombatSignalEvaluation
+
+target이 signal을 해석한 평가 결과다.
+
+예:
+
+```text
+Outcome = Parried
+ShouldCommitDamage = false
+DefenderReaction = Parry
+AttackerResult = Parried
+FeedbackCue = ParrySpark
+```
+
+### CombatSignalApplyResult
+
+평가 결과를 실제 domain에 반영한 결과다.
+
+예:
+
+- committed damage
+- health changed 여부
+- reaction request accepted 여부
+- feedback dispatched 여부
+
+### CombatSignalResult
+
+외부 통지 / source-side result / debug / event에 사용할 최종 결과다.
+
+## 4. 권장 컴포넌트 구조
+
+```text
+UCCombatSignalSourceComponent
+UCCombatSignalTargetComponent
+```
+
+v1에서는 `Evaluator`, `Applier`, `Notifier`를 별도 component로 나누지 않는다. 먼저 target component 내부 메서드 단계로 분리한다.
+
+이유:
+
+- 현재 코드의 실제 압축 위치는 `TakeDamageComponent` 내부다.
+- 컴포넌트를 먼저 늘리면 routing 계층이 다시 과해질 수 있다.
+- 함수 경계와 구조체 경계가 안정된 뒤에만 component 분리를 검토하는 편이 안전하다.
+
+## 5. Source 책임
+
+`CombatSignalSource`는 source-side 사실을 정리한다.
+
+```text
+Weapon overlap / cue
+-> hit window id 확인
+-> duplicate target 검사
+-> signal payload 구성
+-> target delivery
+```
+
+포함 책임:
+
+- `OpenSignalWindow`
+- `CloseSignalWindow`
+- `BuildHitSignal`
+- `BuildCueSignal`
+- `SendCombatSignal`
+- `NotifyCombatSignalResult`
+
+제외 책임:
+
+- target의 guard / parry 성공 판단
+- damage commit
+- defender reaction 실행
+- defender feedback 실행
+
+## 6. Target 책임
+
+`CombatSignalTarget`은 target-side 판단과 후속 적용의 중심이다.
+
+```text
+ReceiveCombatSignal
+-> Validate target context
+-> EvaluateCombatSignal
+-> ApplyCombatSignalOutcome
+-> NotifyCombatSignalResult
+```
+
+포함 책임:
+
+- signal 수신
+- target-side validation
+- defensive outcome 평가
+- damage commit 필요 여부 결정
+- health apply 호출
+- reaction request 구성
+- feedback request 구성
+- source result 구성
+
+제외 책임:
+
+- source-side hit window 관리
+- target discovery
+- source actor의 공격 선택
+
+## 7. Interface 기준
+
+v1에서 반드시 필요한 interface는 target 수신 경계다.
+
+```cpp
+class ICCombatSignalTarget
+{
+    ReceiveCombatSignal(...);
+};
+```
+
+source result notify interface는 후속으로 둔다.
+
+```cpp
+class ICCombatSignalSource
+{
+    NotifyCombatSignalResult(...);
+};
+```
+
+source notify가 후순위인 이유는 result가 항상 source에게 돌아가야 하는 것이 아니기 때문이다. ParryStack / Stagger / network / debug 요구가 정리된 뒤 추가한다.
+
+## 8. Blink / Repulse와의 관계
+
+N04 기준으로 Blink / Repulse는 collision hit가 아니라 cue 기반 defensive success outcome이다.
+
+따라서 별도 `EventSource / EventTarget` 축을 만들기보다 `CombatSignal` 안에 signal type을 둔다.
+
+```text
+ECombatSignalType::HitEvidence
+ECombatSignalType::TimingCue
+```
+
+처리 차이는 target discovery와 payload 해석에서만 둔다.
+
+```text
+Collision hit
+-> overlap으로 target 발견
+-> HitEvidence signal 전달
+
+Timing cue
+-> cached target / lock-on target 발견
+-> TimingCue signal 전달
+```
+
+target 이후 흐름은 가능하면 공유한다.
+
+```text
+ReceiveCombatSignal
+-> EvaluateCombatSignal
+-> ApplyCombatSignalOutcome
+-> NotifyCombatSignalResult
+```
+
+## 9. 기존 컴포넌트 migration
+
+### ApplyDamageComponent
+
+장기적으로 `CombatSignalSource`로 이동한다.
+
+```text
+NotifyHitWindowOpened / Closed
+-> OpenSignalWindow / CloseSignalWindow
+
+RequestApplyDamage
+-> BuildHitSignal
+-> SendCombatSignal
+```
+
+### TakeDamageComponent
+
+장기적으로 `CombatSignalTarget`으로 이동한다.
+
+```text
+RequestTakeDamage
+-> ReceiveCombatSignal
+
+CanTakeDamage / defensive outcome
+-> EvaluateCombatSignal
+
+CommitTakeDamage
+-> ApplyCombatSignalOutcome
+
+Reaction / Feedback / AttackerResult dispatch
+-> NotifyCombatSignalResult
+```
+
+### UE TakeDamage
+
+UE `AActor::TakeDamage()`는 legacy adapter로 유지한다.
+
+```text
+AActor::TakeDamage
+-> BuildSignalFromDamageEvent
+-> CombatSignalTarget.ReceiveCombatSignal
+```
+
+## 10. God Object 방지 규칙
+
+`CombatSignalTarget`이 커지는 위험은 인정한다. v1에서는 책임을 다음 규칙으로 제한한다.
+
+- source-side hit window는 source component에 둔다.
+- target-side 평가만 target component가 소유한다.
+- health 변경은 Health / resource component에 위임한다.
+- reaction 실행 가능성은 ReactionOrchestrator에 위임한다.
+- feedback 실행은 Feedback component에 위임한다.
+- result 전달은 packet / interface / event 경계로 분리한다.
+- 별도 component 분리는 함수 경계와 구조체 경계가 안정된 뒤 진행한다.
+
+## 11. 이번 브랜치의 결론
+
+이번 브랜치에서는 CombatSignal 경계 재정의와 최소 타입 vocabulary 추가까지 포함한다. 기존 gameplay 흐름에 연결되는 리팩터링은 다음 브랜치부터 진행한다.
+
+확정:
+
+- 핵심 이름은 `CombatSignal`로 둔다.
+- source-side component 후보는 `UCCombatSignalSourceComponent`다.
+- target-side component 후보는 `UCCombatSignalTargetComponent`다.
+- `Request`, `Attack`, `Damage`는 핵심 파이프라인 이름에서 제외한다.
+- 기존 `GameplayIntentGateway / GameplayCoordinator` 계획은 W04 주도 구조로 사용하지 않는다.
+
+후속:
+
+- 다음 작업은 같은 브랜치에서 `Combat Signal Types v1`로 진행한다.
+- 이후 target boundary, source boundary, component rename은 별도 브랜치 순서로 진행한다.

--- a/Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md
+++ b/Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md
@@ -4,9 +4,13 @@
 
 이 문서는 W03 이후 전투 처리 구조를 `CombatSignal` 기준으로 다시 정리한다.
 
-기존 논의에서는 `Intent -> Request -> Resolution -> Routing -> Domain` 또는 공용 `GameplayIntentGateway / GameplayCoordinator`가 후보였다. 
+기존 논의에서는 `Intent -> Request -> Resolution -> Routing -> Domain` 또는 공용 `GameplayIntentGateway / GameplayCoordinator`가 후보였다.
 
-그러나 현재 코드의 직접적인 문제는 공용 routing 계층 부재가 아니라, `ApplyDamageComponent`와 `TakeDamageComponent` 안에 전투 신호 생성 / 전달 / 수신 / 판정 / 적용 / 결과 통지가 압축되어 있다는 점이다.
+이 구조는 객체의 상태를 바꾸는 흐름을 하나의 공용 파이프라인으로 통일하려는 장기 방향이었다. 하지만 입력, damage, timing cue, system event는 발생 원인과 해석 기준이 다르다. 이를 하나의 Gateway / Coordinator가 판정하고 분배하면 해당 객체가 각 domain rule을 과도하게 알게 되어 God Object가 될 위험이 크다.
+
+반대로 모든 흐름을 세밀한 adapter / coordinator로 나누면 현재 프로젝트 규모에 비해 계층이 과도하게 늘어난다.
+
+따라서 공용 상태 변경 파이프라인 일반화는 뒤로 미루고, 입력 처리 축 / combat 처리 축 / timing cue 처리 축을 분리해서 바라본다. 그중 현재 코드의 직접적인 문제는 `ApplyDamageComponent`와 `TakeDamageComponent` 안에 전투 신호 생성 / 전달 / 수신 / 판정 / 적용 / 결과 통지가 압축되어 있다는 점이다.
 
 따라서 이번 설계 기준은 다음과 같다.
 
@@ -27,7 +31,7 @@ CombatSignalSource
 
 하지만 현재 전투 흐름은 source가 "이 신호를 처리해 달라"고 보내고, target이 자신의 상태를 기준으로 outcome을 판단하는 구조다. 결과가 source에게 돌아갈 수는 있지만, 모든 signal이 request-response API로 닫혀야 하는 것은 아니다.
 
-따라서 핵심 파이프라인 이름에는 `Request`를 쓰지 않는다.
+따라서 combat 핵심 파이프라인 이름에는 `Request`를 쓰지 않는다. 공용 상태 변경 요청을 모두 `Request`로 묶는 일반화는 domain 경계가 안정된 뒤 다시 검토한다.
 
 ### 2.2 Attack 용어를 핵심 이름에서 제외한다
 
@@ -308,7 +312,7 @@ AActor::TakeDamage
 - source-side component 후보는 `UCCombatSignalSourceComponent`다.
 - target-side component 후보는 `UCCombatSignalTargetComponent`다.
 - `Request`, `Attack`, `Damage`는 핵심 파이프라인 이름에서 제외한다.
-- 기존 `GameplayIntentGateway / GameplayCoordinator` 계획은 W04 주도 구조로 사용하지 않는다.
+- 기존 `GameplayIntentGateway / GameplayCoordinator` 계획은 W04 주도 구조로 사용하지 않는다. 일반화 자체를 부정한 것이 아니라, combat source / target 경계가 안정된 뒤 재검토한다.
 
 후속:
 

--- a/Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md
+++ b/Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md
@@ -62,7 +62,7 @@ refactor/combat-signal-boundary
 목표:
 
 ```text
-기존 Intent Gateway / Coordinator 중심 계획을 보류하고 CombatSignal Source / Target 기준을 문서와 최소 타입으로 확정한다.
+공용 상태 변경 파이프라인 일반화를 보류하고 CombatSignal Source / Target 기준을 문서와 최소 타입으로 확정한다.
 ```
 
 핵심 범위:
@@ -87,6 +87,7 @@ refactor/combat-signal-boundary
 
 - `Request`, `Attack`, `Damage` 중심 이름이 핵심 파이프라인에서 제거된다.
 - `CombatSignal Source / Target` 책임 경계가 문서화되어 있다.
+- 입력 처리 축 / combat 처리 축 / timing cue 처리 축을 하나의 공용 Request 파이프라인으로 묶지 않는 이유가 문서화되어 있다.
 - CombatSignal 최소 타입이 추가되어 있다.
 - 기존 gameplay 동작 변화가 없다.
 - Unreal build 성공.

--- a/Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md
+++ b/Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md
@@ -1,0 +1,261 @@
+# N06 Combat Signal Branch Implementation Plan
+
+## 1. 목적
+
+이 문서는 `CombatSignal` 구조를 실제 코드로 옮기기 위한 작업 분할 계획을 정리한다.
+
+기준은 브랜치를 과도하게 잘게 나누지 않는 것이다. 문서로 확정한 vocabulary를 코드 타입으로 추가하는 작업은 같은 논리 단위이므로 `refactor/combat-signal-boundary` 브랜치 안에서 함께 처리한다. 실제 gameplay 흐름에 연결되는 리팩터링부터 별도 브랜치로 나눈다.
+
+## 2. 전체 순서
+
+```text
+1. refactor/combat-signal-boundary
+   - CombatSignal 경계 문서화
+   - CombatSignal 타입 vocabulary 추가
+
+2. refactor/combat-signal-target-v1
+   - TakeDamageComponent target-side 책임 정리
+
+3. refactor/combat-signal-source-v1
+   - ApplyDamageComponent source-side 책임 정리
+
+4. refactor/combat-signal-component-rename
+   - 책임 정리 이후 component rename
+
+5. feature/combat-signal-cue-v1
+   - Blink / Repulse timing cue 연결
+```
+
+
+## 3. 브랜치 분할 기준
+
+브랜치 분할 기준은 기능 이름이 아니라 동작 변화의 성격과 회귀 위험이 달라지는 지점이다.
+
+```text
+1. 문서 / 타입만 추가하는가?
+2. 기존 target-side 피격 흐름을 바꾸는가?
+3. 기존 source-side 공격 송출 흐름을 바꾸는가?
+4. 이름 / 참조를 크게 바꾸는가?
+5. 새 gameplay behavior를 추가하는가?
+```
+
+따라서 분할 기준은 다음과 같다.
+
+| 구분 | 브랜치 | 분리 이유 |
+| --- | --- | --- |
+| Boundary / Type | `refactor/combat-signal-boundary` | 문서와 타입 vocabulary만 다루며 기존 runtime 흐름에 연결하지 않는다. |
+| Target-side refactor | `refactor/combat-signal-target-v1` | `TakeDamageComponent`는 Guard / Parry / Hit / Dead / feedback / attacker result에 직접 영향을 준다. |
+| Source-side refactor | `refactor/combat-signal-source-v1` | `ApplyDamageComponent`는 hit window / duplicate target / damage spec / target delivery에 직접 영향을 준다. |
+| Component rename | `refactor/combat-signal-component-rename` | 책임 정리 후 이름과 참조를 바꾸며, 동작 변경보다 참조 변경 위험이 크다. |
+| Cue feature | `feature/combat-signal-cue-v1` | Blink / Repulse timing cue는 새 gameplay behavior이므로 리팩터링과 분리한다. |
+
+이 기준에 따라 `CombatSignal Types v1`은 별도 브랜치가 아니라 현재 boundary 브랜치의 두 번째 커밋으로 포함한다. 반면 `TakeDamageComponent`나 `ApplyDamageComponent`에 연결되는 순간부터는 회귀 위험 축이 달라지므로 별도 브랜치로 나눈다.
+
+## 4. Branch 1: Combat Signal Boundary
+
+브랜치명:
+
+```text
+refactor/combat-signal-boundary
+```
+
+목표:
+
+```text
+기존 Intent Gateway / Coordinator 중심 계획을 보류하고 CombatSignal Source / Target 기준을 문서와 최소 타입으로 확정한다.
+```
+
+핵심 범위:
+
+- W04 work list 작성
+- N05 design note 작성
+- N06 implementation plan 작성
+- task brief 작성
+- work journal / prompt update note 작성
+- `Source/Portfolio/Type/CCombatSignalStructure.h/.cpp` 추가
+- CombatSignal 관련 enum / struct vocabulary 추가
+
+제외 범위:
+
+- `UCApplyDamageComponent` 연결
+- `UCTakeDamageComponent` 연결
+- 기존 `FApplyDamagePayload`, `FTakeDamagePacket`, `FCombatResultPacket` 교체
+- component rename
+- Blink / Repulse 구현
+
+완료조건:
+
+- `Request`, `Attack`, `Damage` 중심 이름이 핵심 파이프라인에서 제거된다.
+- `CombatSignal Source / Target` 책임 경계가 문서화되어 있다.
+- CombatSignal 최소 타입이 추가되어 있다.
+- 기존 gameplay 동작 변화가 없다.
+- Unreal build 성공.
+- TB와 prompt update check가 남는다.
+
+권장 커밋 단위:
+
+```text
+docs(combat): define combat signal boundary plan
+feat(combat): add combat signal type vocabulary
+docs(combat): record combat signal type task brief
+```
+
+## 5. Branch 2: Combat Signal Target Boundary v1
+
+브랜치명:
+
+```text
+refactor/combat-signal-target-v1
+```
+
+목표:
+
+```text
+UCTakeDamageComponent 내부 흐름을 CombatSignalTarget 단계로 정리한다.
+```
+
+핵심 범위:
+
+- `Receive` 단계 정리
+- `Evaluate` 단계 정리
+- `Apply` 단계 정리
+- `Notify Result` 단계 정리
+- 기존 `RequestTakeDamage` public API 유지
+- UE `TakeDamage()` adapter 유지
+
+제외 범위:
+
+- 클래스 rename
+- source-side component rename
+- Blink / Repulse cue 구현
+
+완료조건:
+
+- Guard / Parry / Hit / Dead 기존 동작 유지.
+- `TakeDamageComponent` 내부에서 target-side 단계가 명확히 보인다.
+- `FTakeDamageResult`와 `FCombatSignalResult` 후보 관계가 문서화된다.
+- Unreal build 성공.
+
+## 6. Branch 3: Combat Signal Source Boundary v1
+
+브랜치명:
+
+```text
+refactor/combat-signal-source-v1
+```
+
+목표:
+
+```text
+UCApplyDamageComponent 내부 흐름을 CombatSignalSource 단계로 정리한다.
+```
+
+핵심 범위:
+
+- hit window tracking 단계 정리
+- duplicate target tracking 단계 정리
+- source-side validation 정리
+- signal build 후보 경계 정리
+- target delivery 경계 정리
+
+제외 범위:
+
+- 클래스 rename
+- target-side behavior 변경
+- cue-based Blink / Repulse 구현
+
+완료조건:
+
+- 기존 weapon overlap damage 동작 유지.
+- source-side 단계가 코드에서 명확히 보인다.
+- target delivery가 장기적으로 `ReceiveCombatSignal`로 바뀔 수 있는 형태로 정리된다.
+- Unreal build 성공.
+
+## 7. Branch 4: Combat Signal Component Rename
+
+브랜치명:
+
+```text
+refactor/combat-signal-component-rename
+```
+
+목표:
+
+```text
+책임 정리 이후 component 이름을 CombatSignal 기준으로 맞춘다.
+```
+
+핵심 범위:
+
+- `UCApplyDamageComponent` -> `UCCombatSignalSourceComponent`
+- `UCTakeDamageComponent` -> `UCCombatSignalTargetComponent`
+- 파일명 갱신
+- include 갱신
+- Character / Weapon 참조 갱신
+- Blueprint 생성 이름 영향 확인
+
+제외 범위:
+
+- 새로운 combat behavior 추가
+- cue feature 추가
+
+완료조건:
+
+- 이름 변경 전후 동작 차이가 없다.
+- 기존 전투 회귀가 통과한다.
+- Unreal build 성공.
+- redirect / Blueprint 영향이 기록된다.
+
+## 8. Branch 5: Combat Signal Cue v1
+
+브랜치명:
+
+```text
+feature/combat-signal-cue-v1
+```
+
+목표:
+
+```text
+Blink / Repulse 같은 collision 없는 timing cue를 CombatSignal 흐름으로 처리한다.
+```
+
+핵심 범위:
+
+- `ECombatSignalType::TimingCue` 사용
+- cached target / lock-on target delivery 정리
+- Blink evaluation hook
+- Repulse evaluation hook
+- source result notification 정리
+
+완료조건:
+
+- collision hit와 timing cue가 같은 target receive 흐름을 공유한다.
+- cue 전용 예외 파이프라인을 만들지 않는다.
+- Blink / Repulse 성공 outcome이 reaction / movement / feedback / result로 분배될 수 있다.
+
+## 9. 다음 작업 제안
+
+다음 작업은 현재 브랜치 안에서 `Combat Signal Types v1`을 진행하는 것이다.
+
+작업 명세:
+
+```text
+Task:
+Combat Signal Types v1
+
+목표:
+CombatSignal Source / Target이 공유할 최소 타입 vocabulary를 추가한다.
+
+핵심 범위:
+- CCombatSignalStructure.h/.cpp 추가
+- Signal / Context / Evaluation / ApplyResult / Result 타입 정의
+- Minimal validity helper 정의
+- 기존 ApplyDamage / TakeDamage 흐름 연결 없음
+
+완료조건:
+- 기존 gameplay 동작 변화 없음
+- Unreal build 성공
+- TB_W04_02 작성
+- prompt update check 기록
+```

--- a/Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md
+++ b/Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md
@@ -1,5 +1,7 @@
 # Combat Intent / Request / Resolution / Routing Design Note
 
+> Status update: W04에서 이 문서의 공용 `Intent / Request / Routing` 중심 구조를 보류하고, 전투 파이프라인은 `CombatSignal Source / Target` 기준으로 다시 정리했다. 이 문서는 W03 이후 논의 기록으로 보존하며, 최신 작업 기준은 `N05_Combat_Signal_Boundary_Design_Note.md`와 `N06_Combat_Signal_Branch_Implementation_Plan.md`를 따른다.
+
 ## 1. 목적
 
 본 문서는 전투 처리 흐름을 `Intent -> Request -> Resolution -> Routing -> Domain` 계층으로 나누는 장기 구조를 정리한다.

--- a/Docs/06_notes/archive/README.md
+++ b/Docs/06_notes/archive/README.md
@@ -1,0 +1,18 @@
+# Notes Archive
+
+이 폴더는 현재 active note 기준에서는 제외하지만, 과거 논의와 의사결정 추적을 위해 보존할 note를 관리한다.
+
+Archive 문서는 최신 설계 기준이 아니다. active 문서에서 archive 문서를 참조할 때는 비교 근거 또는 과거 판단 기록으로만 사용한다.
+
+## 목록
+
+| ID | 제목 | 파일 | 상태 |
+| --- | --- | --- | --- |
+| NA01 | Combat Intent / Request / Resolution / Routing Design Note | `NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md` | W04 이후 archive |
+
+## 최신 기준
+
+현재 Combat Signal 작업 기준은 다음 문서를 따른다.
+
+- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
+- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`

--- a/Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md
+++ b/Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md
@@ -1,0 +1,58 @@
+# PU01 Combat Signal Boundary Prompt Update Note
+
+## Branch
+
+```text
+refactor/combat-signal-boundary
+```
+
+## Trigger
+
+W03 이후 전투 처리 구조를 논의하면서 `Request`, `Attack`, `Damage`, `Intent Gateway`, `Coordinator` 같은 이름이 실제 책임보다 먼저 구조를 끌고 가는 문제가 확인되었다.
+
+또한 브랜치를 너무 작게 나누면 작업 흐름이 불필요하게 복잡해지고, 너무 크게 묶으면 회귀 원인 추적이 어려워지는 문제가 있었다.
+
+## Candidate Update
+
+전투 송수신 구조를 설계할 때 다음 기준을 우선 검토한다.
+
+```text
+- Request는 request-response 흐름이 실제로 필요할 때만 핵심 이름으로 쓴다.
+- Attack은 공격 행위만이 아니라 source/target 공방 전체를 담아야 하는 경우 핵심 이름으로 쓰지 않는다.
+- Damage는 HP commit 또는 damage apply 단계 이름으로 제한한다.
+- collision hit와 timing cue, defensive outcome을 함께 다룰 때는 CombatSignal vocabulary를 우선 검토한다.
+- 공용 Gateway / Coordinator는 실제 domain boundary가 안정된 뒤 도입한다.
+```
+
+브랜치 분할은 기능 이름보다 동작 변화의 성격과 회귀 위험 기준으로 판단한다.
+
+```text
+- 문서 / 타입만 추가하는가?
+- 기존 target-side 피격 흐름을 바꾸는가?
+- 기존 source-side 공격 송출 흐름을 바꾸는가?
+- 이름 / 참조를 크게 바꾸는가?
+- 새 gameplay behavior를 추가하는가?
+```
+
+## Reason
+
+이 기준은 over-abstraction과 God Object 위험을 줄인다.
+
+특히 Blink / Repulse처럼 collision 없는 cue 기반 outcome은 `Damage`나 `Attack` 중심 이름으로는 자연스럽게 설명되지 않는다. `CombatSignal`은 target이 아직 해석하지 않은 전투 입력 / 증거 / cue라는 의미를 줄 수 있다.
+
+브랜치 분할 기준을 회귀 위험 축으로 두면 PR diff가 작아지고, 문제가 생겼을 때 target-side / source-side / rename / feature 중 어느 축에서 발생했는지 추적하기 쉽다.
+
+## Apply Target
+
+후보:
+
+```text
+Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/02_Working_Reference/02_Project_Stella_Working_Reference_Prompt (KR).md
+Docs/08_AI_Workflow/05_Prompt_Library/00_Prompt_Management/02_Prompt_Pattern_Candidates (KR).md
+```
+
+## Status
+
+```text
+Candidate
+```

--- a/Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md
+++ b/Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md
@@ -10,6 +10,8 @@ refactor/combat-signal-boundary
 
 W03 이후 전투 처리 구조를 논의하면서 `Request`, `Attack`, `Damage`, `Intent Gateway`, `Coordinator` 같은 이름이 실제 책임보다 먼저 구조를 끌고 가는 문제가 확인되었다.
 
+특히 객체의 상태를 바꾸는 모든 흐름을 하나의 `Request` 파이프라인으로 통일하려는 시도는 입력, damage, timing cue, system event의 성격 차이를 충분히 반영하지 못했다.
+
 또한 브랜치를 너무 작게 나누면 작업 흐름이 불필요하게 복잡해지고, 너무 크게 묶으면 회귀 원인 추적이 어려워지는 문제가 있었다.
 
 ## Candidate Update
@@ -21,7 +23,8 @@ W03 이후 전투 처리 구조를 논의하면서 `Request`, `Attack`, `Damage`
 - Attack은 공격 행위만이 아니라 source/target 공방 전체를 담아야 하는 경우 핵심 이름으로 쓰지 않는다.
 - Damage는 HP commit 또는 damage apply 단계 이름으로 제한한다.
 - collision hit와 timing cue, defensive outcome을 함께 다룰 때는 CombatSignal vocabulary를 우선 검토한다.
-- 공용 Gateway / Coordinator는 실제 domain boundary가 안정된 뒤 도입한다.
+- 입력 처리 축 / combat 처리 축 / timing cue 처리 축은 먼저 별도 성격으로 검토한다.
+- 공용 Gateway / Coordinator는 실제 domain boundary와 반복 패턴이 안정된 뒤 도입한다.
 ```
 
 브랜치 분할은 기능 이름보다 동작 변화의 성격과 회귀 위험 기준으로 판단한다.
@@ -37,6 +40,8 @@ W03 이후 전투 처리 구조를 논의하면서 `Request`, `Attack`, `Damage`
 ## Reason
 
 이 기준은 over-abstraction과 God Object 위험을 줄인다.
+
+모든 상태 변경 요청을 하나의 Gateway / Coordinator가 판정하고 분배하게 만들면 해당 객체가 각 domain rule을 과도하게 알게 된다. 반대로 이를 피하기 위해 모든 축을 세밀하게 분리하면 adapter와 계층이 과도하게 늘어난다. 따라서 공통화는 먼저 각 축의 데이터 성격과 반복 패턴이 안정된 뒤 검토한다.
 
 특히 Blink / Repulse처럼 collision 없는 cue 기반 outcome은 `Damage`나 `Attack` 중심 이름으로는 자연스럽게 설명되지 않는다. `CombatSignal`은 target이 아직 해석하지 않은 전투 입력 / 증거 / cue라는 의미를 줄 수 있다.
 

--- a/Docs/06_notes/prompt_updates/README.md
+++ b/Docs/06_notes/prompt_updates/README.md
@@ -1,0 +1,21 @@
+# Prompt Update Notes
+
+이 폴더는 브랜치 작업 중 발견한 프롬프트 업데이트 후보를 기록한다.
+
+여기에는 완성된 프롬프트 본문이 아니라, 이후 working reference prompt 또는 prompt library에 반영할 후보만 간단히 남긴다.
+
+권장 형식:
+
+- Branch
+- Trigger
+- Candidate Update
+- Reason
+- Apply Target
+- Status
+
+## 목록
+
+| ID | 제목 | 파일 | 상태 |
+| --- | --- | --- | --- |
+| PU01 | Combat Signal Boundary Prompt Update | `PU01_Combat_Signal_Boundary_Prompt_Update_Note.md` | 후보 |
+

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
@@ -1,0 +1,24 @@
+# W04 Combat Signal Boundary 작업 브리프
+
+이 폴더는 W04 `Combat Signal Boundary` 작업 단위를 기록한다.
+
+TB는 코드만 보고는 드러나지 않는 작업 의도, 범위, 완료조건, 보류한 선택지를 남기기 위한 문서다.
+
+## 작성 기준
+
+- 작업 전 제안한 명세를 기반으로 작성한다.
+- 실제 구현 또는 문서 정리 후 달라진 결정은 `결정 사항`에 남긴다.
+- 완료조건은 검증 가능한 문장으로 쓴다.
+- 작업 후 prompt update 필요 여부를 마지막에 확인한다.
+
+## 목록
+
+| ID | 제목 | 파일 | 상태 |
+| --- | --- | --- | --- |
+| W04-01 | Combat Signal Boundary 재정의 | `TB_W04_01_Combat_Signal_Boundary_Rescope.md` | 완료 |
+
+## 다음 후보
+
+```text
+TB_W04_02_Combat_Signal_Types_v1.md
+```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
@@ -16,9 +16,10 @@ TB는 코드만 보고는 드러나지 않는 작업 의도, 범위, 완료조�
 | ID | 제목 | 파일 | 상태 |
 | --- | --- | --- | --- |
 | W04-01 | Combat Signal Boundary 재정의 | `TB_W04_01_Combat_Signal_Boundary_Rescope.md` | 완료 |
+| W04-02 | Combat Signal Types v1 | `TB_W04_02_Combat_Signal_Types_v1.md` | 완료 |
 
 ## 다음 후보
 
 ```text
-TB_W04_02_Combat_Signal_Types_v1.md
+TB_W04_03_Combat_Signal_Target_Boundary_v1.md
 ```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
@@ -21,5 +21,5 @@ TB는 코드만 보고는 드러나지 않는 작업 의도, 범위, 완료조�
 ## 다음 후보
 
 ```text
-TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+TB_W04_04_Combat_Signal_Target_Boundary_v1.md
 ```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_01_Combat_Signal_Boundary_Rescope.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_01_Combat_Signal_Boundary_Rescope.md
@@ -1,0 +1,127 @@
+# TB W04-01 Combat Signal Boundary 재정의
+
+## 작업명
+
+```text
+Combat Signal Boundary Re-scope
+```
+
+## 브랜치
+
+```text
+refactor/combat-signal-boundary
+```
+
+## 목표
+
+기존 `GameplayIntentGateway / GameplayCoordinator` 중심 계획을 보류하고, 전투 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의한다.
+
+이번 작업은 코드 구현이 아니라 다음 코드 작업이 흔들리지 않도록 이름, 책임, 흐름, 작업 순서를 확정하는 문서 정리 작업이다.
+
+## 배경
+
+W03 이후 초기 후보는 다음 구조였다.
+
+```text
+Intent
+-> Gateway
+-> Coordinator
+-> Resolution
+-> Domain
+```
+
+하지만 검토 결과 현재 코드에서 가장 직접적인 문제는 공용 intent routing 부재가 아니라 `ApplyDamageComponent`와 `TakeDamageComponent`의 책임 및 이름 혼재였다.
+
+특히 `Request`, `Attack`, `Damage`는 각각 다음 한계를 가진다.
+
+- `Request`: request-response 흐름을 암시한다.
+- `Attack`: source와 target의 전투 공방 전체를 담기에는 좁다.
+- `Damage`: damage commit이 없는 Parry / Blink / Repulse outcome을 담기 어렵다.
+
+따라서 핵심 vocabulary를 `CombatSignal`로 정한다.
+
+## 핵심 범위
+
+- W04 work list 작성
+- N05 Combat Signal Boundary 설계 노트 작성
+- N06 Combat Signal Branch 구현 계획 작성
+- 작업 브리프 작성
+- 작업일지 작성
+- 프롬프트 업데이트 노트 작성
+- 코드 변경 없음
+
+## 제외 범위
+
+- `CCombatSignalStructure` 타입 추가
+- `ApplyDamageComponent` 수정
+- `TakeDamageComponent` 수정
+- component rename
+- Blink / Repulse 구현
+- Intent Gateway / Coordinator 코드 복구
+
+## 결정 사항
+
+확정한 구조:
+
+```text
+UCCombatSignalSourceComponent
+-> FCombatSignal
+-> UCCombatSignalTargetComponent
+-> EvaluateCombatSignal
+-> ApplyCombatSignalOutcome
+-> NotifyCombatSignalResult
+```
+
+보류한 구조:
+
+```text
+GameplayIntentGateway
+GameplayCoordinator
+CombatRequestSource
+CombatReceiver
+CombatConsequenceCoordinator
+```
+
+보류 이유:
+
+- 현재 단계에서 공용 라우팅 계층을 만들면 God Object 위험이 크다.
+- 전투 파이프라인의 핵심 문제는 source-side / target-side boundary 정리다.
+- 더 작은 두 컴포넌트 축으로 시작하는 편이 기존 코드와 맞다.
+
+## 완료조건
+
+- W04 work list가 CombatSignal 기준으로 작성되어 있다.
+- N05 설계 노트가 `CombatSignal Source / Target` 책임을 설명한다.
+- N06 구현 계획이 feature/refactor 브랜치를 분리한다.
+- 다음 작업으로 같은 브랜치의 `Combat Signal Types v1`을 바로 제안할 수 있다.
+- 코드 변경이 없다.
+
+## 검증
+
+문서 추가 작업이므로 빌드는 수행하지 않는다.
+
+검증 기준:
+
+```text
+git status --short
+rg -n "GameplayIntentGateway|GameplayCoordinator" Docs/01_Work_List/W04_Combat_Signal_Boundary Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md
+```
+
+`GameplayIntentGateway / GameplayCoordinator`는 보류 대상으로만 등장해야 한다.
+
+## 프롬프트 업데이트 확인
+
+프롬프트 업데이트 후보 있음.
+
+추가할 내용:
+
+```text
+전투 송수신 구조를 설계할 때 Request / Attack / Damage를 기본 이름으로 두지 말고,
+collision hit와 timing cue, defensive outcome을 함께 담을 수 있는 CombatSignal vocabulary를 우선 검토한다.
+```
+
+기록 위치:
+
+```text
+Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md
+```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_01_Combat_Signal_Boundary_Rescope.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_01_Combat_Signal_Boundary_Rescope.md
@@ -14,7 +14,7 @@ refactor/combat-signal-boundary
 
 ## 목표
 
-기존 `GameplayIntentGateway / GameplayCoordinator` 중심 계획을 보류하고, 전투 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의한다.
+공용 상태 변경 파이프라인 일반화를 보류하고, 전투 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의한다.
 
 이번 작업은 코드 구현이 아니라 다음 코드 작업이 흔들리지 않도록 이름, 책임, 흐름, 작업 순서를 확정하는 문서 정리 작업이다.
 
@@ -30,7 +30,11 @@ Intent
 -> Domain
 ```
 
-하지만 검토 결과 현재 코드에서 가장 직접적인 문제는 공용 intent routing 부재가 아니라 `ApplyDamageComponent`와 `TakeDamageComponent`의 책임 및 이름 혼재였다.
+초기 구조는 객체의 상태를 바꾸는 모든 흐름을 하나의 `Request` 파이프라인으로 통일하려는 접근이었다. 하지만 검토 결과 입력, damage, timing cue, system event는 발생 원인과 해석 기준이 서로 달랐다.
+
+이를 하나의 Gateway / Coordinator가 판정하고 분배하면 해당 객체가 각 domain rule을 과도하게 알게 되어 God Object가 될 위험이 크다. 반대로 모든 축을 세밀하게 분리하면 현재 프로젝트 규모에 비해 adapter와 계층이 과도하게 늘어난다.
+
+따라서 공용 상태 변경 파이프라인을 먼저 만들지 않고, 입력 처리 축 / combat 처리 축 / timing cue 처리 축을 분리해서 바라보기로 했다. 그중 현재 코드에서 가장 직접적인 문제는 `ApplyDamageComponent`와 `TakeDamageComponent`의 책임 및 이름 혼재였다.
 
 특히 `Request`, `Attack`, `Damage`는 각각 다음 한계를 가진다.
 
@@ -84,9 +88,11 @@ CombatConsequenceCoordinator
 
 보류 이유:
 
-- 현재 단계에서 공용 라우팅 계층을 만들면 God Object 위험이 크다.
+- 모든 상태 변경 요청을 하나의 `Request` 파이프라인으로 통일하기에는 입력, damage, timing cue, system event의 성격이 다르다.
+- 공용 Gateway / Coordinator가 이를 모두 판정하고 분배하면 God Object 위험이 크다.
+- 모든 축을 세밀하게 분리하면 현재 규모에 비해 adapter와 계층이 과도하게 늘어난다.
 - 전투 파이프라인의 핵심 문제는 source-side / target-side boundary 정리다.
-- 더 작은 두 컴포넌트 축으로 시작하는 편이 기존 코드와 맞다.
+- 따라서 공용 일반화보다 `CombatSignal Source / Target` 축을 먼저 안정화한다.
 
 ## 완료조건
 

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_02_Combat_Signal_Types_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_02_Combat_Signal_Types_v1.md
@@ -1,0 +1,98 @@
+# TB W04-02 Combat Signal Types v1
+
+## 작업명
+
+```text
+Combat Signal Types v1
+```
+
+## 브랜치
+
+```text
+refactor/combat-signal-boundary
+```
+
+## 목표
+
+`CombatSignalSource`와 `CombatSignalTarget`이 공유할 최소 타입 vocabulary를 추가한다.
+
+이번 작업은 기존 `ApplyDamageComponent`, `TakeDamageComponent`, Action / Reaction / Feedback 흐름에 연결하지 않고, 후속 리팩터링에서 사용할 공용 타입 기반만 만든다.
+
+## 배경
+
+W04-01에서 전투 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의했다.
+
+이제 다음 리팩터링이 같은 단어를 사용하려면 코드에도 최소 타입이 필요하다. 다만 아직 기존 runtime 흐름에 연결하면 회귀 위험 축이 바뀌므로, 이번 작업은 타입 추가로 제한한다.
+
+## 핵심 범위
+
+- `Source/Portfolio/Type/CCombatSignalStructure.h` 추가
+- `Source/Portfolio/Type/CCombatSignalStructure.cpp` 추가
+- `ECombatSignalType` 정의
+- `ECombatSignalOutcome` 정의
+- `ECombatSignalResultType` 정의
+- `FCombatSignalHeader` 정의
+- `FCombatSignal` 정의
+- `FCombatSignalContext` 정의
+- `FCombatSignalEvaluation` 정의
+- `FCombatSignalApplyResult` 정의
+- `FCombatSignalResult` 정의
+- 각 struct에 `IsValidMinimal()` 기준 추가
+
+## 제외 범위
+
+- `UCApplyDamageComponent` include / 호출 연결
+- `UCTakeDamageComponent` include / 호출 연결
+- 기존 `FApplyDamagePayload`, `FTakeDamagePacket`, `FCombatResultPacket` 교체
+- component rename
+- Blink / Repulse 구현
+
+## 결정 사항
+
+새 타입은 기존 `CWeaponStructure.h`에 의존하지 않는다.
+
+이유:
+
+- 이번 단계는 vocabulary 추가가 목적이다.
+- `FApplyDamageSpecKey`, `EReactionType`, `FTakeDamagePacket`에 바로 묶으면 기존 damage pipeline과 결합된다.
+- 후속 branch에서 adapter를 만들 때 기존 타입과 CombatSignal 타입의 매핑을 명시적으로 결정하는 편이 안전하다.
+
+따라서 v1 타입은 actor, tag, amount, vector, result state 중심으로 얇게 둔다.
+
+## 완료조건
+
+- 새 타입 파일이 추가되어 있다.
+- 기존 gameplay 흐름에 연결되지 않는다.
+- 기존 combat/action/reaction 코드 변경이 없다.
+- Unreal build가 성공한다.
+
+## 검증
+
+정적 확인:
+
+```text
+git diff -- Source/Portfolio/Type/CCombatSignalStructure.h Source/Portfolio/Type/CCombatSignalStructure.cpp
+rg -n "CCombatSignalStructure" Source/Portfolio
+```
+
+빌드 확인:
+
+```text
+PortfolioEditor Win64 Development
+```
+
+결과:
+
+```text
+성공
+```
+
+## 프롬프트 업데이트 확인
+
+추가 프롬프트 업데이트 후보 없음.
+
+W04-01의 PU01에 이미 다음 기준을 기록했다.
+
+```text
+collision hit와 timing cue, defensive outcome을 함께 다룰 때는 CombatSignal vocabulary를 우선 검토한다.
+```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_02_Combat_Signal_Types_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_02_Combat_Signal_Types_v1.md
@@ -38,6 +38,7 @@ W04-01에서 전투 송수신 경계를 `CombatSignal Source / Target` 기준으
 - `FCombatSignalApplyResult` 정의
 - `FCombatSignalResult` 정의
 - 각 struct에 `IsValidMinimal()` 기준 추가
+- `AActor` 포인터 사용을 위한 전방 선언 추가
 
 ## 제외 범위
 
@@ -64,6 +65,7 @@ W04-01에서 전투 송수신 경계를 `CombatSignal Source / Target` 기준으
 - 새 타입 파일이 추가되어 있다.
 - 기존 gameplay 흐름에 연결되지 않는다.
 - 기존 combat/action/reaction 코드 변경이 없다.
+- `AActor` 포인터 선언이 header self-contained 기준을 해치지 않는다.
 - Unreal build가 성공한다.
 
 ## 검증

--- a/Docs/06_notes/work_journal/J01_Combat_Signal_Boundary_Work_Journal.md
+++ b/Docs/06_notes/work_journal/J01_Combat_Signal_Boundary_Work_Journal.md
@@ -14,7 +14,9 @@ Intent
 -> Domain
 ```
 
-그러나 설계가 진행될수록 현재 문제를 해결하기 전에 계층이 과하게 늘어나는 느낌이 강해졌다.
+그러나 설계가 진행될수록 입력, damage, timing cue, system event를 모두 하나의 `Request` 파이프라인으로 묶는 것이 현재 문제보다 넓은 일반화라는 점이 드러났다.
+
+각 event source는 발생 원인과 해석 기준이 다르다. 이를 하나의 Gateway / Coordinator가 판정하고 분배하면 해당 객체가 각 domain rule을 과도하게 알게 되고, 반대로 모든 축을 세밀하게 분리하면 현재 규모에 비해 adapter와 계층이 과도하게 늘어난다.
 
 ## 2. Options
 
@@ -90,7 +92,7 @@ FCombatSignalApplyResult
 FCombatSignalResult
 ```
 
-기존 `GameplayIntentGateway / GameplayCoordinator` 구조는 이번 W04 주도 구조에서 제외한다.
+기존 `GameplayIntentGateway / GameplayCoordinator` 구조는 이번 W04 주도 구조에서 제외한다. 이는 일반화 자체를 부정하는 결정이 아니라, 입력 처리 축 / combat 처리 축 / timing cue 처리 축이 안정된 뒤 다시 검토하기 위한 보류다.
 
 ## 5. Reason
 
@@ -98,7 +100,7 @@ FCombatSignalResult
 
 현재 `UCApplyDamageComponent`는 damage applier가 아니라 source-side signal builder / delivery 역할에 가깝고, `UCTakeDamageComponent`는 target-side receive / evaluate / apply / notify 역할을 모두 가진다.
 
-따라서 먼저 두 컴포넌트의 책임을 `CombatSignalSource / Target`으로 재정의하고, 이후 타입 추가와 내부 단계 분리로 들어가는 것이 가장 작고 안전하다.
+따라서 먼저 두 컴포넌트의 책임을 `CombatSignalSource / Target`으로 재정의하고, 이후 타입 추가와 내부 단계 분리로 들어가는 것이 가장 작고 안전하다. 공용 상태 변경 파이프라인은 이 축의 반복 패턴이 안정된 뒤 다시 판단한다.
 
 ## 6. Follow-up
 

--- a/Docs/06_notes/work_journal/J01_Combat_Signal_Boundary_Work_Journal.md
+++ b/Docs/06_notes/work_journal/J01_Combat_Signal_Boundary_Work_Journal.md
@@ -1,0 +1,120 @@
+# J01 Combat Signal Boundary Work Journal
+
+## 1. Context
+
+W03 Guard / Parry v1 이후 다음 브랜치 후보는 `Combat Resolution 분리`, `Combat Consequence Coordinator`, `ApplyDamageComponent 책임 재정리`였다.
+
+초기 논의에서는 공용 intent flow를 만들기 위해 다음 구조가 검토되었다.
+
+```text
+Intent
+-> Gateway
+-> Coordinator
+-> Resolution
+-> Domain
+```
+
+그러나 설계가 진행될수록 현재 문제를 해결하기 전에 계층이 과하게 늘어나는 느낌이 강해졌다.
+
+## 2. Options
+
+### Option A: GameplayIntentGateway / GameplayCoordinator 유지
+
+장점:
+
+- 입력, 이벤트, 결과를 한 공용 흐름으로 묶을 수 있다.
+- 장기적으로 다양한 domain intent를 통제할 수 있다.
+
+단점:
+
+- 현재 전투 파이프라인 문제보다 추상화가 앞선다.
+- Coordinator가 domain rule을 흡수하면 God Object가 되기 쉽다.
+- Submit / Coordinate / Result 용어가 실제 책임과 어긋나기 시작했다.
+
+### Option B: CombatRequest Source / Receiver 구조
+
+장점:
+
+- 기존 ApplyDamage / TakeDamage 구조와 가까워 migration이 쉽다.
+- 송신 / 수신 책임을 나누기 쉽다.
+
+단점:
+
+- `Request`가 request-response 흐름을 암시한다.
+- Hit / Cue / Parry / Blink / Repulse가 모두 요청이라는 이름 아래 들어가면서 의미가 흐려진다.
+
+### Option C: CombatSignal Source / Target 구조
+
+장점:
+
+- collision hit와 timing cue를 함께 담을 수 있다.
+- source는 신호를 만들고 target은 상태 기반 outcome을 판단한다는 흐름이 명확하다.
+- `Attack`보다 넓고 `Damage`보다 앞선 개념이다.
+- 기존 ApplyDamage / TakeDamage의 장기 대체 이름으로 자연스럽다.
+
+단점:
+
+- `Signal`이 다소 추상적이므로 문서에서 의미를 명확히 고정해야 한다.
+- target component가 커질 수 있어 내부 단계 경계를 엄격히 유지해야 한다.
+
+## 3. Discussion
+
+핵심 쟁점은 이름이었다.
+
+`Attack`은 공격 행위 쪽으로 기울어 source와 target의 공방 전체를 담기에는 작았다. `Hit`는 현재 collision damage 흐름에는 직관적이지만, Blink / Repulse 같은 timing cue 기반 defensive outcome까지 담기에는 좁았다. `Damage`는 HP commit 이후의 결과에 가까워 Parry / Guard / Blink / Repulse를 중심 개념으로 다루기 어렵다.
+
+반면 `CombatSignal`은 아직 판정 전인 전투 입력 / 증거 / cue라는 의미를 줄 수 있다.
+
+```text
+CombatSignal
+= target이 아직 해석하지 않은 전투 신호
+```
+
+이 정의라면 collision hit와 non-collision cue를 모두 같은 target receive 흐름으로 다룰 수 있다.
+
+## 4. Decision
+
+W04 기준 구조는 다음으로 확정한다.
+
+```text
+UCCombatSignalSourceComponent
+UCCombatSignalTargetComponent
+```
+
+핵심 데이터 이름은 다음 후보로 둔다.
+
+```text
+FCombatSignal
+FCombatSignalEvaluation
+FCombatSignalApplyResult
+FCombatSignalResult
+```
+
+기존 `GameplayIntentGateway / GameplayCoordinator` 구조는 이번 W04 주도 구조에서 제외한다.
+
+## 5. Reason
+
+이 결정은 현재 코드의 실제 문제와 가장 가깝다.
+
+현재 `UCApplyDamageComponent`는 damage applier가 아니라 source-side signal builder / delivery 역할에 가깝고, `UCTakeDamageComponent`는 target-side receive / evaluate / apply / notify 역할을 모두 가진다.
+
+따라서 먼저 두 컴포넌트의 책임을 `CombatSignalSource / Target`으로 재정의하고, 이후 타입 추가와 내부 단계 분리로 들어가는 것이 가장 작고 안전하다.
+
+## 6. Follow-up
+
+다음 작업은 같은 브랜치에서 진행한다.
+
+```text
+Combat Signal Types v1
+```
+
+작업 목표:
+
+```text
+CombatSignal Source / Target이 공유할 최소 타입 vocabulary를 추가한다.
+```
+
+주의:
+
+- 기존 ApplyDamage / TakeDamage 흐름에 바로 연결하지 않는다.
+- component rename은 책임 정리가 끝난 뒤 별도 브랜치에서 수행한다.

--- a/Docs/06_notes/work_journal/README.md
+++ b/Docs/06_notes/work_journal/README.md
@@ -1,0 +1,21 @@
+# Work Journal Notes
+
+이 폴더는 브랜치 작업 중 구조 결정이 바뀌는 지점과 논의 흐름을 기록한다.
+
+작업일지는 매일 기록하는 로그가 아니라, 하나의 논점에서 출발해 설계 방향이 바뀌거나 책임 경계가 확정되는 단위로 작성한다.
+
+권장 형식:
+
+- Context: 왜 이 논점이 생겼는가
+- Options: 검토한 선택지
+- Discussion: 장단점과 논의 과정
+- Decision: 최종 결정
+- Reason: 그 결정을 선택한 이유
+- Follow-up: 다음 작업에 넘길 내용
+
+## 목록
+
+| ID | 제목 | 파일 | 브랜치 |
+| --- | --- | --- | --- |
+| J01 | Combat Signal Boundary Work Journal | `J01_Combat_Signal_Boundary_Work_Journal.md` | `refactor/combat-signal-boundary` |
+

--- a/Source/Portfolio/Type/CCombatSignalStructure.cpp
+++ b/Source/Portfolio/Type/CCombatSignalStructure.cpp
@@ -1,0 +1,1 @@
+#include "Type/CCombatSignalStructure.h"

--- a/Source/Portfolio/Type/CCombatSignalStructure.h
+++ b/Source/Portfolio/Type/CCombatSignalStructure.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CCombatSignalStructure.generated.h"
 
+class AActor;
+
 UENUM(BlueprintType)
 enum class ECombatSignalType : uint8
 {

--- a/Source/Portfolio/Type/CCombatSignalStructure.h
+++ b/Source/Portfolio/Type/CCombatSignalStructure.h
@@ -1,0 +1,318 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CCombatSignalStructure.generated.h"
+
+UENUM(BlueprintType)
+enum class ECombatSignalType : uint8
+{
+	None = 0,
+
+	HitEvidence,
+	TimingCue,
+	DirectDamage,
+	System,
+
+	Max,
+};
+
+UENUM(BlueprintType)
+enum class ECombatSignalOutcome : uint8
+{
+	None = 0,
+
+	Hit,
+	Blocked,
+	Parried,
+	Blink,
+	Repulse,
+	Staggered,
+	Dead,
+
+	Max,
+};
+
+UENUM(BlueprintType)
+enum class ECombatSignalResultType : uint8
+{
+	None = 0,
+
+	Handled,
+	Ignored,
+	Rejected,
+
+	Max,
+};
+
+USTRUCT(BlueprintType)
+struct FCombatSignalHeader
+{
+	GENERATED_BODY()
+
+public:
+	// Signal category.
+	UPROPERTY(Transient)
+	ECombatSignalType SignalType = ECombatSignalType::None;
+
+	// Signal source.
+	UPROPERTY(Transient)
+	AActor* SourceActor = nullptr;
+
+	// Signal target.
+	UPROPERTY(Transient)
+	AActor* TargetActor = nullptr;
+
+	// Intent owner.
+	UPROPERTY(Transient)
+	AActor* InstigatorActor = nullptr;
+
+	// Intent causer.
+	UPROPERTY(Transient)
+	AActor* SignalCauser = nullptr;
+
+	// Correlation id.
+	UPROPERTY(Transient)
+	FGuid TraceId = FGuid();
+
+	// Source-local order.
+	UPROPERTY(Transient)
+	int32 SequenceId = INDEX_NONE;
+
+	// Debug label.
+	UPROPERTY(Transient)
+	FName DebugTag = NAME_None;
+
+public:
+	FCombatSignalHeader() = default;
+
+public:
+	bool IsValidMinimal() const
+	{
+		return SignalType != ECombatSignalType::None
+			&& SignalType != ECombatSignalType::Max;
+	}
+};
+
+USTRUCT(BlueprintType)
+struct FCombatSignal
+{
+	GENERATED_BODY()
+
+public:
+	// Signal metadata.
+	UPROPERTY(Transient)
+	FCombatSignalHeader Header = FCombatSignalHeader();
+
+	// Signal identity.
+	UPROPERTY(Transient)
+	FName SignalTag = NAME_None;
+
+	// Optional cue identity.
+	UPROPERTY(Transient)
+	FName CueTag = NAME_None;
+
+	// Pre-evaluation damage.
+	UPROPERTY(Transient)
+	float RequestedDamage = 0.0f;
+
+	// Hit or cue point.
+	UPROPERTY(Transient)
+	FVector ImpactLocation = FVector::ZeroVector;
+
+	// Hit normal.
+	UPROPERTY(Transient)
+	FVector ImpactNormal = FVector::ZeroVector;
+
+	// Signal direction.
+	UPROPERTY(Transient)
+	FVector Direction = FVector::ZeroVector;
+
+public:
+	FCombatSignal() = default;
+
+public:
+	bool IsValidMinimal() const
+	{
+		return Header.IsValidMinimal()
+			&& SignalTag != NAME_None;
+	}
+};
+
+USTRUCT(BlueprintType)
+struct FCombatSignalContext
+{
+	GENERATED_BODY()
+
+public:
+	// Incoming signal.
+	UPROPERTY(Transient)
+	FCombatSignal Signal = FCombatSignal();
+
+	// Actual receiver.
+	UPROPERTY(Transient)
+	AActor* ReceiverActor = nullptr;
+
+	// Source validity.
+	UPROPERTY(Transient)
+	bool bSourceActorValid = false;
+
+	// Target validity.
+	UPROPERTY(Transient)
+	bool bTargetActorValid = false;
+
+	// Receiver validity.
+	UPROPERTY(Transient)
+	bool bReceiverActorValid = false;
+
+public:
+	FCombatSignalContext() = default;
+
+public:
+	bool IsValidMinimal() const
+	{
+		return Signal.IsValidMinimal();
+	}
+};
+
+USTRUCT(BlueprintType)
+struct FCombatSignalEvaluation
+{
+	GENERATED_BODY()
+
+public:
+	// Signal metadata.
+	UPROPERTY(Transient)
+	FCombatSignalHeader Header = FCombatSignalHeader();
+
+	// Evaluated outcome.
+	UPROPERTY(Transient)
+	ECombatSignalOutcome Outcome = ECombatSignalOutcome::None;
+
+	// Apply gate.
+	UPROPERTY(Transient)
+	bool bShouldApply = false;
+
+	// Source notify gate.
+	UPROPERTY(Transient)
+	bool bShouldNotifySource = false;
+
+	// Evaluated damage.
+	UPROPERTY(Transient)
+	float FinalDamage = 0.0f;
+
+	// Reaction identity.
+	UPROPERTY(Transient)
+	FName ReactionTag = NAME_None;
+
+	// Feedback identity.
+	UPROPERTY(Transient)
+	FName FeedbackTag = NAME_None;
+
+	// Result identity.
+	UPROPERTY(Transient)
+	FName ResultTag = NAME_None;
+
+public:
+	FCombatSignalEvaluation() = default;
+
+public:
+	bool IsValidMinimal() const
+	{
+		return Header.IsValidMinimal()
+			&& Outcome != ECombatSignalOutcome::None
+			&& Outcome != ECombatSignalOutcome::Max;
+	}
+};
+
+USTRUCT(BlueprintType)
+struct FCombatSignalApplyResult
+{
+	GENERATED_BODY()
+
+public:
+	// Signal metadata.
+	UPROPERTY(Transient)
+	FCombatSignalHeader Header = FCombatSignalHeader();
+
+	// Applied outcome.
+	UPROPERTY(Transient)
+	ECombatSignalOutcome Outcome = ECombatSignalOutcome::None;
+
+	// Apply state.
+	UPROPERTY(Transient)
+	bool bApplied = false;
+
+	// Damage commit state.
+	UPROPERTY(Transient)
+	bool bDamageCommitted = false;
+
+	// Committed damage.
+	UPROPERTY(Transient)
+	float CommittedDamage = 0.0f;
+
+	// Reaction request state.
+	UPROPERTY(Transient)
+	bool bReactionRequested = false;
+
+	// Feedback request state.
+	UPROPERTY(Transient)
+	bool bFeedbackRequested = false;
+
+public:
+	FCombatSignalApplyResult() = default;
+
+public:
+	bool IsValidMinimal() const
+	{
+		return Header.IsValidMinimal()
+			&& Outcome != ECombatSignalOutcome::None
+			&& Outcome != ECombatSignalOutcome::Max;
+	}
+};
+
+USTRUCT(BlueprintType)
+struct FCombatSignalResult
+{
+	GENERATED_BODY()
+
+public:
+	// Signal metadata.
+	UPROPERTY(Transient)
+	FCombatSignalHeader Header = FCombatSignalHeader();
+
+	// Result state.
+	UPROPERTY(Transient)
+	ECombatSignalResultType ResultType = ECombatSignalResultType::None;
+
+	// Result outcome.
+	UPROPERTY(Transient)
+	ECombatSignalOutcome Outcome = ECombatSignalOutcome::None;
+
+	// Handled flag.
+	UPROPERTY(Transient)
+	bool bHandled = false;
+
+	// Success flag.
+	UPROPERTY(Transient)
+	bool bSucceeded = false;
+
+	// Result identity.
+	UPROPERTY(Transient)
+	FName ResultTag = NAME_None;
+
+public:
+	FCombatSignalResult() = default;
+
+public:
+	bool IsValidMinimal() const
+	{
+		return Header.IsValidMinimal()
+			&& ResultType != ECombatSignalResultType::None
+			&& ResultType != ECombatSignalResultType::Max;
+	}
+
+	bool IsHandled() const
+	{
+		return ResultType == ECombatSignalResultType::Handled;
+	}
+};


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P21: Combat Signal Boundary v1 정리**

## 날짜

**2026.06.22**

## 상태

- [x] **완료**

---

## 브랜치

- `refactor/combat-signal-boundary`

---

## 요약

이번 PR에서는 이후 combat 송수신 책임을 정리하기 위한 기준으로 **Combat Signal Boundary v1**을 문서화하고, 다음 리팩터링에서 공유할 최소 타입 vocabulary를 추가했다.

기존 gameplay 흐름은 변경하지 않았다. `ApplyDamageComponent`, `TakeDamageComponent`, Guard / Parry / Hit / Dead 흐름은 그대로 두고, 후속 브랜치에서 Target / Source 책임을 나눌 수 있도록 설계 기준과 타입만 마련했다.

---

## 변경 배경

Guard / Parry v1 이후 damage 처리 흐름에는 hit 전달, 수신 측 방어 판정, damage commit, reaction / feedback, attacker result 전달 책임이 함께 모여 있었다.

초기에는 이를 일반화된 `Intent / Request / Receiver / Resolution / Coordinator` 구조로 분리하는 방향을 검토했다. 하지만 입력, damage, timing cue, system event는 발생 원인과 해석 기준이 달라 하나의 공용 `Request` 파이프라인으로 먼저 묶기에는 범위가 넓었다.

따라서 현재 브랜치에서는 공용 상태 변경 파이프라인 일반화를 보류하고, 후속 리팩터링의 기준으로 사용할 `CombatSignal Source / Target` 경계만 정리했다.

---

## 변경 범위

### 1. Combat Signal 설계 기준 정리

- `N05_Combat_Signal_Boundary_Design_Note.md` 추가 및 정리
- `N06_Combat_Signal_Branch_Implementation_Plan.md` 추가 및 정리
- branch 분할 기준을 feature 단위가 아니라 behavior / risk 축 기준으로 정리

### 2. 기존 Request Routing 설계 문서 archive

- 기존 Request / Receiver / Resolution / Coordinator 중심 문서를 archive로 이동
- active note와 충돌하지 않도록 관련 참조 갱신

```text
Docs/06_notes/archive/NA01_Combat_Intent_Request_Resolution_Routing_Design_Note.md
```

### 3. Combat Signal 타입 vocabulary 추가

새 타입 파일을 추가했다.

```text
Source/Portfolio/Type/CCombatSignalStructure.h
Source/Portfolio/Type/CCombatSignalStructure.cpp
```

추가된 주요 타입:

```text
ECombatSignalType
ECombatSignalOutcome
ECombatSignalResultType
FCombatSignalHeader
FCombatSignal
FCombatSignalContext
FCombatSignalEvaluation
FCombatSignalApplyResult
FCombatSignalResult
```

각 struct에는 최소 유효성 검사용 `IsValidMinimal()`을 두었다. 이번 단계에서는 actor 유효성이나 domain별 rule을 강제하지 않고, signal/result 타입의 기본 상태만 확인한다.

### 4. 작업 기록 체계 정리

- W04 작업 리스트 갱신
- task brief 추가
- work journal 정리
- prompt update note 정리

---

## 구현 범위

이번 PR에서 실제 runtime 연결은 하지 않았다.

- `ApplyDamageComponent` 변경 없음
- `TakeDamageComponent` 변경 없음
- Guard / Parry / Hit / Dead 동작 변경 없음
- CombatSignal 타입은 아직 기존 damage packet 흐름에 연결하지 않음

이번 PR의 구현 범위는 다음으로 제한했다.

- Combat Signal 타입 파일 추가
- 타입별 최소 유효성 검사 추가
- 관련 문서와 작업 기록 갱신

---

## 검증

### 빌드

```text
PortfolioEditor Win64 Development
```

- UnrealHeaderTool 통과
- `CCombatSignalStructure.cpp` 컴파일 통과
- Editor target 빌드 성공

### 정적 확인

- 기존 gameplay component 변경 없음
- 기존 damage / guard / parry runtime 연결 없음
- 신규 타입 파일은 `CoreMinimal.h`와 generated header만 포함

---

## 제외 범위

이번 PR에서는 다음 작업을 의도적으로 제외했다.

- `TakeDamageComponent`의 Target 내부 경계 정리
- `ApplyDamageComponent`의 Source 내부 경계 정리
- 컴포넌트 rename
- CombatSignal 타입을 기존 damage 흐름에 연결
- Blink / Repulse cue 구현
- 별도 Coordinator / Gateway 계층 구현

---

## 후속 작업

권장 후속 브랜치는 다음과 같다.

```text
refactor/combat-signal-target-v1
```

후속 작업 목표:

- `TakeDamageComponent` 내부를 Target 관점으로 정리
- Receive / Evaluate / Apply / Notify 단계 명시
- 기존 Guard / Parry / Hit / Dead 동작 유지
- CombatSignal 타입 연결 여부는 필요한 지점에서만 검토

그 다음 후보:

```text
refactor/combat-signal-source-v1
refactor/combat-signal-component-rename
feature/combat-signal-cue-v1
```

---

## 관련 문서

- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`
- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_01_Combat_Signal_Boundary_Rescope.md`
- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_02_Combat_Signal_Types_v1.md`
- `Docs/06_notes/work_journal/J01_Combat_Signal_Boundary_Work_Journal.md`
- `Docs/06_notes/prompt_updates/PU01_Combat_Signal_Boundary_Prompt_Update_Note.md`
