### PR TITLE
P23: Combat Signal Source Boundary v1 정리

### DIFF
--- a/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
@@ -512,7 +512,7 @@ UCTakeDamageComponent 내부 흐름을 CombatSignalTarget 책임 기준으로 �
 **상태**
 
 ```text
-진행 중
+완료
 ```
 
 **브랜치**
@@ -529,16 +529,20 @@ UCApplyDamageComponent 내부 흐름을 CombatSignalSource 책임 기준으로 �
 
 **핵심 범위**
 
-- hit window tracking
-- duplicate target tracking
-- signal build 후보 경계
-- target delivery 경계
-- `RequestApplyDamage` API rename 후보 준비
+- `UCApplyDamageComponent` private API를 HitWindow / Entry / Receive / Resolve / Send / Cache / Helper / Debug 기준으로 재배치
+- `CApplyDamageComponent.cpp` 정의 순서를 header 선언 순서와 일치
+- `ProcessApplyDamage` 내부 흐름을 Receive / Resolve / Send / Debug 라벨로 정리
+- 기존 `RequestApplyDamage` 흐름 유지
+- 기존 weapon overlap damage 흐름 유지
+- target `TakeDamage()` 전달 방식 유지
+- `FCombatSignal` 직접 연결 없음
+- 클래스명 rename은 아직 하지 않음
 
 **완료조건**
 
 - 기존 weapon overlap damage 동작 유지
 - source-side 책임 단계가 코드에서 명확히 보임
+- `ProcessApplyDamage` 흐름이 source-side 단계 기준으로 읽힘
 - Unreal build 성공
 
 ### 7.3 W04-05 Combat Signal Component Rename
@@ -546,7 +550,7 @@ UCApplyDamageComponent 내부 흐름을 CombatSignalSource 책임 기준으로 �
 **상태**
 
 ```text
-예정
+다음 작업
 ```
 
 **브랜치**

--- a/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md
@@ -512,7 +512,7 @@ UCTakeDamageComponent 내부 흐름을 CombatSignalTarget 책임 기준으로 �
 **상태**
 
 ```text
-다음 작업
+진행 중
 ```
 
 **브랜치**

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -28,5 +28,6 @@
 | P20 | Guard / Parry Action v1 | `P20_UE5_Portfolio_Pull_Request.md` | `feature/combat-guard-parry` |  | W03, B11, B12, N02, N03, N04, N05 |
 | P21 | Combat Signal Boundary v1 | `P21_UE5_Portfolio_Pull_Request.md` | `refactor/combat-signal-boundary` |  | W04, N05, N06, NA01 |
 | P22 | Combat Signal Target Boundary v1 | `P22_UE5_Portfolio_Pull_Request.md` | `refactor/combat-signal-target-v1` |  | W04, TB_W04_03 |
+| P23 | Combat Signal Source Boundary v1 | `P23_UE5_Portfolio_Pull_Request.md` | `refactor/combat-signal-source-v1` |  | W04, TB_W04_04 |
 
 ---

--- a/Docs/04_Pull_Request/P23_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P23_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,150 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P23: Combat Signal Source Boundary v1 정리**
+
+## 날짜
+
+**2026.06.23**
+
+## 상태
+
+- [x] **완료**
+
+---
+
+## 브랜치
+
+- `refactor/combat-signal-source-v1`
+
+---
+
+## 요약
+
+이번 PR에서는 `UCApplyDamageComponent`를 rename하거나 `FCombatSignal`에 연결하지 않고, 현재 weapon overlap damage 송신 흐름을 source-side 처리 단계 기준으로 정리했다.
+
+핵심은 기존 weapon overlap damage 동작과 target `TakeDamage()` 전달 방식을 유지하면서, `ApplyDamageComponent`가 실제로 수행하는 hit window 관리, hit context 정규화, damage spec 해석, target 전달, duplicate cache 책임을 코드에서 더 명확히 읽히게 만드는 것이다.
+
+---
+
+## 변경 배경
+
+P22에서 `TakeDamageComponent` 내부 흐름을 target-side 기준으로 정리했다.
+
+다음 단계에서 바로 component rename이나 packet 교체를 진행하면 source / target 양쪽 책임 정리가 끝나기 전에 이름만 먼저 바뀔 수 있다. 따라서 이번 PR에서는 `ApplyDamageComponent` 내부 책임을 먼저 source-side 단계로 정렬하고, 실제 `CombatSignalSource` 전환은 후속 브랜치로 남겼다.
+
+---
+
+## 변경 범위
+
+### 1. ApplyDamage source-side 단계 정리
+
+`UCApplyDamageComponent` private API를 다음 단계 기준으로 재배치했다.
+
+```text
+HitWindow
+-> Entry
+-> Receive
+-> Resolve
+-> Send
+-> Cache
+-> Helper
+-> Debug
+```
+
+### 2. Header / Source 정의 순서 정렬
+
+`CApplyDamageComponent.h`의 선언 순서와 `CApplyDamageComponent.cpp`의 정의 순서를 맞췄다.
+
+큰 처리 흐름은 위에서 아래로 읽히게 두고, `BuildHitWindowKey`, `BuildSpecKey`, `ResolveInstigatorController`, duplicate / friendly target helper는 별도 `Helper` 단계로 분리했다.
+
+### 3. ProcessApplyDamage 흐름 라벨 정리
+
+`ProcessApplyDamage()` 내부에 다음 단계 라벨을 추가했다.
+
+```text
+Receive
+Resolve
+Send
+Debug
+```
+
+라벨은 흐름 가독성을 위한 주석이며, 기존 실행 순서와 조건 분기는 변경하지 않았다.
+
+---
+
+## 구현 범위
+
+이번 PR의 코드 변경은 `UCApplyDamageComponent` 내부 정렬로 제한했다.
+
+- 기존 public API 유지
+- 기존 `RequestApplyDamage` 흐름 유지
+- 기존 weapon overlap damage 흐름 유지
+- 기존 target `TakeDamage()` 전달 방식 유지
+- 기존 `FHitContext`, `FApplyDamagePayload`, `FApplyDamageContext`, `FApplyDamageResult` 유지
+- `FCombatSignal` 직접 연결 없음
+
+---
+
+## 검증
+
+### 빌드
+
+```text
+PortfolioEditor Win64 Development
+```
+
+결과:
+
+```text
+성공
+Target is up to date
+```
+
+### 정적 확인
+
+- `CApplyDamageComponent.h` private method group 확인
+- `CApplyDamageComponent.cpp` 정의 순서 확인
+- `ProcessApplyDamage()` 단계 라벨 확인
+- `git diff --check` 통과
+
+---
+
+## 제외 범위
+
+이번 PR에서는 다음 작업을 의도적으로 제외했다.
+
+- `UCApplyDamageComponent` rename
+- `UCCombatSignalSourceComponent` 신설
+- `FCombatSignal`을 기존 damage flow에 연결
+- `RequestApplyDamage` API rename
+- `UCTakeDamageComponent` 수정
+- `FCombatSignalResult` 변환 함수 구현
+- Blink / Repulse / GuardBreak cue flow 정리
+
+---
+
+## 후속 작업
+
+권장 후속 브랜치는 다음과 같다.
+
+```text
+refactor/combat-signal-component-rename
+```
+
+후속 작업 목표:
+
+- `UCApplyDamageComponent`와 `UCTakeDamageComponent` 명칭을 Source / Target 책임 기준으로 교체
+- Character / Weapon 참조 갱신
+- Blueprint 영향 확인
+- 기존 weapon overlap damage와 Guard / Parry / Hit / Dead 회귀 확인
+
+---
+
+## 관련 문서
+
+- `Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md`
+- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
+- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`
+- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md`

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
@@ -18,7 +18,7 @@ TB는 코드만 보고는 드러나지 않는 작업 의도, 범위, 완료조�
 | W04-01 | Combat Signal Boundary 재정의 | `TB_W04_01_Combat_Signal_Boundary_Rescope.md` | 완료 |
 | W04-02 | Combat Signal Types v1 | `TB_W04_02_Combat_Signal_Types_v1.md` | 완료 |
 | W04-03 | Combat Signal Target Boundary v1 | `TB_W04_03_Combat_Signal_Target_Boundary_v1.md` | 완료 |
