### PR TITLE
F04: Combat Signal Target 흐름 순서 정렬 보정

### DIFF
--- a/Docs/04-02_Fix_Pull_Request/F04_UE5_Portfolio_Pull_Request_Fix.md
+++ b/Docs/04-02_Fix_Pull_Request/F04_UE5_Portfolio_Pull_Request_Fix.md
@@ -1,0 +1,89 @@
+# UE5 Portfolio Pull Request Fix
+
+## 제목
+
+**F04: Combat Signal Target 흐름 순서 정렬 보정**
+
+## 날짜
+
+**2026.06.23**
+
+## 상태
+
+- [x] **완료**
+
+---
+
+## 브랜치
+
+- `fix/combat-signal-target-flow-order`
+
+---
+
+## 요약
+
+이번 Fix PR에서는 `UCTakeDamageComponent`의 선언부와 정의부 순서를 Combat Signal Target 기준 흐름에 맞게 정렬했다.
+
+기능 동작이나 combat 처리 로직은 변경하지 않고, 이후 `Combat Signal Target` 리팩터링을 읽고 이어가기 쉽도록 API 배치만 보정했다.
+
+---
+
+## 변경 사항
+
+- `CTakeDamageComponent.h`의 private API 구간을 다음 순서로 정리했다.
+
+```text
+Entry
+Receive
+Evaluate
+Apply
+Packet
+Notify
+Helper
+Debug
+```
+
+- `CTakeDamageComponent.cpp`의 함수 정의 순서를 헤더 선언 순서와 일치시켰다.
+
+- `BuildPacket`은 Packet 구간으로 이동했다.
+
+- `ResolveInstigatorController`, `CommitDamageToHealth`, `ResolveCombatResultReceiverActor`, `BuildCombatResultPacket`은 Helper 구간으로 모았다.
+
+---
+
+## 변경하지 않은 것
+
+- damage 수신/판정/적용 로직
+
+- Guard / Parry / Defensive Outcome 처리
+
+- CombatResultPacket 생성 값
+
+- reaction / feedback / result dispatch 동작
+
+- 문서 구조나 Work List 상태
+
+---
+
+## 검증 결과
+
+- `git diff --check` 통과
+
+- `PortfolioEditor Win64 Development` 빌드 성공
+
+- 최종 워킹트리 기준 코드 변경 파일:
+
+```text
+Source/Portfolio/Component/CTakeDamageComponent.h
+Source/Portfolio/Component/CTakeDamageComponent.cpp
+```
+
+---
+
+## 관련 문서
+
+- `Docs/04_Pull_Request/P22_UE5_Portfolio_Pull_Request.md`
+
+- `Docs/06_Notes/Task_Briefs/TB_W04_03_Combat_Signal_Target_Boundary_v1.md`
+
+---

--- a/Source/Portfolio/Component/CTakeDamageComponent.cpp
+++ b/Source/Portfolio/Component/CTakeDamageComponent.cpp
@@ -166,49 +166,6 @@ FTakeDamageContext UCTakeDamageComponent::BuildContext(const FTakeDamagePayload&
 	return takeDamageContext;
 }
 
