### PR TITLE
P22: Combat Signal Target Boundary v1 정리

### DIFF
--- a/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
@@ -469,7 +469,7 @@ PortfolioEditor Win64 Development
 
 ## 7. 후속 작업
 
-### 7.1 W04-04 Combat Signal Target Boundary v1
+### 7.1 W04-03 Combat Signal Target Boundary v1
 
 **브랜치**
 
@@ -496,7 +496,7 @@ UCTakeDamageComponent 내부 흐름을 CombatSignalTarget 책임 기준으로 �
 - target-side 책임 단계가 코드에서 명확히 보임
 - Unreal build 성공
 
-### 7.2 W04-05 Combat Signal Source Boundary v1
+### 7.2 W04-04 Combat Signal Source Boundary v1
 
 **브랜치**
 
@@ -524,7 +524,7 @@ UCApplyDamageComponent 내부 흐름을 CombatSignalSource 책임 기준으로 �
 - source-side 책임 단계가 코드에서 명확히 보임
 - Unreal build 성공
 
-### 7.3 W04-06 Combat Signal Component Rename
+### 7.3 W04-05 Combat Signal Component Rename
 
 **브랜치**
 
@@ -551,7 +551,7 @@ refactor/combat-signal-component-rename
 - 기존 전투 회귀 통과
 - Unreal build 성공
 
-### 7.4 W04-07 Combat Signal Cue v1
+### 7.4 W04-06 Combat Signal Cue v1
 
 **브랜치**
 

--- a/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
@@ -471,6 +471,12 @@ PortfolioEditor Win64 Development
 
 ### 7.1 W04-03 Combat Signal Target Boundary v1
 
+**상태**
+
+```text
+완료
+```
+
 **브랜치**
 
 ```text
@@ -485,18 +491,29 @@ UCTakeDamageComponent 내부 흐름을 CombatSignalTarget 책임 기준으로 �
 
 **핵심 범위**
 
-- Receive / Evaluate / Apply / Notify 단계 메서드 분리
+- `UCTakeDamageComponent` private API를 Entry / Receive / Evaluate / Apply / Notify / Packet / Debug 기준으로 재배치
+- `CTakeDamageComponent.cpp` 정의 순서를 header 선언 순서와 일치
+- `HandleDefaultDamageEvent` 내부 흐름을 Receive / Evaluate / Apply / Packet / Notify 라벨로 정리
+- `FTakeDamageResult`와 `FCombatSignalResult` 관계를 내부 authoritative result / 외부 summary result 후보로 정리
 - 기존 `RequestTakeDamage` 흐름 유지
 - UE `TakeDamage()` adapter 유지
+- `FCombatSignal` 직접 연결 없음
 - 클래스명 rename은 아직 하지 않음
 
 **완료조건**
 
 - 기존 Guard / Parry / Hit / Dead 동작 유지
 - target-side 책임 단계가 코드에서 명확히 보임
+- `FTakeDamageResult` / `FCombatSignalResult` 관계가 현재 브랜치 범위 안에서 정리됨
 - Unreal build 성공
 
 ### 7.2 W04-04 Combat Signal Source Boundary v1
+
+**상태**
+
+```text
+다음 작업
+```
 
 **브랜치**
 
@@ -526,6 +543,12 @@ UCApplyDamageComponent 내부 흐름을 CombatSignalSource 책임 기준으로 �
 
 ### 7.3 W04-05 Combat Signal Component Rename
 
+**상태**
+
+```text
+예정
+```
+
 **브랜치**
 
 ```text
@@ -552,6 +575,12 @@ refactor/combat-signal-component-rename
 - Unreal build 성공
 
 ### 7.4 W04-06 Combat Signal Cue v1
+
+**상태**
+
+```text
+예정
+```
 
 **브랜치**
 

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -27,5 +27,6 @@
 | P19 | Documentation Workflow Update | `P19_UE5_Portfolio_Pull_Request.md` | `docs/portfolio-documentation-update` |  | W02, N01 |
 | P20 | Guard / Parry Action v1 | `P20_UE5_Portfolio_Pull_Request.md` | `feature/combat-guard-parry` |  | W03, B11, B12, N02, N03, N04, N05 |
 | P21 | Combat Signal Boundary v1 | `P21_UE5_Portfolio_Pull_Request.md` | `refactor/combat-signal-boundary` |  | W04, N05, N06, NA01 |
+| P22 | Combat Signal Target Boundary v1 | `P22_UE5_Portfolio_Pull_Request.md` | `refactor/combat-signal-target-v1` |  | W04, TB_W04_03 |
 
 ---

--- a/Docs/04_Pull_Request/P22_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P22_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,162 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P22: Combat Signal Target Boundary v1 정리**
+
+## 날짜
+
+**2026.06.23**
+
+## 상태
+
+- [x] **완료**
+
+---
+
+## 브랜치
+
+- `refactor/combat-signal-target-v1`
+
+---
+
+## 요약
+
+이번 PR에서는 `UCTakeDamageComponent`를 rename하거나 `FCombatSignal`에 연결하지 않고, 현재 damage 수신 흐름을 target-side 처리 단계 기준으로 정리했다.
+
+핵심은 기존 Guard / Parry / Hit / Dead 동작을 유지하면서 header와 source의 API 순서를 같은 단계 기준으로 맞추고, `HandleDefaultDamageEvent()` 실행 흐름이 `Receive / Evaluate / Apply / Packet / Notify` 순서로 읽히게 만드는 것이다.
+
+---
+
+## 변경 배경
+
+P21에서 combat 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의하고 최소 타입 vocabulary를 추가했다.
+
+다음 단계에서 바로 component rename이나 packet 교체를 진행하면 기존 damage flow와 Guard / Parry 회귀 위험이 커질 수 있다. 따라서 이번 PR에서는 `TakeDamageComponent` 내부 책임을 먼저 target-side 단계로 정렬하고, 실제 `CombatSignalTarget` 전환은 후속 브랜치로 남겼다.
+
+---
+
+## 변경 범위
+
+### 1. TakeDamage target-side 단계 정리
+
+`UCTakeDamageComponent` private API를 다음 단계 기준으로 재배치했다.
+
+```text
+Entry
+-> Receive
+-> Evaluate
+-> Apply
+-> Notify
+-> Packet
+-> Debug
+```
+
+### 2. Header / Source 정의 순서 정렬
+
+`CTakeDamageComponent.h`의 선언 순서와 `CTakeDamageComponent.cpp`의 정의 순서를 맞췄다.
+
+이를 통해 `RequestTakeDamage()` 진입 이후 수신, 평가, 적용, 통지, packet 생성, debug 출력 흐름을 같은 순서로 따라갈 수 있게 했다.
+
+### 3. HandleDefaultDamageEvent 흐름 라벨 정리
+
+`HandleDefaultDamageEvent()` 내부에 다음 단계 라벨을 추가했다.
+
+```text
+Receive
+Evaluate
+Apply
+Packet
+Notify
+```
+
+라벨은 흐름 가독성을 위한 주석이며, 기존 실행 순서와 조건 분기는 변경하지 않았다.
+
+### 4. Result boundary 정리
+
+`FTakeDamageResult`와 `FCombatSignalResult`의 관계를 task brief에 정리했다.
+
+```text
+FTakeDamageResult
+= TakeDamage flow 내부 authoritative result
+
+FCombatSignalResult
+= 외부 송출용 summary result 후보
+```
+
+이번 PR에서는 변환 함수를 선언하거나 구현하지 않는다.
+
+---
+
+## 구현 범위
+
+이번 PR의 코드 변경은 `UCTakeDamageComponent` 내부 정렬로 제한했다.
+
+- 기존 public API 유지
+- 기존 UE `TakeDamage()` adapter 유지
+- 기존 `FTakeDamagePayload`, `FTakeDamageContext`, `FTakeDamageResult`, `FTakeDamagePacket` 유지
+- 기존 `FCombatResultPacket` 유지
+- `FCombatSignal` 직접 연결 없음
+
+---
+
+## 검증
+
+### 빌드
+
+```text
+PortfolioEditor Win64 Development
+```
+
+결과:
+
+```text
+성공
+Target is up to date
+```
+
+### 정적 확인
+
+- `CTakeDamageComponent.h` private method group 확인
+- `CTakeDamageComponent.cpp` 정의 순서 확인
+- `HandleDefaultDamageEvent()` 단계 라벨 확인
+- `git diff --check` 통과
+
+---
+
+## 제외 범위
+
+이번 PR에서는 다음 작업을 의도적으로 제외했다.
+
+- `UCTakeDamageComponent` rename
+- `UCCombatSignalTargetComponent` 신설
+- `FCombatSignal`을 기존 damage flow에 연결
+- `FCombatSignalResult` 변환 함수 구현
+- `UCApplyDamageComponent` source-side 정리
+- Blink / Repulse / GuardBreak cue flow 정리
+
+---
+
+## 후속 작업
+
+권장 후속 브랜치는 다음과 같다.
+
+```text
+refactor/combat-signal-source-v1
+```
+
+후속 작업 목표:
+
+- `UCApplyDamageComponent` 내부를 Source 관점으로 정리
+- hit window / duplicate target / damage spec / target delivery 경계를 명확히 정리
+- 기존 weapon overlap damage 동작 유지
+- component rename은 source / target 양쪽 책임 정리 후 별도 브랜치에서 진행
+
+---
+
+## 관련 문서
+
+- `Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md`
+- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
+- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`
+- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md`

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
@@ -17,7 +17,7 @@ TB는 코드만 보고는 드러나지 않는 작업 의도, 범위, 완료조�
 | --- | --- | --- | --- |
 | W04-01 | Combat Signal Boundary 재정의 | `TB_W04_01_Combat_Signal_Boundary_Rescope.md` | 완료 |
 | W04-02 | Combat Signal Types v1 | `TB_W04_02_Combat_Signal_Types_v1.md` | 완료 |