-| W04-04 | Combat Signal Source Boundary v1 | `TB_W04_04_Combat_Signal_Source_Boundary_v1.md` | 진행 중 |
+| W04-04 | Combat Signal Source Boundary v1 | `TB_W04_04_Combat_Signal_Source_Boundary_v1.md` | 완료 |
 
 ## 다음 후보
 

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/README.md
@@ -18,9 +18,10 @@ TB는 코드만 보고는 드러나지 않는 작업 의도, 범위, 완료조�
 | W04-01 | Combat Signal Boundary 재정의 | `TB_W04_01_Combat_Signal_Boundary_Rescope.md` | 완료 |
 | W04-02 | Combat Signal Types v1 | `TB_W04_02_Combat_Signal_Types_v1.md` | 완료 |
 | W04-03 | Combat Signal Target Boundary v1 | `TB_W04_03_Combat_Signal_Target_Boundary_v1.md` | 완료 |
+| W04-04 | Combat Signal Source Boundary v1 | `TB_W04_04_Combat_Signal_Source_Boundary_v1.md` | 진행 중 |
 
 ## 다음 후보
 
 ```text
-TB_W04_04_Combat_Signal_Source_Boundary_v1.md
+TB_W04_05_Combat_Signal_Component_Rename.md
 ```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
@@ -192,12 +192,14 @@ TB_W04_04 생성
 W04 Work List 상태 진행 중 반영
 ApplyDamage Header Source Sections v1 완료
 ApplyDamage Source Definition Order Alignment 완료
+ApplyDamage Process Flow Labels v1 완료
 ```
 
 확인 내용:
 
 - `CApplyDamageComponent.h` private method group을 `HitWindow / Entry / Receive / Resolve / Send / Cache / Helper / Debug` 기준으로 재배치했다.
 - `CApplyDamageComponent.cpp` 정의 순서를 `CApplyDamageComponent.h` 선언 순서와 일치시켰다.
+- `ProcessApplyDamage` 내부 흐름을 `Receive / Resolve / Send / Debug` 라벨로 정리했다.
 - 기존 public API와 함수명은 유지했다.
 - 함수 구현 로직은 변경하지 않았다.
 - `FCombatSignal`은 기존 damage flow에 연결하지 않았다.

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
@@ -189,7 +189,7 @@ PrintRejectReasonInfo
 
 ```text
 TB_W04_04 생성
-W04 Work List 상태 진행 중 반영
+W04 Work List 상태 완료 반영
 ApplyDamage Header Source Sections v1 완료
 ApplyDamage Source Definition Order Alignment 완료
 ApplyDamage Process Flow Labels v1 완료
@@ -217,9 +217,16 @@ rg -n "Entry|HitWindow|Receive|Resolve|Send|Cache|Debug" Source/Portfolio/Compon
 PortfolioEditor Win64 Development
 ```
 
+결과:
+
+```text
+성공
+Target is up to date
+```
+
 ## 프롬프트 업데이트 확인
 
-추가 프롬프트 업데이트 후보는 작업 후 확인한다.
+추가 프롬프트 업데이트 후보 없음.
 
 후보 기준:
 

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
@@ -44,12 +44,13 @@ debug 출력
 이번 작업에서는 이 흐름을 다음 단계로 정리한다.
 
 ```text