-AController* UCTakeDamageComponent::ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const
-{
-	// 1) Best case: engine provided instigator
-	if (IsValid(EventInstigator))
-		return EventInstigator;
-
-	// 2) Fallback needs a valid causer
-	if (!IsValid(DamageCauser))
-		return nullptr;
-
-	/* === Fallback Process (DamageCauser-based) === */
-
-	// 2-1) Case 01: Explicit instigator set on the causer (ex. projectile / weaponActor / trap)
-	if (AController* causerInstigator = DamageCauser->GetInstigatorController())
-		return causerInstigator;
-
-	// 2-2) Case 02: Direct hit (the causer itself is a Pawn/Character)
-	if (APawn* causerPawn = Cast<APawn>(DamageCauser))
-	{
-		if (AController* causerController = causerPawn->GetController())
-			return causerController;
-	}
-
-	// 2-3) Case 03: Proxy case (projectile / trap / weaponActor owned by another actor)
-	if (AActor* causerOwner = DamageCauser->GetOwner())
-	{
-		// 2-3-1) Case 03-01: Owner is the carrier and holds the correct instigator (ex. projectile / weaponActor / trap)
-		if (AController* ownerInstigator = causerOwner->GetInstigatorController())
-			return ownerInstigator;
-
-		// 2-3-1) Case 03-02: Fallback (Owner is Pawn/Character)
-		if (APawn* ownerPawn = Cast<APawn>(causerOwner))
-		{
-			if (AController* ownerController = ownerPawn->GetController())
-				return ownerController;
-		}
-	}
-
-	/* ============================================= */
-
-	return nullptr;
-}
-
 bool UCTakeDamageComponent::ValidateContext(FTakeDamageContext& InOutTakeDamageContext)
 {
 	if (!IsValid(InOutTakeDamageContext.TargetActor))
@@ -370,11 +327,15 @@ void UCTakeDamageComponent::CommitTakeDamage(FTakeDamageContext& InOutTakeDamage
 	InOutTakeDamageContext.HealthPointAfter = HealthComp_Cached->GetCurrentHP();
 }
 
-float UCTakeDamageComponent::CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const
+FTakeDamagePacket UCTakeDamageComponent::BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
 {
-	if (!IsValid(HealthComp_Cached)) return 0.0;
+	FTakeDamagePacket takeDamagePacket;
 
-	return HealthComp_Cached->TakeDamage(InOutTakeDamageContext.FinalTakenDamage);
+	takeDamagePacket.Payload = InTakeDamagePayload;
+	takeDamagePacket.Context = InTakeDamageContext;
+	takeDamagePacket.Result = InTakeDamageResult;
+
+	return takeDamagePacket;
 }
 
 void UCTakeDamageComponent::DispatchAcceptedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const
@@ -451,6 +412,56 @@ void UCTakeDamageComponent::DispatchCombatResultToReceiver(const FTakeDamagePack
 		*GetNameSafe(combatResultPacket.TargetActor)));
 }
 