-| W04-03 | Combat Signal Target Boundary v1 | `TB_W04_03_Combat_Signal_Target_Boundary_v1.md` | 진행 중 |
+| W04-03 | Combat Signal Target Boundary v1 | `TB_W04_03_Combat_Signal_Target_Boundary_v1.md` | 완료 |
 
 ## 다음 후보
 

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
@@ -17,9 +17,10 @@ TB는 코드만 보고는 드러나지 않는 작업 의도, 범위, 완료조�
 | --- | --- | --- | --- |
 | W04-01 | Combat Signal Boundary 재정의 | `TB_W04_01_Combat_Signal_Boundary_Rescope.md` | 완료 |
 | W04-02 | Combat Signal Types v1 | `TB_W04_02_Combat_Signal_Types_v1.md` | 완료 |
+| W04-03 | Combat Signal Target Boundary v1 | `TB_W04_03_Combat_Signal_Target_Boundary_v1.md` | 진행 중 |
 
 ## 다음 후보
 
 ```text
-TB_W04_04_Combat_Signal_Target_Boundary_v1.md
+TB_W04_04_Combat_Signal_Source_Boundary_v1.md
 ```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
@@ -81,6 +81,124 @@ Receive
 
 따라서 v1에서는 기존 타입을 유지한 채 함수 그룹과 호출 흐름만 `Receive / Evaluate / Apply / Notify` 기준으로 정리한다.
 
+## 결과 타입 관계
+
+`FTakeDamageResult`는 현재 damage flow 내부의 target-side authoritative result다.
+
+주요 책임:
+
+```text
+damage 수신 허용 여부
+reject reason
+defense outcome
+damage commit 여부
+request / mitigated / final / committed damage
+dead state 전후 snapshot
+```
+
+`FCombatSignalResult`는 장기적으로 combat signal 처리 결과를 외부에 요약해서 전달하기 위한 summary result다.
+
+주요 책임:
+
+```text
+signal metadata
+handled / rejected / ignored 같은 처리 상태
+combat outcome 요약
+handled / succeeded flag
+result tag
+```
+
+따라서 두 타입의 관계는 1:1 교체가 아니라 내부 결과와 외부 송출 요약의 관계로 본다.
+
+```text
+FTakeDamageResult
+= damage target 내부 판정과 적용 결과
+
+FCombatSignalResult
+= combat signal 처리 결과를 외부 경계에서 읽기 위한 요약 결과
+```
+
+현재 damage flow에서는 `FTakeDamageResult`를 기반으로 `FCombatSignalResult`를 생성하는 방향을 기본 후보로 둔다.
+
+다만 모든 combat signal이 `TakeDamage` flow를 타는 것은 아니다. Parry, GuardBreak, Blink, Repulse 같은 흐름이 별도 내부 결과를 갖게 되면, 각 flow의 내부 결과를 기반으로 동일한 외부 송출용 `FCombatSignalResult`를 만들 수 있다.
+
+```text
+Damage flow
+-> FTakeDamageResult
+-> FCombatSignalResult
+
+Parry flow
+-> FParryResult 후보
+-> FCombatSignalResult
+
+GuardBreak flow
+-> FGuardBreakResult 후보
+-> FCombatSignalResult
+```
+
+핵심 원칙:
+
+```text
+내부 판정은 flow별 result가 authoritative source다.
+외부 송출은 CombatSignalResult로 요약한다.
+CombatSignalResult는 판정을 다시 수행하지 않는다.
+```
+
+후보 매핑:
+
+```text
+FTakeDamageResult.bAccepted
+-> FCombatSignalResult.ResultType
+
+FTakeDamageResult.DefenseOutcome
+-> FCombatSignalResult.Outcome
+
+FTakeDamageResult.RejectReason
+-> FCombatSignalResult.ResultTag 또는 domain-specific detail
+
+FTakeDamageResult.bShouldCommitDamage / CommittedDamage
+-> FCombatSignalResult.bSucceeded 판단 재료
+```
+
+변환 함수 후보 위치:
+
+```text
+BuildResult
+= TakeDamage flow 내부 authoritative result 생성
+
+BuildPacket
+= payload / context / result 묶음 생성
+
+BuildCombatSignalResult 후보
+= 외부 송출용 summary result 생성
+```
+
+따라서 변환 후보는 `BuildResult()` 내부가 아니라, `FTakeDamagePacket`이 구성된 뒤 `Notify` 경계에서 두는 편이 자연스럽다.
+
+이유:
+
+- `BuildResult()`는 damage target 내부 결과만 만들어야 한다.
+- 외부 송출 summary는 actor lineage, signal metadata, result tag 같은 context 정보가 함께 필요하다.
+- `FTakeDamagePacket` 이후에는 payload / context / result를 모두 참조할 수 있다.
+- 기존 `BuildCombatResultPacket()`도 이 위치에서 source-side result packet을 구성한다.
+
+후속 함수 후보:
+
+```text
+BuildCombatSignalResult(const FTakeDamagePacket& InTakeDamagePacket)
+```
+
+단, 이번 branch에서는 선언하거나 구현하지 않는다.
+
+이번 branch에서는 이 변환을 구현하지 않는다.
+
+이유:
+
+- 현재 목표는 `UCTakeDamageComponent` 내부 target-side 경계를 정리하는 것이다.
+- `FCombatSignalResult`를 바로 연결하면 기존 damage flow가 아직 확정되지 않은 상위 signal 타입에 의존한다.
+- 실제 변환 위치는 `CombatSignalTarget` rename 또는 adapter 도입 시점에 결정하는 편이 안전하다.
+- 이번 branch에서는 결과 관계를 먼저 고정하고, 변환 함수 도입은 후속 작업으로 분리한다.
+
 ## 단계 분류 기준
 
 이번 작업의 기준은 `UCTakeDamageComponent`가 target 입장에서 damage signal을 처리할 때의 시간 순서와 책임 변화다.
@@ -175,6 +293,8 @@ PrintDamageAmountInfo
 TakeDamage Header Target Sections v1 완료
 TakeDamage Default Event Flow Labels v1 완료
 TakeDamage Source Definition Order Alignment 완료