-Entry
--> HitWindow
+HitWindow
+-> Entry
 -> Receive
 -> Resolve
 -> Send
 -> Cache
+-> Helper
 -> Debug
 ```
 
@@ -93,28 +94,28 @@ Entry
 이번 작업의 기준은 `UCApplyDamageComponent`가 source 입장에서 hit evidence를 target damage 전달로 바꿀 때의 시간 순서와 책임 변화다.
 
 ```text
-Entry
--> HitWindow
+HitWindow
+-> Entry
 -> Receive
 -> Resolve
 -> Send
 -> Cache
+-> Helper
 -> Debug
 ```
 
-`Entry`는 외부에서 이 component로 들어오는 진입점이다.
+`HitWindow`는 montage timing 기반 hit 가능 구간과 window별 hit cache lifecycle을 관리하는 단계다.
 
 ```text
 NotifyHitWindowOpened
 NotifyHitWindowClosed
-RequestApplyDamage
-ProcessApplyDamage
 ```
 
-`HitWindow`는 montage timing 기반 hit 가능 구간과 window별 hit cache를 관리하는 단계다.
+`Entry`는 overlap hit를 damage 송신 처리로 넘기는 진입점이다.
 
 ```text
-BuildHitWindowKey
+RequestApplyDamage
+ProcessApplyDamage
 ```
 
 `Receive`는 overlap에서 들어온 hit context를 내부에서 처리 가능한 자료로 정규화하고 검증하는 단계다.
@@ -123,18 +124,16 @@ BuildHitWindowKey
 ValidateRequest
 BuildPayload
 BuildContext
-ValidateContext
-CanApplyDamage
 ```
 
 `Resolve`는 source-side damage 전달에 필요한 spec, controller, damage amount를 해석하는 단계다.
 
 ```text
-BuildSpecKey
+ValidateContext
+CanApplyDamage
 ResolveApplyDamageSpec
 ComputeApplyDamage
 BuildResult
-ResolveInstigatorController
 ```
 
 `Send`는 target 쪽 `TakeDamage()` entry로 damage event를 전달하는 단계다.