+AController* UCTakeDamageComponent::ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const
+{
+	// 1) Best case: engine provided instigator
+	if (IsValid(EventInstigator))
+		return EventInstigator;
+
+	// 2) Fallback needs a valid causer
+	if (!IsValid(DamageCauser))
+		return nullptr;
+
+	/* === Fallback Process (DamageCauser-based) === */
+
+	// 2-1) Case 01: Explicit instigator set on the causer (ex. projectile / weaponActor / trap)
+	if (AController* causerInstigator = DamageCauser->GetInstigatorController())
+		return causerInstigator;
+
+	// 2-2) Case 02: Direct hit (the causer itself is a Pawn/Character)
+	if (APawn* causerPawn = Cast<APawn>(DamageCauser))
+	{
+		if (AController* causerController = causerPawn->GetController())
+			return causerController;
+	}
+
+	// 2-3) Case 03: Proxy case (projectile / trap / weaponActor owned by another actor)
+	if (AActor* causerOwner = DamageCauser->GetOwner())
+	{
+		// 2-3-1) Case 03-01: Owner is the carrier and holds the correct instigator (ex. projectile / weaponActor / trap)
+		if (AController* ownerInstigator = causerOwner->GetInstigatorController())
+			return ownerInstigator;
+
+		// 2-3-1) Case 03-02: Fallback (Owner is Pawn/Character)
+		if (APawn* ownerPawn = Cast<APawn>(causerOwner))
+		{
+			if (AController* ownerController = ownerPawn->GetController())
+				return ownerController;
+		}
+	}
+
+	/* ============================================= */
+
+	return nullptr;
+}
+
+float UCTakeDamageComponent::CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const
+{
+	if (!IsValid(HealthComp_Cached)) return 0.0;
+
+	return HealthComp_Cached->TakeDamage(InOutTakeDamageContext.FinalTakenDamage);
+}
+
 AActor* UCTakeDamageComponent::ResolveCombatResultReceiverActor(const FTakeDamagePacket& InTakeDamagePacket) const
 {
 	if (IsValid(InTakeDamagePacket.Context.SourceActor)) return InTakeDamagePacket.Context.SourceActor;
@@ -485,17 +496,6 @@ FCombatResultPacket UCTakeDamageComponent::BuildCombatResultPacket(const FTakeDa
 	combatResultPacket.CommittedDamage = InTakeDamagePacket.Result.CommittedDamage;
 
 	return combatResultPacket;
-}
-
-FTakeDamagePacket UCTakeDamageComponent::BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const
-{
-	FTakeDamagePacket takeDamagePacket;
-
-	takeDamagePacket.Payload = InTakeDamagePayload;
-	takeDamagePacket.Context = InTakeDamageContext;
-	takeDamagePacket.Result = InTakeDamageResult;
-
-	return takeDamagePacket;
 }
 
 void UCTakeDamageComponent::PrintTakeDamageSummaryInfo(const FTakeDamagePacket& InTakeDamagePacket) const

--- a/Source/Portfolio/Component/CTakeDamageComponent.h
+++ b/Source/Portfolio/Component/CTakeDamageComponent.h
@@ -46,7 +46,6 @@ private:
 	bool ValidateRequest(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser);
 	FTakeDamagePayload BuildPayload(float DamageAmount, const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser) const;
 	FTakeDamageContext BuildContext(const FTakeDamagePayload& InTakeDamagePayload) const;
-	AController* ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const;
 
 private:
 	// Evaluate
@@ -60,19 +59,23 @@ private:
 private:
 	// Apply
 	void CommitTakeDamage(FTakeDamageContext& InOutTakeDamageContext);
-	float CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const;
+
+private:
+	// Packet
+	FTakeDamagePacket BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;
 
 private:
 	// Notify
 	void DispatchAcceptedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const;
 	void DispatchRejectedCombatResult(const FTakeDamagePacket& InTakeDamagePacket) const;
 	void DispatchCombatResultToReceiver(const FTakeDamagePacket& InTakeDamagePacket) const;
-	AActor* ResolveCombatResultReceiverActor(const FTakeDamagePacket& InTakeDamagePacket) const;
-	FCombatResultPacket BuildCombatResultPacket(const FTakeDamagePacket& InTakeDamagePacket) const;
 
 private:
-	// Packet
-	FTakeDamagePacket BuildPacket(const FTakeDamagePayload& InTakeDamagePayload, const FTakeDamageContext& InTakeDamageContext, const FTakeDamageResult& InTakeDamageResult) const;
+	// Helper
+	AController* ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const;
+	float CommitDamageToHealth(const FTakeDamageContext& InOutTakeDamageContext) const;
+	AActor* ResolveCombatResultReceiverActor(const FTakeDamagePacket& InTakeDamagePacket) const;
+	FCombatResultPacket BuildCombatResultPacket(const FTakeDamagePacket& InTakeDamagePacket) const;
 
 private:
 	// Debug


### PR DESCRIPTION
# UE5 Portfolio Pull Request Fix

## 제목

**F04: Combat Signal Target 흐름 순서 정렬 보정**

## 날짜

**2026.06.23**

## 상태

- [x] **완료**

---

## 브랜치

- `fix/combat-signal-target-flow-order`

---

## 요약

이번 Fix PR에서는 `UCTakeDamageComponent`의 선언부와 정의부 순서를 Combat Signal Target 기준 흐름에 맞게 정렬했다.

기능 동작이나 combat 처리 로직은 변경하지 않고, 이후 `Combat Signal Target` 리팩터링을 읽고 이어가기 쉽도록 API 배치만 보정했다.

---

## 변경 사항

- `CTakeDamageComponent.h`의 private API 구간을 다음 순서로 정리했다.

```text
Entry
Receive
Evaluate
Apply
Packet
Notify
Helper
Debug
```

- `CTakeDamageComponent.cpp`의 함수 정의 순서를 헤더 선언 순서와 일치시켰다.

- `BuildPacket`은 Packet 구간으로 이동했다.

- `ResolveInstigatorController`, `CommitDamageToHealth`, `ResolveCombatResultReceiverActor`, `BuildCombatResultPacket`은 Helper 구간으로 모았다.

---

## 변경하지 않은 것

- damage 수신/판정/적용 로직

- Guard / Parry / Defensive Outcome 처리

- CombatResultPacket 생성 값

- reaction / feedback / result dispatch 동작

- 문서 구조나 Work List 상태

---

## 검증 결과

- `git diff --check` 통과

- `PortfolioEditor Win64 Development` 빌드 성공

- 최종 워킹트리 기준 코드 변경 파일:

```text
Source/Portfolio/Component/CTakeDamageComponent.h
Source/Portfolio/Component/CTakeDamageComponent.cpp
```

---

## 관련 문서

- `Docs/04_Pull_Request/P22_UE5_Portfolio_Pull_Request.md`

- `Docs/06_Notes/Task_Briefs/TB_W04_03_Combat_Signal_Target_Boundary_v1.md`

---