+TakeDamage Result Boundary Documentation 완료
+TakeDamage Result Conversion Point Documentation 완료
 ```
 
 확인 내용:
@@ -186,6 +306,8 @@ TakeDamage Source Definition Order Alignment 완료
 - `CTakeDamageComponent.cpp` 정의 순서를 `CTakeDamageComponent.h` 선언 순서와 일치시켰다.
 - 함수 구현 로직은 변경하지 않았다.
 - `FCombatSignal`은 기존 damage flow에 연결하지 않았다.
+- `FTakeDamageResult`와 `FCombatSignalResult`를 교체 관계가 아닌 변환/요약 후보 관계로 정리했다.
+- `FCombatSignalResult` 변환 후보 위치를 `FTakeDamagePacket` 구성 이후의 Notify 경계로 정리했다.
 
 정적 확인:
 
@@ -205,10 +327,6 @@ PortfolioEditor Win64 Development
 ```text
 성공
 ```
-
-남은 작업:
-
-- `FTakeDamageResult`와 `FCombatSignalResult` 후보 관계를 문서화한다.
 
 ## 프롬프트 업데이트 확인
 

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
@@ -83,32 +83,11 @@ Receive
 
 ## 결과 타입 관계
 
-`FTakeDamageResult`는 현재 damage flow 내부의 target-side authoritative result다.
+`FTakeDamageResult`는 현재 damage flow 내부의 target-side authoritative result다. damage 수신 허용 여부, reject reason, defense outcome, damage commit 여부, damage amount, dead state snapshot을 가진다.
 
-주요 책임:
+`FCombatSignalResult`는 장기적으로 combat signal 처리 결과를 외부에 요약해서 전달하기 위한 summary result 후보다.
 
-```text
-damage 수신 허용 여부
-reject reason
-defense outcome
-damage commit 여부
-request / mitigated / final / committed damage
-dead state 전후 snapshot
-```
-
-`FCombatSignalResult`는 장기적으로 combat signal 처리 결과를 외부에 요약해서 전달하기 위한 summary result다.
-
-주요 책임:
-
-```text
-signal metadata
-handled / rejected / ignored 같은 처리 상태
-combat outcome 요약
-handled / succeeded flag
-result tag
-```
-
-따라서 두 타입의 관계는 1:1 교체가 아니라 내부 결과와 외부 송출 요약의 관계로 본다.
+따라서 두 타입은 1:1 교체 관계가 아니라 내부 결과와 외부 송출 요약의 관계로 본다.
 
 ```text
 FTakeDamageResult
@@ -118,86 +97,21 @@ FCombatSignalResult
 = combat signal 처리 결과를 외부 경계에서 읽기 위한 요약 결과
 ```
 
-현재 damage flow에서는 `FTakeDamageResult`를 기반으로 `FCombatSignalResult`를 생성하는 방향을 기본 후보로 둔다.
-
-다만 모든 combat signal이 `TakeDamage` flow를 타는 것은 아니다. Parry, GuardBreak, Blink, Repulse 같은 흐름이 별도 내부 결과를 갖게 되면, 각 flow의 내부 결과를 기반으로 동일한 외부 송출용 `FCombatSignalResult`를 만들 수 있다.
-
-```text
-Damage flow
--> FTakeDamageResult
--> FCombatSignalResult
-
-Parry flow
--> FParryResult 후보
--> FCombatSignalResult
-
-GuardBreak flow
--> FGuardBreakResult 후보
--> FCombatSignalResult
-```
-
 핵심 원칙:
 
 ```text
-내부 판정은 flow별 result가 authoritative source다.
+내부 판정은 flow별 result가 authoritative result다.
 외부 송출은 CombatSignalResult로 요약한다.
 CombatSignalResult는 판정을 다시 수행하지 않는다.
 ```
 
-후보 매핑:
-
-```text
-FTakeDamageResult.bAccepted
--> FCombatSignalResult.ResultType
-
-FTakeDamageResult.DefenseOutcome
--> FCombatSignalResult.Outcome
-
-FTakeDamageResult.RejectReason
--> FCombatSignalResult.ResultTag 또는 domain-specific detail
-
-FTakeDamageResult.bShouldCommitDamage / CommittedDamage
--> FCombatSignalResult.bSucceeded 판단 재료
-```
-
-변환 함수 후보 위치:
-
-```text
-BuildResult
-= TakeDamage flow 내부 authoritative result 생성
-
-BuildPacket
-= payload / context / result 묶음 생성
-
-BuildCombatSignalResult 후보
-= 외부 송출용 summary result 생성
-```
-
-따라서 변환 후보는 `BuildResult()` 내부가 아니라, `FTakeDamagePacket`이 구성된 뒤 `Notify` 경계에서 두는 편이 자연스럽다.
-
-이유:
-
-- `BuildResult()`는 damage target 내부 결과만 만들어야 한다.
-- 외부 송출 summary는 actor lineage, signal metadata, result tag 같은 context 정보가 함께 필요하다.
-- `FTakeDamagePacket` 이후에는 payload / context / result를 모두 참조할 수 있다.
-- 기존 `BuildCombatResultPacket()`도 이 위치에서 source-side result packet을 구성한다.
-
-후속 함수 후보:
-
-```text
-BuildCombatSignalResult(const FTakeDamagePacket& InTakeDamagePacket)
-```
-
-단, 이번 branch에서는 선언하거나 구현하지 않는다.
-
-이번 branch에서는 이 변환을 구현하지 않는다.
+현재 damage flow에서 `FCombatSignalResult`가 필요해지면 `FTakeDamageResult`를 기반으로 생성하는 방향이 기본 후보다. 다만 이번 branch에서는 변환 함수를 선언하거나 구현하지 않는다.
 
 이유:
 
 - 현재 목표는 `UCTakeDamageComponent` 내부 target-side 경계를 정리하는 것이다.
-- `FCombatSignalResult`를 바로 연결하면 기존 damage flow가 아직 확정되지 않은 상위 signal 타입에 의존한다.
-- 실제 변환 위치는 `CombatSignalTarget` rename 또는 adapter 도입 시점에 결정하는 편이 안전하다.
-- 이번 branch에서는 결과 관계를 먼저 고정하고, 변환 함수 도입은 후속 작업으로 분리한다.
+- `FCombatSignalResult` 연결은 현재 브랜치의 정리 범위를 넘는다.
+- 실제 변환 위치는 `CombatSignalTarget` rename 또는 adapter 도입 시점에 결정한다.
 
 ## 단계 분류 기준
 
@@ -294,7 +208,6 @@ TakeDamage Header Target Sections v1 완료
 TakeDamage Default Event Flow Labels v1 완료
 TakeDamage Source Definition Order Alignment 완료
 TakeDamage Result Boundary Documentation 완료
-TakeDamage Result Conversion Point Documentation 완료
 ```
 
 확인 내용:
@@ -307,13 +220,12 @@ TakeDamage Result Conversion Point Documentation 완료
 - 함수 구현 로직은 변경하지 않았다.
 - `FCombatSignal`은 기존 damage flow에 연결하지 않았다.
 - `FTakeDamageResult`와 `FCombatSignalResult`를 교체 관계가 아닌 변환/요약 후보 관계로 정리했다.
-- `FCombatSignalResult` 변환 후보 위치를 `FTakeDamagePacket` 구성 이후의 Notify 경계로 정리했다.
 
 정적 확인:
 
 ```text
 git diff -- Source/Portfolio/Component/CTakeDamageComponent.h Source/Portfolio/Component/CTakeDamageComponent.cpp
-rg -n "Receive|Evaluate|Apply|Notify|FCombatSignalResult|FTakeDamageResult" Source/Portfolio/Component/CTakeDamageComponent.* Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+rg -n "Receive|Evaluate|Apply|Notify|FCombatSignalResult|FTakeDamageResult" Source/Portfolio/Component/CTakeDamageComponent.h Source/Portfolio/Component/CTakeDamageComponent.cpp Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
 ```
 
 빌드 확인:

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
@@ -173,13 +173,18 @@ PrintDamageAmountInfo
 
 ```text
 TakeDamage Header Target Sections v1 완료
+TakeDamage Default Event Flow Labels v1 완료
+TakeDamage Source Definition Order Alignment 완료
 ```
 
 확인 내용:
 
 - `CTakeDamageComponent.h` private method group을 `Receive / Evaluate / Apply / Notify / Packet / Debug` 기준으로 재배치했다.
 - 기존 public API와 함수명은 유지했다.