@@ -147,9 +146,17 @@ ApplyDamageToTarget
 `Cache`는 같은 hit window 안에서 동일 target 중복 적용을 막기 위한 기록 단계다.
 
 ```text
+CacheDamagedTargetInWindow
+```
+
+`Helper`는 주요 source-side 흐름에서 호출되는 세부 계산 / 조회 함수다.
+
+```text
+BuildHitWindowKey
+BuildSpecKey
+ResolveInstigatorController
 IsDuplicateHit
 IsFriendlyTarget
-CacheDamagedTargetInWindow
 ```
 
 `Debug`는 runtime decision에 영향을 주지 않는 관찰용 출력이다.

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
@@ -1,0 +1,211 @@
+# TB W04-04 Combat Signal Source Boundary v1
+
+## 작업명
+
+```text
+Combat Signal Source Boundary v1
+```
+
+## 브랜치
+
+```text
+refactor/combat-signal-source-v1
+```
+
+## 목표
+
+`UCApplyDamageComponent` 내부 흐름을 `CombatSignalSource` 책임 기준으로 정리한다.
+
+이번 작업은 component rename이나 `FCombatSignal` 연결이 아니라, 기존 weapon overlap damage 송신 흐름을 유지하면서 source-side 처리 단계를 코드에서 명확히 보이게 만드는 준비 리팩터링이다.
+
+## 배경
+
+W04-03에서는 `UCTakeDamageComponent`를 target-side 기준으로 정리했다.
+
+다음 단계는 `UCApplyDamageComponent` 내부에 모여 있는 hit window 관리, overlap 입력 수신, damage spec 해석, target 전달, duplicate hit cache 책임을 source-side 단계로 읽히게 정리하는 것이다.
+
+현재 `UCApplyDamageComponent`는 이름과 달리 target HP를 직접 적용하지 않는다. 실제로는 source 쪽에서 hit evidence를 받아 damage payload / context를 만들고, target의 `TakeDamage()` entry로 전달하는 역할에 가깝다.
+
+현재 `UCApplyDamageComponent`는 다음 책임을 함께 가진다.
+
+```text
+hit window open / close 수신
+overlap hit context 수신
+hit request validation
+payload / context 구성
+duplicate target 검증
+damage spec 조회
+damage amount 계산
+target TakeDamage 호출
+damaged target cache
+debug 출력
+```
+
+이번 작업에서는 이 흐름을 다음 단계로 정리한다.
+
+```text
+Entry
+-> HitWindow
+-> Receive
+-> Resolve
+-> Send
+-> Cache
+-> Debug
+```
+
+## 핵심 범위
+
+- 기존 public API 유지
+  - `NotifyHitWindowOpened`
+  - `NotifyHitWindowClosed`
+  - `RequestApplyDamage`
+- 기존 weapon overlap damage 흐름 유지
+- `ProcessApplyDamage` 내부 단계 주석과 호출 흐름 정리
+- `CApplyDamageComponent.h` private method group을 source-side 단계 기준으로 재배치
+- `CApplyDamageComponent.cpp` 정의 순서를 header 선언 순서와 일치
+- 기존 `FHitContext`, `FApplyDamagePayload`, `FApplyDamageContext`, `FApplyDamageResult` 유지
+- 기존 target `TakeDamage()` 전달 방식 유지
+
+## 제외 범위
+
+- `UCApplyDamageComponent` rename
+- `UCCombatSignalSourceComponent` 신설
+- `FCombatSignal`을 기존 damage flow에 직접 연결
+- `RequestApplyDamage` API rename
+- `UCTakeDamageComponent` 수정
+- `FCombatSignalResult` 변환 함수 구현
+- Blink / Repulse timing cue 구현
+
+## 결정 사항
+
+이번 작업에서는 `FCombatSignal` 타입을 기존 source damage flow에 강제로 연결하지 않는다.
+
+이유:
+
+- 현재 목표는 source-side 단계 경계를 명확히 하는 것이다.
+- target-side 정리와 동일하게 runtime packet 교체는 후속 브랜치에서 판단한다.
+- component rename은 source / target 양쪽 내부 책임 정리가 끝난 뒤 진행하는 편이 안전하다.
+
+따라서 v1에서는 기존 타입과 public API를 유지한 채 함수 그룹과 내부 책임 흐름만 source-side 기준으로 정리한다.
+
+## 단계 분류 기준
+
+이번 작업의 기준은 `UCApplyDamageComponent`가 source 입장에서 hit evidence를 target damage 전달로 바꿀 때의 시간 순서와 책임 변화다.
+
+```text
+Entry
+-> HitWindow
+-> Receive
+-> Resolve
+-> Send
+-> Cache
+-> Debug
+```
+
+`Entry`는 외부에서 이 component로 들어오는 진입점이다.
+
+```text
+NotifyHitWindowOpened
+NotifyHitWindowClosed
+RequestApplyDamage
+ProcessApplyDamage
+```
+
+`HitWindow`는 montage timing 기반 hit 가능 구간과 window별 hit cache를 관리하는 단계다.
+
+```text
+BuildHitWindowKey
+```
+
+`Receive`는 overlap에서 들어온 hit context를 내부에서 처리 가능한 자료로 정규화하고 검증하는 단계다.
+
+```text
+ValidateRequest
+BuildPayload
+BuildContext
+ValidateContext
+CanApplyDamage
+```
+
+`Resolve`는 source-side damage 전달에 필요한 spec, controller, damage amount를 해석하는 단계다.
+
+```text
+BuildSpecKey
+ResolveApplyDamageSpec
+ComputeApplyDamage
+BuildResult
+ResolveInstigatorController
+```
+
+`Send`는 target 쪽 `TakeDamage()` entry로 damage event를 전달하는 단계다.
+
+```text
+CommitApplyDamage
+ApplyDamageToTarget
+```
+
+`Cache`는 같은 hit window 안에서 동일 target 중복 적용을 막기 위한 기록 단계다.
+
+```text
+IsDuplicateHit
+IsFriendlyTarget
+CacheDamagedTargetInWindow
+```
+
+`Debug`는 runtime decision에 영향을 주지 않는 관찰용 출력이다.
+
+```text
+PrintApplyDamageSummaryInfo
+PrintApplyDamageContextInfo
+PrintApplyDamageRejectedSummaryInfo
+PrintApplyDamageRejectedContextInfo
+PrintOverlapContextInfo
+PrintHitContextInfo
+PrintDamageSpecInfo
+PrintDamageResultInfo
+PrintRejectReasonInfo
+```
+
+## 완료조건
+
+- `UCApplyDamageComponent` public API가 유지되어 있다.
+- 기존 weapon overlap damage 흐름과 target `TakeDamage()` 전달 방식이 유지되어 있다.
+- 기존 Guard / Parry / Hit / Dead 동작 의도가 바뀌지 않는다.
+- `CApplyDamageComponent.h`에서 source-side 단계가 명확히 보인다.
+- `ProcessApplyDamage` 흐름이 source-side 단계 기준으로 읽힌다.
+- `FCombatSignal`은 기존 damage flow에 연결하지 않는다.
+- Unreal build가 성공한다.
+
+## 검증
+
+진행 전 기준:
+
+```text
+TB_W04_04 생성
+W04 Work List 상태 진행 중 반영
+코드 수정 전 source-side 단계 분류 기준 확정
+```
+
+정적 확인:
+
+```text
+git diff -- Source/Portfolio/Component/CApplyDamageComponent.h Source/Portfolio/Component/CApplyDamageComponent.cpp
+rg -n "Entry|HitWindow|Receive|Resolve|Send|Cache|Debug" Source/Portfolio/Component/CApplyDamageComponent.h Source/Portfolio/Component/CApplyDamageComponent.cpp Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
+```
+
+빌드 확인:
+
+```text
+PortfolioEditor Win64 Development
+```
+
+## 프롬프트 업데이트 확인
+
+추가 프롬프트 업데이트 후보는 작업 후 확인한다.
+
+후보 기준:
+
+```text
+기존 runtime component를 rename하기 전에 내부 책임 단계를 먼저 정리하고,
+새 packet type 연결은 단계 경계가 안정된 뒤 별도 작업으로 분리한다.
+```

--- a/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
+++ b/Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md
@@ -185,13 +185,22 @@ PrintRejectReasonInfo
 
 ## 검증
 
-진행 전 기준:
+진행 결과:
 
 ```text
 TB_W04_04 생성
 W04 Work List 상태 진행 중 반영
-코드 수정 전 source-side 단계 분류 기준 확정
+ApplyDamage Header Source Sections v1 완료
+ApplyDamage Source Definition Order Alignment 완료
 ```
+
+확인 내용:
+
+- `CApplyDamageComponent.h` private method group을 `HitWindow / Entry / Receive / Resolve / Send / Cache / Helper / Debug` 기준으로 재배치했다.
+- `CApplyDamageComponent.cpp` 정의 순서를 `CApplyDamageComponent.h` 선언 순서와 일치시켰다.
+- 기존 public API와 함수명은 유지했다.
+- 함수 구현 로직은 변경하지 않았다.
+- `FCombatSignal`은 기존 damage flow에 연결하지 않았다.
 
 정적 확인:
 