-- 함수 구현은 변경하지 않았다.
+- `HandleDefaultDamageEvent` 내부 흐름을 `Receive / Evaluate / Apply / Packet / Notify` 라벨로 정리했다.
+- rejected / accepted packet 생성과 dispatch 위치의 의미를 명시했다.
+- `CTakeDamageComponent.cpp` 정의 순서를 `CTakeDamageComponent.h` 선언 순서와 일치시켰다.
+- 함수 구현 로직은 변경하지 않았다.
 - `FCombatSignal`은 기존 damage flow에 연결하지 않았다.
 
 정적 확인:
@@ -203,7 +208,6 @@ PortfolioEditor Win64 Development
 
 남은 작업:
 
-- `HandleDefaultDamageEvent` 내부 단계 주석과 호출 흐름을 `Receive / Evaluate / Apply / Notify` 기준으로 정리한다.
 - `FTakeDamageResult`와 `FCombatSignalResult` 후보 관계를 문서화한다.
 
 ## 프롬프트 업데이트 확인

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
@@ -79,7 +79,7 @@ Receive
 - packet 교체까지 동시에 진행하면 회귀 위험 축이 커진다.
 - `FTakeDamageResult`와 `FCombatSignalResult`의 대응 관계는 먼저 문서화하고, 실제 교체 여부는 후속 branch에서 판단하는 편이 안전하다.
 
-따라서 v1에서는 기존 타입을 유지한 채 함수 그룹과 호출 흐름만 `Receive / Evaluate / Apply / Notify` 기준으로 정리한다.
+따라서 v1에서는 기존 타입을 유지한 채 함수 그룹과 내부 책임 흐름을 `Receive / Evaluate / Apply / Notify` 기준으로 정리한다.
 
 ## 결과 타입 관계
 
@@ -195,7 +195,7 @@ PrintDamageAmountInfo
 - 기존 `ApplyDamageComponent` / weapon overlap flow와 연결 방식이 유지되어 있다.
 - 기존 Guard / Parry / Hit / Dead 동작 의도가 바뀌지 않는다.
 - `CTakeDamageComponent.h`에서 target-side 단계가 명확히 보인다.
-- `HandleDefaultDamageEvent` 흐름이 Receive / Evaluate / Apply / Notify 기준으로 읽힌다.
+- `HandleDefaultDamageEvent` 흐름이 Receive / Evaluate / Apply / Packet / Notify 기준으로 읽힌다.
 - `FTakeDamageResult`와 `FCombatSignalResult` 후보 관계가 문서화되어 있다.
 - Unreal build가 성공한다.
 

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
@@ -1,0 +1,118 @@
+# TB W04-03 Combat Signal Target Boundary v1
+
+## 작업명
+
+```text
+Combat Signal Target Boundary v1
+```
+
+## 브랜치
+
+```text
+refactor/combat-signal-target-v1
+```
+
+## 목표
+
+`UCTakeDamageComponent` 내부 흐름을 `CombatSignalTarget` 책임 기준으로 정리한다.
+
+이번 작업은 component rename이나 `FCombatSignal` 연결이 아니라, 기존 damage 수신 흐름을 유지하면서 target-side 처리 단계를 코드에서 명확히 보이게 만드는 준비 리팩터링이다.
+
+## 배경
+
+W04-01 / W04-02에서 combat 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의하고, 최소 타입 vocabulary를 추가했다.
+
+다음 단계는 실제 runtime에 바로 `FCombatSignal`을 연결하는 것이 아니라, 현재 `UCTakeDamageComponent` 안에 모여 있는 수신, 평가, 적용, 후속 통지 책임을 단계별로 읽히게 정리하는 것이다.
+
+현재 `UCTakeDamageComponent`는 다음 책임을 함께 가진다.
+
+```text
+UE damage event 수신
+payload / context 구성
+context validation
+defensive outcome 평가
+damage 계산
+Health commit
+defender reaction / feedback 요청
+attacker result packet 전달
+debug 출력
+```
+
+이번 작업에서는 이 흐름을 다음 단계로 정리한다.
+
+```text
+Receive
+-> Evaluate
+-> Apply
+-> Notify
+```
+
+## 핵심 범위
+
+- 기존 public API 유지
+  - `RequestTakeDamage`
+  - `ProcessTakeDamage`
+- UE `AActor::TakeDamage()` adapter 흐름 유지
+- `HandleDefaultDamageEvent` 내부 단계 주석과 호출 흐름 정리
+- `CTakeDamageComponent.h` private method group을 target-side 단계 기준으로 재배치
+- 기존 `FTakeDamagePayload`, `FTakeDamageContext`, `FTakeDamageResult`, `FTakeDamagePacket` 유지
+- `FTakeDamageResult`와 `FCombatSignalResult`의 관계 후보 문서화
+- 기존 Guard / Parry / Hit / Dead 동작 유지
+
+## 제외 범위
+
+- `UCTakeDamageComponent` rename
+- `UCCombatSignalTargetComponent` 신설
+- `FCombatSignal`을 기존 damage flow에 직접 연결
+- `UCApplyDamageComponent` 수정
+- `CombatSignalSource` 구현
+- Blink / Repulse timing cue 구현
+- 기존 `FCombatResultPacket` 교체
+
+## 결정 사항
+
+이번 작업에서는 `FCombatSignal` 타입을 기존 damage flow에 강제로 연결하지 않는다.
+
+이유:
+
+- 현재 목표는 target-side 단계 경계를 명확히 하는 것이다.
+- packet 교체까지 동시에 진행하면 회귀 위험 축이 커진다.
+- `FTakeDamageResult`와 `FCombatSignalResult`의 대응 관계는 먼저 문서화하고, 실제 교체 여부는 후속 branch에서 판단하는 편이 안전하다.
+
+따라서 v1에서는 기존 타입을 유지한 채 함수 그룹과 호출 흐름만 `Receive / Evaluate / Apply / Notify` 기준으로 정리한다.
+
+## 완료조건
+
+- `UCTakeDamageComponent` public API가 유지되어 있다.
+- 기존 `ApplyDamageComponent` / weapon overlap flow와 연결 방식이 유지되어 있다.
+- 기존 Guard / Parry / Hit / Dead 동작 의도가 바뀌지 않는다.
+- `CTakeDamageComponent.h`에서 target-side 단계가 명확히 보인다.
+- `HandleDefaultDamageEvent` 흐름이 Receive / Evaluate / Apply / Notify 기준으로 읽힌다.
+- `FTakeDamageResult`와 `FCombatSignalResult` 후보 관계가 문서화되어 있다.
+- Unreal build가 성공한다.
+
+## 검증
+
+정적 확인:
+
+```text
+git diff -- Source/Portfolio/Component/CTakeDamageComponent.h Source/Portfolio/Component/CTakeDamageComponent.cpp
+rg -n "Receive|Evaluate|Apply|Notify|FCombatSignalResult|FTakeDamageResult" Source/Portfolio/Component/CTakeDamageComponent.* Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+```
+
+빌드 확인:
+
+```text
+PortfolioEditor Win64 Development
+```
+
+## 프롬프트 업데이트 확인
+
+작업 후 확인한다.
+
+후보 기준:
+
+```text
+기존 runtime component를 rename하기 전에 내부 책임 단계를 먼저 정리하고,
+새 packet type 연결은 단계 경계가 안정된 뒤 별도 작업으로 분리한다.
+```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md
@@ -81,6 +81,82 @@ Receive
 
 따라서 v1에서는 기존 타입을 유지한 채 함수 그룹과 호출 흐름만 `Receive / Evaluate / Apply / Notify` 기준으로 정리한다.
 