--- a/Source/Portfolio/Component/CApplyDamageComponent.cpp
+++ b/Source/Portfolio/Component/CApplyDamageComponent.cpp
@@ -106,7 +106,6 @@ void UCApplyDamageComponent::ProcessApplyDamage(const FHitContext& InHitContext)
 	// PrintApplyDamageSummaryInfo(applyDamageContext.HitContext, applyDamageResult);
 }
 
-
 bool UCApplyDamageComponent::ValidateRequest(const FHitContext& InHitContext) const
 {
 	const FOverlapContext& overlapContext = InHitContext.OverlapContext;
@@ -140,6 +139,37 @@ bool UCApplyDamageComponent::ValidateRequest(const FHitContext& InHitContext) co
 		return false;
 
 	return true;
+}
+
+FApplyDamagePayload UCApplyDamageComponent::BuildPayload(const FHitContext& InHitContext) const
+{
+	FApplyDamagePayload applyDamagePayload;
+
+	applyDamagePayload.HitContext = InHitContext;
+	applyDamagePayload.SourceActor = InHitContext.OverlapContext.OwnerActor;
+	applyDamagePayload.DamageCauser = InHitContext.OverlapContext.DamageCauser;
+	applyDamagePayload.TargetActor = InHitContext.OverlapContext.OtherActor;
+	applyDamagePayload.DamageImpactInfo = InHitContext.DamageImpactInfo;
+	applyDamagePayload.HitWindowKey = BuildHitWindowKey(InHitContext);
+	applyDamagePayload.ApplyDamageSpecKey = BuildSpecKey(InHitContext);
+
+	return applyDamagePayload;
+}
+
+FApplyDamageContext UCApplyDamageComponent::BuildContext(const FApplyDamagePayload& InApplyDamagePayload) const
+{
+	FApplyDamageContext applyDamageContext;
+
+	applyDamageContext.HitContext = InApplyDamagePayload.HitContext;
+	applyDamageContext.SourceActor = InApplyDamagePayload.SourceActor;
+	applyDamageContext.DamageCauser = InApplyDamagePayload.DamageCauser;
+	applyDamageContext.TargetActor = InApplyDamagePayload.TargetActor;
+	applyDamageContext.HitWindowKey = InApplyDamagePayload.HitWindowKey;
+	applyDamageContext.DamageImpactInfo = InApplyDamagePayload.DamageImpactInfo;
+	applyDamageContext.ApplyDamageSpecKey = InApplyDamagePayload.ApplyDamageSpecKey;
+	applyDamageContext.Instigator = ResolveInstigatorController(InApplyDamagePayload.SourceActor, InApplyDamagePayload.DamageCauser);
+
+	return applyDamageContext;
 }
 
 bool UCApplyDamageComponent::ValidateContext(FApplyDamageContext& InOutApplyDamageContext) const
@@ -250,6 +280,21 @@ void UCApplyDamageComponent::ComputeApplyDamage(FApplyDamageContext& InOutApplyD
 	InOutApplyDamageContext.RejectReason = EApplyDamageRejectReason::None;
 }
 