+## 단계 분류 기준
+
+이번 작업의 기준은 `UCTakeDamageComponent`가 target 입장에서 damage signal을 처리할 때의 시간 순서와 책임 변화다.
+
+```text
+Entry
+-> Receive
+-> Evaluate
+-> Apply
+-> Notify
+-> Packet
+-> Debug
+```
+
+`Entry`는 외부에서 이 component로 들어오는 진입점이다.
+
+```text
+RequestTakeDamage
+ProcessTakeDamage
+HandleDefaultDamageEvent
+```
+
+`Receive`는 외부 입력을 내부에서 처리 가능한 자료로 정규화하는 단계다.
+
+```text
+ValidateRequest
+BuildPayload
+BuildContext
+ResolveInstigatorController
+```
+
+`Evaluate`는 target의 현재 상태를 기준으로 수신 결과를 판단하는 단계다.
+
+```text
+ValidateContext
+CanTakeDamage
+ComputeTakeDamage
+ComputeMitigatedDamage
+ComputeFinalTakenDamage
+BuildResult
+```
+
+`Apply`는 실제 상태 변경을 수행하는 단계다.
+
+```text
+CommitTakeDamage
+CommitDamageToHealth
+```
+
+`Notify`는 처리 결과를 다른 domain 또는 source-side receiver로 전달하는 단계다.
+
+```text
+DispatchAcceptedCombatResult
+DispatchRejectedCombatResult
+DispatchCombatResultToReceiver
+ResolveCombatResultReceiverActor
+BuildCombatResultPacket
+```
+
+`Packet`은 payload / context / result를 후속 단계가 읽을 수 있는 자료로 묶는 단계다.
+
+```text
+BuildPacket
+```
+
+`Debug`는 runtime decision에 영향을 주지 않는 관찰용 출력이다.
+
+```text
+PrintTakeDamageSummaryInfo
+PrintTakeDamageContextInfo
+PrintTakeDamageOutcomeInfo
+PrintObjectInfo
+PrintSpecKeyInfo
+PrintDamageAmountInfo
+```
+
 ## 완료조건
 
 - `UCTakeDamageComponent` public API가 유지되어 있다.
@@ -92,6 +168,19 @@ Receive
 - Unreal build가 성공한다.
 
 ## 검증
+
+진행 결과:
+
+```text
+TakeDamage Header Target Sections v1 완료
+```
+
+확인 내용:
+
+- `CTakeDamageComponent.h` private method group을 `Receive / Evaluate / Apply / Notify / Packet / Debug` 기준으로 재배치했다.
+- 기존 public API와 함수명은 유지했다.
+- 함수 구현은 변경하지 않았다.
+- `FCombatSignal`은 기존 damage flow에 연결하지 않았다.
 
 정적 확인:
 
@@ -106,9 +195,20 @@ rg -n "Receive|Evaluate|Apply|Notify|FCombatSignalResult|FTakeDamageResult" Sour
 PortfolioEditor Win64 Development
 ```
 
+결과:
+
+```text
+성공
+```
+
+남은 작업:
+
+- `HandleDefaultDamageEvent` 내부 단계 주석과 호출 흐름을 `Receive / Evaluate / Apply / Notify` 기준으로 정리한다.
+- `FTakeDamageResult`와 `FCombatSignalResult` 후보 관계를 문서화한다.
+
 ## 프롬프트 업데이트 확인
 
-작업 후 확인한다.
+추가 프롬프트 업데이트 후보 없음.
 
 후보 기준:
 
@@ -116,3 +216,5 @@ PortfolioEditor Win64 Development
 기존 runtime component를 rename하기 전에 내부 책임 단계를 먼저 정리하고,
 새 packet type 연결은 단계 경계가 안정된 뒤 별도 작업으로 분리한다.
 ```
+
+위 기준은 이번 작업에서 새로 발견된 것이 아니라 W04-01 / PU01의 기존 판단을 따른 것이다.