+FApplyDamageResult UCApplyDamageComponent::BuildResult(const FApplyDamageContext& InApplyDamageContext) const
+{
+	FApplyDamageResult applyDamageResult;
+
+	applyDamageResult.bAccepted = InApplyDamageContext.bAccepted;
+	applyDamageResult.RejectReason = InApplyDamageContext.RejectReason;
+	applyDamageResult.HitWindowKey = InApplyDamageContext.HitWindowKey;
+	applyDamageResult.ApplyDamageSpecKey = InApplyDamageContext.ApplyDamageSpecKey;
+	applyDamageResult.BaseDamage = InApplyDamageContext.ApplyDamageSpec.BaseDamage;
+	applyDamageResult.RequestDamage = InApplyDamageContext.ApplyDamageAmount.RequestDamage;
+	applyDamageResult.CommittedDamage = InApplyDamageContext.CommittedDamage;
+
+	return applyDamageResult;
+}
+
 void UCApplyDamageComponent::CommitApplyDamage(FApplyDamageContext& InOutApplyDamageContext)
 {
 	InOutApplyDamageContext.CommittedDamage = ApplyDamageToTarget(InOutApplyDamageContext);
@@ -266,7 +311,6 @@ void UCApplyDamageComponent::CommitApplyDamage(FApplyDamageContext& InOutApplyDa
 
 	CacheDamagedTargetInWindow(InOutApplyDamageContext);
 }
-
 
 float UCApplyDamageComponent::ApplyDamageToTarget(const FApplyDamageContext& InApplyDamageContext) const
 {
@@ -285,37 +329,14 @@ float UCApplyDamageComponent::ApplyDamageToTarget(const FApplyDamageContext& InA
 	return InApplyDamageContext.TargetActor->TakeDamage(InApplyDamageContext.ApplyDamageAmount.RequestDamage, damageEvent, InApplyDamageContext.Instigator, InApplyDamageContext.DamageCauser);
 }
 
-bool UCApplyDamageComponent::IsDuplicateHit(const FApplyDamageContext& InApplyDamageContext) const
+void UCApplyDamageComponent::CacheDamagedTargetInWindow(const FApplyDamageContext& InApplyDamageContext)
 {
-	const TSet<AActor*>* foundTargets = DamagedTargetContainer.Find(InApplyDamageContext.HitWindowKey);
-
-	if (!foundTargets) return false;
-
-	return foundTargets->Contains(InApplyDamageContext.TargetActor);
-}
-
-bool UCApplyDamageComponent::IsFriendlyTarget(const FApplyDamageContext& InApplyDamageContext) const
-{
-	AActor* ownerActor = InApplyDamageContext.SourceActor;
 	AActor* targetActor = InApplyDamageContext.TargetActor;
+	if (!IsValid(targetActor)) return;
 
-	if (!IsValid(ownerActor) || !IsValid(targetActor)) return false;
-
-	// TODO:
-	// Team / Friendly Fire policy
-	//
-	// Suggested direction:
-	// 1. Resolve team source from ownerActor
-	// 2. Resolve team source from targetActor
-	// 3. Compare team ids or attitudes
-	// 4. Return true when friendly-fire should be blocked
-	//
-	// Example candidates:
-	// - Team component on character
-	// - Team interface on actor
-	// - Gameplay tag based faction policy
-
-	return false;
+	// Cached
+	auto& damagedTargets = DamagedTargetContainer.FindOrAdd(InApplyDamageContext.HitWindowKey);
+	damagedTargets.Add(targetActor);
 }
 
 FApplyDamageHitWindowKey UCApplyDamageComponent::BuildHitWindowKey(const FHitContext& InHitContext) const
@@ -337,52 +358,6 @@ FApplyDamageSpecKey UCApplyDamageComponent::BuildSpecKey(const FHitContext& InHi
 	applyDamageSpecKey.ActionIndex = InHitContext.ActionContext.ActionIndex;
 
 	return applyDamageSpecKey;
-}
-
-FApplyDamagePayload UCApplyDamageComponent::BuildPayload(const FHitContext& InHitContext) const
-{
-	FApplyDamagePayload applyDamagePayload;
-
-	applyDamagePayload.HitContext = InHitContext;
-	applyDamagePayload.SourceActor = InHitContext.OverlapContext.OwnerActor;
-	applyDamagePayload.DamageCauser = InHitContext.OverlapContext.DamageCauser;
-	applyDamagePayload.TargetActor = InHitContext.OverlapContext.OtherActor;
-	applyDamagePayload.DamageImpactInfo = InHitContext.DamageImpactInfo;
-	applyDamagePayload.HitWindowKey = BuildHitWindowKey(InHitContext);
-	applyDamagePayload.ApplyDamageSpecKey = BuildSpecKey(InHitContext);
-
-	return applyDamagePayload;
-}
-
-FApplyDamageContext UCApplyDamageComponent::BuildContext(const FApplyDamagePayload& InApplyDamagePayload) const
-{
-	FApplyDamageContext applyDamageContext;
-
-	applyDamageContext.HitContext = InApplyDamagePayload.HitContext;
-	applyDamageContext.SourceActor = InApplyDamagePayload.SourceActor;
-	applyDamageContext.DamageCauser = InApplyDamagePayload.DamageCauser;
-	applyDamageContext.TargetActor = InApplyDamagePayload.TargetActor;
-	applyDamageContext.HitWindowKey = InApplyDamagePayload.HitWindowKey;
-	applyDamageContext.DamageImpactInfo = InApplyDamagePayload.DamageImpactInfo;
-	applyDamageContext.ApplyDamageSpecKey = InApplyDamagePayload.ApplyDamageSpecKey;
-	applyDamageContext.Instigator = ResolveInstigatorController(InApplyDamagePayload.SourceActor, InApplyDamagePayload.DamageCauser);
-
-	return applyDamageContext;
-}
-
-FApplyDamageResult UCApplyDamageComponent::BuildResult(const FApplyDamageContext& InApplyDamageContext) const
-{
-	FApplyDamageResult applyDamageResult;
-
-	applyDamageResult.bAccepted = InApplyDamageContext.bAccepted;
-	applyDamageResult.RejectReason = InApplyDamageContext.RejectReason;
-	applyDamageResult.HitWindowKey = InApplyDamageContext.HitWindowKey;
-	applyDamageResult.ApplyDamageSpecKey = InApplyDamageContext.ApplyDamageSpecKey;
-	applyDamageResult.BaseDamage = InApplyDamageContext.ApplyDamageSpec.BaseDamage;
-	applyDamageResult.RequestDamage = InApplyDamageContext.ApplyDamageAmount.RequestDamage;
-	applyDamageResult.CommittedDamage = InApplyDamageContext.CommittedDamage;
-
-	return applyDamageResult;
 }
 
 AController* UCApplyDamageComponent::ResolveInstigatorController(AActor* InAttacker, AActor* InDamageCauser) const
@@ -425,14 +400,37 @@ AController* UCApplyDamageComponent::ResolveInstigatorController(AActor* InAttac
 	return nullptr;
 }
 
-void UCApplyDamageComponent::CacheDamagedTargetInWindow(const FApplyDamageContext& InApplyDamageContext)
+bool UCApplyDamageComponent::IsDuplicateHit(const FApplyDamageContext& InApplyDamageContext) const
 {
-	AActor* targetActor = InApplyDamageContext.TargetActor;
-	if (!IsValid(targetActor)) return;
+	const TSet<AActor*>* foundTargets = DamagedTargetContainer.Find(InApplyDamageContext.HitWindowKey);
 
-	// Cached
-	auto& damagedTargets = DamagedTargetContainer.FindOrAdd(InApplyDamageContext.HitWindowKey);
-	damagedTargets.Add(targetActor);
+	if (!foundTargets) return false;
+
+	return foundTargets->Contains(InApplyDamageContext.TargetActor);
+}
+
+bool UCApplyDamageComponent::IsFriendlyTarget(const FApplyDamageContext& InApplyDamageContext) const
+{
+	AActor* ownerActor = InApplyDamageContext.SourceActor;
+	AActor* targetActor = InApplyDamageContext.TargetActor;
+
+	if (!IsValid(ownerActor) || !IsValid(targetActor)) return false;
+
+	// TODO:
+	// Team / Friendly Fire policy
+	//
+	// Suggested direction:
+	// 1. Resolve team source from ownerActor
+	// 2. Resolve team source from targetActor
+	// 3. Compare team ids or attitudes
+	// 4. Return true when friendly-fire should be blocked
+	//
+	// Example candidates:
+	// - Team component on character
+	// - Team interface on actor
+	// - Gameplay tag based faction policy
+
+	return false;
 }
 
 void UCApplyDamageComponent::PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageResult& InApplyDamageResult) const

--- a/Source/Portfolio/Component/CApplyDamageComponent.cpp
+++ b/Source/Portfolio/Component/CApplyDamageComponent.cpp
@@ -55,6 +55,7 @@ void UCApplyDamageComponent::RequestApplyDamage(const FHitContext& InHitContext)
 
 void UCApplyDamageComponent::ProcessApplyDamage(const FHitContext& InHitContext)
 {
+	// Receive: validate overlap hit input and normalize it into source-side data.
 	if (!ValidateRequest(InHitContext))
 	{
 		// PrintApplyDamageRejectedSummaryInfo(InHitContext, EApplyDamageRejectReason::InvalidRequest);
@@ -64,6 +65,7 @@ void UCApplyDamageComponent::ProcessApplyDamage(const FHitContext& InHitContext)
 	FApplyDamagePayload applyDamagePayload = BuildPayload(InHitContext);
 	FApplyDamageContext applyDamageContext = BuildContext(applyDamagePayload);
 
+	// Resolve: validate source-side context and sender policy before target delivery.
 	if (!ValidateContext(applyDamageContext))
 	{
 		const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
@@ -78,6 +80,7 @@ void UCApplyDamageComponent::ProcessApplyDamage(const FHitContext& InHitContext)
 		return;
 	}
 
+	// Resolve: resolve damage spec and compute request damage.
 	ResolveApplyDamageSpec(applyDamageContext);
 	if (!applyDamageContext.bAccepted)
 	{
@@ -94,6 +97,7 @@ void UCApplyDamageComponent::ProcessApplyDamage(const FHitContext& InHitContext)
 		return;
 	}
 
+	// Send: deliver the source-side damage event to the target damage entry.
 	CommitApplyDamage(applyDamageContext);
 	if (!applyDamageContext.bAccepted)
 	{
@@ -102,6 +106,7 @@ void UCApplyDamageComponent::ProcessApplyDamage(const FHitContext& InHitContext)
 		return;
 	}
 
+	// Debug: build the final source-side result for optional reporting.
 	const FApplyDamageResult applyDamageResult = BuildResult(applyDamageContext);
 	// PrintApplyDamageSummaryInfo(applyDamageContext.HitContext, applyDamageResult);
 }

--- a/Source/Portfolio/Component/CApplyDamageComponent.h
+++ b/Source/Portfolio/Component/CApplyDamageComponent.h
@@ -30,53 +30,55 @@ protected:
 	void BeginPlay() override;
 
 public:
-	// HitWindow API
+	// HitWindow
 	void NotifyHitWindowOpened(AActor* InDamageCauser, int32 InHitWindowId);
 	void NotifyHitWindowClosed(AActor* InDamageCauser, int32 InHitWindowId);
 
 public:
-	// Entry API
+	// Entry
 	void RequestApplyDamage(const FHitContext& InHitContext);
 
 private:
-	// Pipeline
 	void ProcessApplyDamage(const FHitContext& InHitContext);
 
 private:
+	// Receive
 	bool ValidateRequest(const FHitContext& InHitContext) const;
+	FApplyDamagePayload BuildPayload(const FHitContext& InHitContext) const;
+	FApplyDamageContext BuildContext(const FApplyDamagePayload& InApplyDamagePayload) const;
+
+private:
+	// Resolve
 	bool ValidateContext(FApplyDamageContext& InOutApplyDamageContext) const;
 	bool CanApplyDamage(FApplyDamageContext& InOutApplyDamageContext) const;
 	void ResolveApplyDamageSpec(FApplyDamageContext& InOutApplyDamageContext) const;
 	void ComputeApplyDamage(FApplyDamageContext& InOutApplyDamageContext) const;
-	void CommitApplyDamage(FApplyDamageContext& InOutApplyDamageContext);
+	FApplyDamageResult BuildResult(const FApplyDamageContext& InApplyDamageContext) const;
 
 private:
+	// Send
+	void CommitApplyDamage(FApplyDamageContext& InOutApplyDamageContext);
 	float ApplyDamageToTarget(const FApplyDamageContext& InApplyDamageContext) const;
 
 private:
+	// Cache
+	void CacheDamagedTargetInWindow(const FApplyDamageContext& InApplyDamageContext);
+
+private:
+	// Helper
+	FApplyDamageHitWindowKey BuildHitWindowKey(const FHitContext& InHitContext) const;
+	FApplyDamageSpecKey BuildSpecKey(const FHitContext& InHitContext) const;
+	AController* ResolveInstigatorController(AActor* InAttacker, AActor* InDamageCauser) const;
 	bool IsDuplicateHit(const FApplyDamageContext& InApplyDamageContext) const;
 	bool IsFriendlyTarget(const FApplyDamageContext& InApplyDamageContext) const;
 
 private:
-	FApplyDamageHitWindowKey BuildHitWindowKey(const FHitContext& InHitContext) const;
-	FApplyDamageSpecKey BuildSpecKey(const FHitContext& InHitContext) const;
-	FApplyDamagePayload BuildPayload(const FHitContext& InHitContext) const;
-	FApplyDamageContext BuildContext(const FApplyDamagePayload& InApplyDamagePayload) const;
-	FApplyDamageResult BuildResult(const FApplyDamageContext& InApplyDamageContext) const;
-
-private:
-	AController* ResolveInstigatorController(AActor* InAttacker, AActor* InDamageCauser) const;
-
-private:
-	void CacheDamagedTargetInWindow(const FApplyDamageContext& InApplyDamageContext);
-
-private:
+	// Debug
 	void PrintApplyDamageSummaryInfo(const FHitContext& InHitContext, const FApplyDamageResult& InApplyDamageResult) const;
 	void PrintApplyDamageContextInfo(const FHitContext& InHitContext, const FApplyDamageSpec& InApplyDamageSpec, const FApplyDamageResult& InApplyDamageResult) const;
 	void PrintApplyDamageRejectedSummaryInfo(const FHitContext& InHitContext, EApplyDamageRejectReason InRejectReason) const;
 	void PrintApplyDamageRejectedContextInfo(const FHitContext& InHitContext, EApplyDamageRejectReason InRejectReason) const;
 
-private:
 	void PrintOverlapContextInfo(const FOverlapContext& InOverlapContext) const;
 	void PrintHitContextInfo(const FWeaponContext& InWeaponContext, const FActionContext& InActionContext) const;
 	void PrintDamageSpecInfo(const FApplyDamageSpec& InApplyDamageSpec) const;


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P23: Combat Signal Source Boundary v1 정리**

## 날짜

**2026.06.23**

## 상태

- [x] **완료**

---

## 브랜치

- `refactor/combat-signal-source-v1`

---

## 요약

이번 PR에서는 `UCApplyDamageComponent`를 rename하거나 `FCombatSignal`에 연결하지 않고, 현재 weapon overlap damage 송신 흐름을 source-side 처리 단계 기준으로 정리했다.

핵심은 기존 weapon overlap damage 동작과 target `TakeDamage()` 전달 방식을 유지하면서, `ApplyDamageComponent`가 실제로 수행하는 hit window 관리, hit context 정규화, damage spec 해석, target 전달, duplicate cache 책임을 코드에서 더 명확히 읽히게 만드는 것이다.

---

## 변경 배경

P22에서 `TakeDamageComponent` 내부 흐름을 target-side 기준으로 정리했다.

다음 단계에서 바로 component rename이나 packet 교체를 진행하면 source / target 양쪽 책임 정리가 끝나기 전에 이름만 먼저 바뀔 수 있다. 따라서 이번 PR에서는 `ApplyDamageComponent` 내부 책임을 먼저 source-side 단계로 정렬하고, 실제 `CombatSignalSource` 전환은 후속 브랜치로 남겼다.

---

## 변경 범위

### 1. ApplyDamage source-side 단계 정리

`UCApplyDamageComponent` private API를 다음 단계 기준으로 재배치했다.

```text
HitWindow
-> Entry
-> Receive
-> Resolve
-> Send
-> Cache
-> Helper
-> Debug
```

### 2. Header / Source 정의 순서 정렬

`CApplyDamageComponent.h`의 선언 순서와 `CApplyDamageComponent.cpp`의 정의 순서를 맞췄다.

큰 처리 흐름은 위에서 아래로 읽히게 두고, `BuildHitWindowKey`, `BuildSpecKey`, `ResolveInstigatorController`, duplicate / friendly target helper는 별도 `Helper` 단계로 분리했다.

### 3. ProcessApplyDamage 흐름 라벨 정리

`ProcessApplyDamage()` 내부에 다음 단계 라벨을 추가했다.

```text
Receive
Resolve
Send
Debug
```

라벨은 흐름 가독성을 위한 주석이며, 기존 실행 순서와 조건 분기는 변경하지 않았다.

---

## 구현 범위

이번 PR의 코드 변경은 `UCApplyDamageComponent` 내부 정렬로 제한했다.

- 기존 public API 유지
- 기존 `RequestApplyDamage` 흐름 유지
- 기존 weapon overlap damage 흐름 유지
- 기존 target `TakeDamage()` 전달 방식 유지
- 기존 `FHitContext`, `FApplyDamagePayload`, `FApplyDamageContext`, `FApplyDamageResult` 유지
- `FCombatSignal` 직접 연결 없음

---

## 검증

### 빌드

```text
PortfolioEditor Win64 Development
```

결과:

```text
성공
Target is up to date
```

### 정적 확인

- `CApplyDamageComponent.h` private method group 확인
- `CApplyDamageComponent.cpp` 정의 순서 확인
- `ProcessApplyDamage()` 단계 라벨 확인
- `git diff --check` 통과

---

## 제외 범위

이번 PR에서는 다음 작업을 의도적으로 제외했다.

- `UCApplyDamageComponent` rename
- `UCCombatSignalSourceComponent` 신설
- `FCombatSignal`을 기존 damage flow에 연결
- `RequestApplyDamage` API rename
- `UCTakeDamageComponent` 수정
- `FCombatSignalResult` 변환 함수 구현
- Blink / Repulse / GuardBreak cue flow 정리

---

## 후속 작업

권장 후속 브랜치는 다음과 같다.

```text
refactor/combat-signal-component-rename
```

후속 작업 목표:

- `UCApplyDamageComponent`와 `UCTakeDamageComponent` 명칭을 Source / Target 책임 기준으로 교체
- Character / Weapon 참조 갱신
- Blueprint 영향 확인
- 기존 weapon overlap damage와 Guard / Parry / Hit / Dead 회귀 확인

---

## 관련 문서

- `Docs/01_Work_List/W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md`
- `Docs/06_notes/N05_Combat_Signal_Boundary_Design_Note.md`
- `Docs/06_notes/N06_Combat_Signal_Branch_Implementation_Plan.md`
- `Docs/06_notes/task_briefs/W04_Combat_Signal_Boundary/TB_W04_04_Combat_Signal_Source_Boundary_v1.md`