--- a/Source/Portfolio/Component/CTakeDamageComponent.cpp
+++ b/Source/Portfolio/Component/CTakeDamageComponent.cpp
@@ -53,20 +53,17 @@ float UCTakeDamageComponent::ProcessTakeDamage(float DamageAmount, FDamageEvent 
 
 float UCTakeDamageComponent::HandleDefaultDamageEvent(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser)
 {
-	// [Function Object]
-	// 'FDefaultDamageEvent + @(FTakeDamagePayload) -> FTakeDamageContext' and TakeDamage it-self
-
-	// 1) Validate Request
+	// Receive: validate engine damage input and normalize it into target-side data.
 	if (!FMath::IsFinite(DamageAmount)) return 0.f;
 	if (!ValidateRequest(InDefaultDamageEvent, InDamageInstigator, InDamageCauser)) return 0.f;
 
-	// 2) Build Payload / Context
 	FTakeDamagePayload takeDamagePayload = BuildPayload(DamageAmount, InDefaultDamageEvent, InDamageInstigator, InDamageCauser);
 	FTakeDamageContext takeDamageContext = BuildContext(takeDamagePayload);
 
-	// 3) Validate Context
+	// Evaluate: validate target-side context and defensive policy before applying state changes.
 	if (!ValidateContext(takeDamageContext))
 	{
+		// Packet / Notify: publish rejected target outcome.
 		const FTakeDamageResult rejectedResult = BuildResult(takeDamageContext);
 		const FTakeDamagePacket takeDamagePacket = BuildPacket(takeDamagePayload, takeDamageContext, rejectedResult);
 
@@ -75,13 +72,13 @@ float UCTakeDamageComponent::HandleDefaultDamageEvent(float DamageAmount, const 
 		return 0.f;
 	}
 
-	// 4) Take Pre-state Snapshot
+	// Evaluate: snapshot target pre-state for outcome/result construction.
 	takeDamageContext.DeadState_Before = HealthComp_Cached->GetDeadState();
 	takeDamageContext.HealthPointBefore = HealthComp_Cached->GetCurrentHP();
 
-	// 5) Validate Policy
 	if (!CanTakeDamage(takeDamageContext))
 	{
+		// Packet / Notify: publish rejected target outcome.
 		const FTakeDamageResult rejectedResult = BuildResult(takeDamageContext);
 		const FTakeDamagePacket takeDamagePacket = BuildPacket(takeDamagePayload, takeDamageContext, rejectedResult);
 
@@ -90,11 +87,11 @@ float UCTakeDamageComponent::HandleDefaultDamageEvent(float DamageAmount, const 
 		return 0.f;
 	}
 
-	// 6) Compute TakeDamage
 	ComputeTakeDamage(takeDamageContext);
 
 	if (!takeDamageContext.bAccepted)
 	{
+		// Packet / Notify: publish rejected target outcome.
 		const FTakeDamageResult rejectedResult = BuildResult(takeDamageContext);
 		const FTakeDamagePacket takeDamagePacket = BuildPacket(takeDamagePayload, takeDamageContext, rejectedResult);
 
@@ -103,12 +100,14 @@ float UCTakeDamageComponent::HandleDefaultDamageEvent(float DamageAmount, const 
 		return 0.f;
 	}
 
-	// 7) Commit
+	// Apply: commit accepted damage to target-side resource state.
 	CommitTakeDamage(takeDamageContext);
 
+	// Packet: combine payload, context, and result for notify/debug consumers.
 	const FTakeDamageResult committedResult = BuildResult(takeDamageContext);
 	const FTakeDamagePacket takeDamagePacket = BuildPacket(takeDamagePayload, takeDamageContext, committedResult);
 
+	// Notify: publish target outcome to reaction, feedback, and source-side result receivers.
 	// PrintTakeDamageSummaryInfo(takeDamagePacket);
 	PrintTakeDamageOutcomeInfo(takeDamagePacket);
 	DispatchAcceptedCombatResult(takeDamagePacket);
@@ -129,6 +128,85 @@ bool UCTakeDamageComponent::ValidateRequest(const FDefaultDamageEvent& InDefault
 	if (!FMath::IsFinite(InDefaultDamageEvent.ApplyDamageAmount.RequestDamage)) return false;
 
 	return true;
+}
+
+FTakeDamagePayload UCTakeDamageComponent::BuildPayload(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const
+{
+	FTakeDamagePayload takeDamagePayload = FTakeDamagePayload();
+
+	takeDamagePayload.SourceActor = InDefaultDamageEvent.SourceActor;
+	takeDamagePayload.TargetActor = OwnerActor_Cached;
+	takeDamagePayload.EventInstigator = InDamageInstigator;
+	takeDamagePayload.DamageCauser = InDamageCauser;
+
+	takeDamagePayload.DamageImpactInfo = InDefaultDamageEvent.DamageImpactInfo;
+	takeDamagePayload.ApplyDamageSpecKey = InDefaultDamageEvent.ApplyDamageSpecKey;
+	takeDamagePayload.ApplyDamageSpec = InDefaultDamageEvent.ApplyDamageSpec;
+	takeDamagePayload.ApplyDamageAmount = InDefaultDamageEvent.ApplyDamageAmount;
+
+	takeDamagePayload.RequestedDamage = DamageAmount;
+
+	return takeDamagePayload;
+}
+
+FTakeDamageContext UCTakeDamageComponent::BuildContext(const FTakeDamagePayload& InTakeDamagePayload) const
+{
+	FTakeDamageContext takeDamageContext = FTakeDamageContext();
+
+	takeDamageContext.SourceActor = InTakeDamagePayload.SourceActor;
+	takeDamageContext.TargetActor = InTakeDamagePayload.TargetActor;
+	takeDamageContext.Instigator = ResolveInstigatorController(InTakeDamagePayload.EventInstigator, InTakeDamagePayload.DamageCauser);
+	takeDamageContext.DamageCauser = InTakeDamagePayload.DamageCauser;
+
+	takeDamageContext.DamageImpactInfo = InTakeDamagePayload.DamageImpactInfo;
+	takeDamageContext.ApplyDamageSpecKey = InTakeDamagePayload.ApplyDamageSpecKey;
+
+	takeDamageContext.RequestedDamage = InTakeDamagePayload.RequestedDamage;
+
+	return takeDamageContext;
+}
+
+AController* UCTakeDamageComponent::ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const
+{
+	// 1) Best case: engine provided instigator
+	if (IsValid(EventInstigator))
+		return EventInstigator;
+
+	// 2) Fallback needs a valid causer
+	if (!IsValid(DamageCauser))
+		return nullptr;
+
+	/* === Fallback Process (DamageCauser-based) === */
+
+	// 2-1) Case 01: Explicit instigator set on the causer (ex. projectile / weaponActor / trap)
+	if (AController* causerInstigator = DamageCauser->GetInstigatorController())
+		return causerInstigator;
+
+	// 2-2) Case 02: Direct hit (the causer itself is a Pawn/Character)
+	if (APawn* causerPawn = Cast<APawn>(DamageCauser))
+	{
+		if (AController* causerController = causerPawn->GetController())
+			return causerController;
+	}
+
+	// 2-3) Case 03: Proxy case (projectile / trap / weaponActor owned by another actor)
+	if (AActor* causerOwner = DamageCauser->GetOwner())
+	{
+		// 2-3-1) Case 03-01: Owner is the carrier and holds the correct instigator (ex. projectile / weaponActor / trap)
+		if (AController* ownerInstigator = causerOwner->GetInstigatorController())
+			return ownerInstigator;
+
+		// 2-3-1) Case 03-02: Fallback (Owner is Pawn/Character)
+		if (APawn* ownerPawn = Cast<APawn>(causerOwner))
+		{
+			if (AController* ownerController = ownerPawn->GetController())
+				return ownerController;
+		}
+	}
+
+	/* ============================================= */
+
+	return nullptr;
 }
 
 bool UCTakeDamageComponent::ValidateContext(FTakeDamageContext& InOutTakeDamageContext)
@@ -220,6 +298,64 @@ void UCTakeDamageComponent::ComputeTakeDamage(FTakeDamageContext& InOutTakeDamag
 	InOutTakeDamageContext.FinalTakenDamage = ComputeFinalTakenDamage(InOutTakeDamageContext);	// TODO
 }
 
+float UCTakeDamageComponent::ComputeMitigatedDamage(FTakeDamageContext& InOutTakeDamageContext) const
+{
+	const float requestedDamage = InOutTakeDamageContext.RequestedDamage;
+
+	// Minimal safe policy (Check NaN, +Inf/-Inf)
+	if (!FMath::IsFinite(requestedDamage)) return 0.f;
+
+	float mitigatedDamage = requestedDamage;
+
+	if (IsValid(DefenseComp_Cached) && DefenseComp_Cached->CanGuard())
+	{
+		InOutTakeDamageContext.DefenseOutcome = EDamageDefenseOutcome::Guard;
+		mitigatedDamage *= 0.5f;
+	}
+
+	// TODO: Defense / Armor / Resistance Policy
+
+	return FMath::Max(0.f, mitigatedDamage);
+}
+
+float UCTakeDamageComponent::ComputeFinalTakenDamage(FTakeDamageContext& InOutTakeDamageContext) const
+{
+	if (!InOutTakeDamageContext.bShouldCommitDamage) return 0.f;
+
+	const float mitigatedDamage = InOutTakeDamageContext.MitigatedDamage;
+
+	// Minimal safe policy (Check NaN, +Inf/-Inf)
+	if (!FMath::IsFinite(mitigatedDamage)) return 0.f;
+
+	const float finalTakenDamage = mitigatedDamage;
+
+	// TODO: Critical / Guard / Headshot etc Policy
+
+	return FMath::Max(0.f, finalTakenDamage);
+}
+
+FTakeDamageResult UCTakeDamageComponent::BuildResult(const FTakeDamageContext& InTakeDamageContext) const
+{
+	FTakeDamageResult takeDamageResult = FTakeDamageResult();
+
+	takeDamageResult.bAccepted = InTakeDamageContext.bAccepted;
+	takeDamageResult.RejectReason = InTakeDamageContext.RejectReason;
+	takeDamageResult.DefenseOutcome = InTakeDamageContext.DefenseOutcome;
+	takeDamageResult.bShouldCommitDamage = InTakeDamageContext.bShouldCommitDamage;
+
+	takeDamageResult.ApplyDamageSpecKey = InTakeDamageContext.ApplyDamageSpecKey;
+
+	takeDamageResult.RequestDamage = InTakeDamageContext.RequestedDamage;
+	takeDamageResult.MitigatedDamage = InTakeDamageContext.MitigatedDamage;
+	takeDamageResult.FinalTakenDamage = InTakeDamageContext.FinalTakenDamage;
+	takeDamageResult.CommittedDamage = InTakeDamageContext.CommittedDamage;
+
+	takeDamageResult.DeadState_Before = InTakeDamageContext.DeadState_Before;
+	takeDamageResult.DeadState_After = InTakeDamageContext.DeadState_After;
+
+	return takeDamageResult;
+}
+
 void UCTakeDamageComponent::CommitTakeDamage(FTakeDamageContext& InOutTakeDamageContext)
 {
 	if (!IsValid(HealthComp_Cached)) return;
@@ -232,6 +368,13 @@ void UCTakeDamageComponent::CommitTakeDamage(FTakeDamageContext& InOutTakeDamage
 	// Post-state Snapshot: Set BuildResult
 	InOutTakeDamageContext.DeadState_After = HealthComp_Cached->GetDeadState();
 	InOutTakeDamageContext.HealthPointAfter = HealthComp_Cached->GetCurrentHP();
+}
+
+float UCTakeDamageComponent::CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const
+{
+	if (!IsValid(HealthComp_Cached)) return 0.0;
+
+	return HealthComp_Cached->TakeDamage(InOutTakeDamageContext.FinalTakenDamage);
 }
 
 void UCTakeDamageComponent::DispatchAcceptedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const
@@ -257,6 +400,11 @@ void UCTakeDamageComponent::DispatchAcceptedCombatResult(const FTakeDamagePacket
 
 	// TODO:
 	// - Debug/UI Feedback
+}
+
+void UCTakeDamageComponent::DispatchRejectedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const
+{
+	// - Debug/UI rejected feedback
 }
 
 void UCTakeDamageComponent::DispatchCombatResultToReceiver(const FTakeDamagePacket& InTakeDamagePacket) const
@@ -303,54 +451,6 @@ void UCTakeDamageComponent::DispatchCombatResultToReceiver(const FTakeDamagePack
 		*GetNameSafe(combatResultPacket.TargetActor)));
 }
 
-void UCTakeDamageComponent::DispatchRejectedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const
-{
-	// - Debug/UI rejected feedback
-}
-
-AController* UCTakeDamageComponent::ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const
-{
-	// 1) Best case: engine provided instigator
-	if (IsValid(EventInstigator))
-		return EventInstigator;
-
-	// 2) Fallback needs a valid causer
-	if (!IsValid(DamageCauser))
-		return nullptr;
-
-	/* === Fallback Process (DamageCauser-based) === */
-
-	// 2-1) Case 01: Explicit instigator set on the causer (ex. projectile / weaponActor / trap)
-	if (AController* causerInstigator = DamageCauser->GetInstigatorController())
-		return causerInstigator;
-
-	// 2-2) Case 02: Direct hit (the causer itself is a Pawn/Character)
-	if (APawn* causerPawn = Cast<APawn>(DamageCauser))
-	{
-		if (AController* causerController = causerPawn->GetController())
-			return causerController;
-	}
-
-	// 2-3) Case 03: Proxy case (projectile / trap / weaponActor owned by another actor)
-	if (AActor* causerOwner = DamageCauser->GetOwner())
-	{
-		// 2-3-1) Case 03-01: Owner is the carrier and holds the correct instigator (ex. projectile / weaponActor / trap)
-		if (AController* ownerInstigator = causerOwner->GetInstigatorController())
-			return ownerInstigator;
-
-		// 2-3-1) Case 03-02: Fallback (Owner is Pawn/Character)
-		if (APawn* ownerPawn = Cast<APawn>(causerOwner))
-		{
-			if (AController* ownerController = ownerPawn->GetController())
-				return ownerController;
-		}
-	}
-
-	/* ============================================= */
-
-	return nullptr;
-}
-
 AActor* UCTakeDamageComponent::ResolveCombatResultReceiverActor(const FTakeDamagePacket& InTakeDamagePacket) const
 {
 	if (IsValid(InTakeDamagePacket.Context.SourceActor)) return InTakeDamagePacket.Context.SourceActor;
@@ -370,118 +470,6 @@ AActor* UCTakeDamageComponent::ResolveCombatResultReceiverActor(const FTakeDamag
 	return nullptr;
 }
 
-float UCTakeDamageComponent::ComputeMitigatedDamage(FTakeDamageContext& InOutTakeDamageContext) const
-{
-	const float requestedDamage = InOutTakeDamageContext.RequestedDamage;
-
-	// Minimal safe policy (Check NaN, +Inf/-Inf)
-	if (!FMath::IsFinite(requestedDamage)) return 0.f;
-
-	float mitigatedDamage = requestedDamage;
-
-	if (IsValid(DefenseComp_Cached) && DefenseComp_Cached->CanGuard())
-	{
-		InOutTakeDamageContext.DefenseOutcome = EDamageDefenseOutcome::Guard;
-		mitigatedDamage *= 0.5f;
-	}
-
-	// TODO: Defense / Armor / Resistance Policy
-
-	return FMath::Max(0.f, mitigatedDamage);
-}
-
-float UCTakeDamageComponent::ComputeFinalTakenDamage(FTakeDamageContext& InOutTakeDamageContext) const
-{
-	if (!InOutTakeDamageContext.bShouldCommitDamage) return 0.f;
-
-	const float mitigatedDamage = InOutTakeDamageContext.MitigatedDamage;
-
-	// Minimal safe policy (Check NaN, +Inf/-Inf)
-	if (!FMath::IsFinite(mitigatedDamage)) return 0.f;
-
-	const float finalTakenDamage = mitigatedDamage;
-
-	// TODO: Critical / Guard / Headshot etc Policy
-
-	return FMath::Max(0.f, finalTakenDamage);
-}
-
-float UCTakeDamageComponent::CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const
-{
-	if (!IsValid(HealthComp_Cached)) return 0.0;
-
-	return HealthComp_Cached->TakeDamage(InOutTakeDamageContext.FinalTakenDamage);
-}
-
-FTakeDamagePayload UCTakeDamageComponent::BuildPayload(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const
-{
-	FTakeDamagePayload takeDamagePayload = FTakeDamagePayload();
-
-	takeDamagePayload.SourceActor = InDefaultDamageEvent.SourceActor;
-	takeDamagePayload.TargetActor = OwnerActor_Cached;
-	takeDamagePayload.EventInstigator = InDamageInstigator;
-	takeDamagePayload.DamageCauser = InDamageCauser;
-
-	takeDamagePayload.DamageImpactInfo = InDefaultDamageEvent.DamageImpactInfo;
-	takeDamagePayload.ApplyDamageSpecKey = InDefaultDamageEvent.ApplyDamageSpecKey;
-	takeDamagePayload.ApplyDamageSpec = InDefaultDamageEvent.ApplyDamageSpec;
-	takeDamagePayload.ApplyDamageAmount = InDefaultDamageEvent.ApplyDamageAmount;
-
-	takeDamagePayload.RequestedDamage = DamageAmount;
-
-	return takeDamagePayload;
-}
-
-FTakeDamageContext UCTakeDamageComponent::BuildContext(const FTakeDamagePayload& InTakeDamagePayload) const
-{
-	FTakeDamageContext takeDamageContext = FTakeDamageContext();
-
-	takeDamageContext.SourceActor = InTakeDamagePayload.SourceActor;
-	takeDamageContext.TargetActor = InTakeDamagePayload.TargetActor;
-	takeDamageContext.Instigator = ResolveInstigatorController(InTakeDamagePayload.EventInstigator, InTakeDamagePayload.DamageCauser);
-	takeDamageContext.DamageCauser = InTakeDamagePayload.DamageCauser;
-
-	takeDamageContext.DamageImpactInfo = InTakeDamagePayload.DamageImpactInfo;
-	takeDamageContext.ApplyDamageSpecKey = InTakeDamagePayload.ApplyDamageSpecKey;
-
-	takeDamageContext.RequestedDamage = InTakeDamagePayload.RequestedDamage;
-
-	return takeDamageContext;
-}
-
-FTakeDamageResult UCTakeDamageComponent::BuildResult(const FTakeDamageContext& InTakeDamageContext) const
-{
-	FTakeDamageResult takeDamageResult = FTakeDamageResult();
-
-	takeDamageResult.bAccepted = InTakeDamageContext.bAccepted;
-	takeDamageResult.RejectReason = InTakeDamageContext.RejectReason;
-	takeDamageResult.DefenseOutcome = InTakeDamageContext.DefenseOutcome;
-	takeDamageResult.bShouldCommitDamage = InTakeDamageContext.bShouldCommitDamage;
-
-	takeDamageResult.ApplyDamageSpecKey = InTakeDamageContext.ApplyDamageSpecKey;
-
-	takeDamageResult.RequestDamage = InTakeDamageContext.RequestedDamage;
-	takeDamageResult.MitigatedDamage = InTakeDamageContext.MitigatedDamage;
-	takeDamageResult.FinalTakenDamage = InTakeDamageContext.FinalTakenDamage;
-	takeDamageResult.CommittedDamage = InTakeDamageContext.CommittedDamage;
-
-	takeDamageResult.DeadState_Before = InTakeDamageContext.DeadState_Before;
-	takeDamageResult.DeadState_After = InTakeDamageContext.DeadState_After;
-
-	return takeDamageResult;
-}
-
-FTakeDamagePacket UCTakeDamageComponent::BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
-{
-	FTakeDamagePacket takeDamagePacket;
-
-	takeDamagePacket.Payload = InTakeDamagePayload;
-	takeDamagePacket.Context = InTakeDamageContext;
-	takeDamagePacket.Result = InTakeDamageResult;
-
-	return takeDamagePacket;
-}
-
 FCombatResultPacket UCTakeDamageComponent::BuildCombatResultPacket(const FTakeDamagePacket& InTakeDamagePacket) const
 {
 	FCombatResultPacket combatResultPacket;
@@ -497,6 +485,17 @@ FCombatResultPacket UCTakeDamageComponent::BuildCombatResultPacket(const FTakeDa
 	combatResultPacket.CommittedDamage = InTakeDamagePacket.Result.CommittedDamage;
 
 	return combatResultPacket;
+}
+
+FTakeDamagePacket UCTakeDamageComponent::BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
+{
+	FTakeDamagePacket takeDamagePacket;
+
+	takeDamagePacket.Payload = InTakeDamagePayload;
+	takeDamagePacket.Context = InTakeDamageContext;
+	takeDamagePacket.Result = InTakeDamageResult;
+
+	return takeDamagePacket;
 }
 
 void UCTakeDamageComponent::PrintTakeDamageSummaryInfo(const FTakeDamagePacket& InTakeDamagePacket) const

--- a/Source/Portfolio/Component/CTakeDamageComponent.h
+++ b/Source/Portfolio/Component/CTakeDamageComponent.h
@@ -34,47 +34,51 @@ protected:
 	void BeginPlay() override;
 
 public:
-	// Entry API
+	// Entry
 	float RequestTakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, class AController* EventInstigator, class AActor* DamageCauser);
 
 private:
-	// Pipeline
 	float ProcessTakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, class AController* EventInstigator, class AActor* DamageCauser);
-
-private:
 	float HandleDefaultDamageEvent(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, class AController* InDamageInstigator, class AActor* InDamageCauser);
 
 private:
+	// Receive
 	bool ValidateRequest(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser);
+	FTakeDamagePayload BuildPayload(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const;
+	FTakeDamageContext BuildContext(const FTakeDamagePayload& InTakeDamagePayload) const;
+	AController* ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const;
+
+private:
+	// Evaluate
 	bool ValidateContext(FTakeDamageContext& InOutTakeDamageContext);
 	bool CanTakeDamage(FTakeDamageContext& InOutTakeDamageContext);
 	void ComputeTakeDamage(FTakeDamageContext& InOutTakeDamageContext) const;
-	void CommitTakeDamage(FTakeDamageContext& InOutTakeDamageContext);
-	void DispatchAcceptedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const;
-	void DispatchRejectedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const;
-	void DispatchCombatResultToReceiver(const FTakeDamagePacket& InTakeDamagePacket) const;
-
-private:
-	AController* ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const;
-	AActor* ResolveCombatResultReceiverActor(const FTakeDamagePacket& InTakeDamagePacket) const;
-
 	float ComputeMitigatedDamage(FTakeDamageContext& InOutTakeDamageContext) const;
 	float ComputeFinalTakenDamage(FTakeDamageContext& InOutTakeDamageContext) const;
+	FTakeDamageResult BuildResult(const FTakeDamageContext& InTakeDamageContext) const;
+
+private:
+	// Apply
+	void CommitTakeDamage(FTakeDamageContext& InOutTakeDamageContext);
 	float CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const;
 
 private:
-	FTakeDamagePayload BuildPayload(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const;
-	FTakeDamageContext BuildContext(const FTakeDamagePayload& InTakeDamagePayload) const;
-	FTakeDamageResult BuildResult(const FTakeDamageContext& InTakeDamageContext) const;
-	FTakeDamagePacket BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;
+	// Notify
+	void DispatchAcceptedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const;
+	void DispatchRejectedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const;
+	void DispatchCombatResultToReceiver(const FTakeDamagePacket& InTakeDamagePacket) const;
+	AActor* ResolveCombatResultReceiverActor(const FTakeDamagePacket& InTakeDamagePacket) const;
 	FCombatResultPacket BuildCombatResultPacket(const FTakeDamagePacket& InTakeDamagePacket) const;
 
 private:
+	// Packet
+	FTakeDamagePacket BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;
+
+private:
+	// Debug
 	void PrintTakeDamageSummaryInfo(const FTakeDamagePacket& InTakeDamagePacket) const;
 	void PrintTakeDamageContextInfo(const FTakeDamagePacket& InTakeDamagePacket) const;
 	void PrintTakeDamageOutcomeInfo(const FTakeDamagePacket& InTakeDamagePacket) const;
-
-private:
 	void PrintObjectInfo(const FTakeDamagePacket& InTakeDamagePacket) const;
 	void PrintSpecKeyInfo(const FTakeDamagePacket& InTakeDamagePacket) const;
 	void PrintDamageAmountInfo(const FTakeDamagePacket& InTakeDamagePacket) const;


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P22: Combat Signal Target Boundary v1 정리**

## 날짜

**2026.06.23**

## 상태

- [x] **완료**

---

## 브랜치

- `refactor/combat-signal-target-v1`

---

## 요약

이번 PR에서는 `UCTakeDamageComponent`를 rename하거나 `FCombatSignal`에 연결하지 않고, 현재 damage 수신 흐름을 target-side 처리 단계 기준으로 정리했다.

핵심은 기존 Guard / Parry / Hit / Dead 동작을 유지하면서 `Receive / Evaluate / Apply / Notify` 흐름이 header와 source에서 같은 순서로 읽히게 만드는 것이다.

---

## 변경 배경

P21에서 combat 송수신 경계를 `CombatSignal Source / Target` 기준으로 재정의하고 최소 타입 vocabulary를 추가했다.

다음 단계에서 바로 component rename이나 packet 교체를 진행하면 기존 damage flow와 Guard / Parry 회귀 위험이 커질 수 있다. 따라서 이번 PR에서는 `TakeDamageComponent` 내부 책임을 먼저 target-side 단계로 정렬하고, 실제 `CombatSignalTarget` 전환은 후속 브랜치로 남겼다.

---

## 변경 범위

### 1. TakeDamage target-side 단계 정리

`UCTakeDamageComponent` private API를 다음 단계 기준으로 재배치했다.

```text
Entry
-> Receive
-> Evaluate
-> Apply
-> Notify
-> Packet
-> Debug
```

### 2. Header / Source 정의 순서 정렬

`CTakeDamageComponent.h`의 선언 순서와 `CTakeDamageComponent.cpp`의 정의 순서를 맞췄다.

이를 통해 `RequestTakeDamage()` 진입 이후 수신, 평가, 적용, 통지, packet 생성, debug 출력 흐름을 같은 순서로 따라갈 수 있게 했다.

### 3. HandleDefaultDamageEvent 흐름 라벨 정리

`HandleDefaultDamageEvent()` 내부에 다음 단계 라벨을 추가했다.

```text
Receive
Evaluate
Apply
Packet
Notify
```

라벨은 흐름 가독성을 위한 주석이며, 기존 실행 순서와 조건 분기는 변경하지 않았다.

### 4. Result boundary 정리

`FTakeDamageResult`와 `FCombatSignalResult`의 관계를 task brief에 정리했다.

```text
FTakeDamageResult
= TakeDamage flow 내부 authoritative result

FCombatSignalResult
= 외부 송출용 summary result 후보
```

이번 PR에서는 변환 함수를 선언하거나 구현하지 않는다.

---

## 구현 범위

이번 PR의 코드 변경은 `UCTakeDamageComponent` 내부 정렬로 제한했다.

- 기존 public API 유지
- 기존 UE `TakeDamage()` adapter 유지
- 기존 `FTakeDamagePayload`, `FTakeDamageContext`, `FTakeDamageResult`, `FTakeDamagePacket` 유지
- 기존 `FCombatResultPacket` 유지
- `FCombatSignal` 직접 연결 없음

---

## 검증

### 빌드

```text
PortfolioEditor Win64 Development
```

결과:

```text
성공
Target is up to date
```

### 정적 확인

- `CTakeDamageComponent.h` private method group 확인
- `CTakeDamageComponent.cpp` 정의 순서 확인
- `HandleDefaultDamageEvent()` 단계 라벨 확인
- `git diff --check` 통과

---

## 제외 범위

이번 PR에서는 다음 작업을 의도적으로 제외했다.

- `UCTakeDamageComponent` rename
- `UCCombatSignalTargetComponent` 신설
- `FCombatSignal`을 기존 damage flow에 연결
- `FCombatSignalResult` 변환 함수 구현
- `UCApplyDamageComponent` source-side 정리
- Blink / Repulse / GuardBreak cue flow 정리

---

## 후속 작업

권장 후속 브랜치는 다음과 같다.

```text
refactor/combat-signal-source-v1
```

후속 작업 목표:

- `UCApplyDamageComponent` 내부를 Source 관점으로 정리
- hit window / duplicate target / damage spec / target delivery 경계를 명확히 정리
- 기존 weapon overlap damage 동작 유지
- component rename은 source / target 양쪽 책임 정리 후 별도 브랜치에서 진행

---

## 관련 문서

- `Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md`
- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`
- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_03_Combat_Signal_Target_Boundary_v1.md`
