### PR TITLE
P28: Unreal Reference Safety 정책 정리

### DIFF
--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -33,5 +33,6 @@
 | P25 | Combat Signal Damage Data Type 정리 | `P25_UE5_Portfolio_Pull_Request.md` | `refactor/combat-damage-data-types` |  | W04, TB_W04_06 |
 | P26 | Combat Signal TimingCue 연결 v1 | `P26_UE5_Portfolio_Pull_Request.md` | `feature/combat-signal-cue-v1` |  | W04, N04, N05, N06, TB_W04_07 |
 | P27 | Code Quality Cleanup Plan | `P27_UE5_Portfolio_Pull_Request.md` | `docs/code-quality-plan` |  | W05, N08 |
+| P28 | Unreal 참조 안전성 v1 | `P28_UE5_Portfolio_Pull_Request.md` | `refactor/unreal-reference-safety-v1` |  | W05, N08, N09 |
 
 ---

--- a/Docs/04_Pull_Request/P28_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P28_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,179 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P28: Unreal 참조 안전성 v1**
+
+## 날짜
+
+**2026.06.28**
+
+## 상태
+
+- [x] **완료**
+
+---
+
+## 브랜치
+
+- `refactor/unreal-reference-safety-v1`
+
+---
+
+## 요약
+
+이번 PR은 `Source/Portfolio`의 UObject 참조 중 UHT / GC / runtime lifetime 관점에서 바로 설명이 필요한 부분을 작게 정리한다.
+
+핵심은 모든 raw pointer를 한 번에 교체하는 것이 아니라, 명확한 안전성 이슈와 리뷰 질문이 생길 수 있는 필드만 우선 보완하는 것이다.
+
+---
+
+## 변경 배경
+
+W05 코드 품질 정리 계획에서 첫 번째 코드 작업으로 `Unreal Reference Safety`를 선택했다.
+
+UE C++에서는 UObject 참조가 다음 기준을 명확히 가져야 한다.
+
+```text
+- Unreal reflection / GC가 알아야 하는 필드인가
+- 런타임 캐시지만 저장되면 안 되는 필드인가
+- 참조 대상 actor를 살려두면 안 되는 임시 추적 데이터인가
+- raw pointer가 함수 경계 / payload / local access 수준에서만 쓰이는가
+```
+
+이번 PR은 이 기준을 문서화하고, 현재 코드에서 바로 수정 가능한 작은 범위에 적용한다.
+
+---
+
+## 변경 범위
+
+### 1. HealthComponent cached owner 참조 보완
+
+`UCHealthComponent::OwnerActor_Cached`에 `UPROPERTY(Transient)`와 `nullptr` 초기화를 추가했다.
+
+```text
+변경 전
+-> raw AActor* member
+-> UPROPERTY 없음
+-> 기본 초기화 없음
+
+변경 후
+-> UPROPERTY(Transient)
+-> nullptr 초기화
+```
+
+이 필드는 런타임에 `GetOwner()` 결과를 캐시하는 필드다. 저장 대상은 아니지만 Unreal GC / reflection 관점에서 명확한 런타임 UObject 참조로 보이도록 정리했다.
+
+### 2. CombatFeedback hit-stop actor 추적을 weak reference로 변경
+
+`UCWorldSubsystem_CombatFeedback`의 hit-stop 추적 맵을 raw actor key에서 `TWeakObjectPtr<AActor>` key로 변경했다.
+
+```text
+ActiveHitStopMap
+CachedTimeDilationMap
+```
+
+hit-stop 대상 actor는 subsystem이 소유하는 객체가 아니다. 타이머 대기 중 actor가 먼저 파괴될 수 있으므로, 추적 맵이 actor를 붙잡거나 raw pointer 보관 의미를 주지 않도록 weak reference를 사용한다.
+
+`RestoreHitStop`도 `TWeakObjectPtr<AActor>`를 받아 실행 시점에 actor 유효성을 다시 확인한다.
+
+### 3. CombatSignalSource duplicate hit target cache를 weak reference로 변경
+
+`UCCombatSignalSourceComponent::DamagedTargetContainer`의 target set을 `TSet<TWeakObjectPtr<AActor>>`로 변경했다.
+
+이 컨테이너는 hit window 안에서 이미 damage를 보낸 target을 추적하는 임시 cache다. target actor를 소유하거나 수명을 연장하는 것이 목적이 아니므로 weak reference가 더 적절하다.
+
+### 4. UObject reference safety 기준 문서 추가
+
+다음 노트를 추가했다.
+
+```text
+Docs/06_notes/N09_Unreal_Reference_Safety_Policy_Note.md
+```
+
+문서에는 다음 기준을 정리했다.
+
+```text
+- UPROPERTY 사용 기준
+- Transient runtime cache 기준
+- TObjectPtr 사용 후보
+- TWeakObjectPtr 사용 후보
+- raw pointer 허용 범위
+- TSoftObjectPtr / TSoftClassPtr 사용 기준
+- UObject에 일반 스마트 포인터를 사용하지 않는 기준
+- timer / delegate payload 기준
+```
+
+### 5. Code Quality Note 연결
+
+`N08_Code_Quality_Cleanup_Plan_Note`의 UObject 참조 안정성 항목에서 세부 기준 문서 `N09`를 참조하도록 갱신했다.
+
+---
+
+## 검증
+
+### 빌드
+
+```text
+PortfolioEditor Win64 Development
+```
+
+결과:
+
+```text
+성공
+```
+
+### 정적 확인
+
+```text
+git diff --check
+```
+
+결과:
+
+```text
+성공
+```
+
+### 필드 스캔
+
+헤더의 raw UObject pointer member 중 즉시 `UPROPERTY`가 없는 후보를 재스캔했다.
+
+결과:
+
+```text
+No missing immediate UPROPERTY candidates for raw UObject pointer fields.
+```
+
+---
+
+## 제외 범위
+
+이번 PR에서는 다음 작업을 의도적으로 제외한다.
+
+```text
+- 프로젝트 전체 TObjectPtr migration
+- 모든 cached pointer의 nullptr 초기화 통일
+- FCombatSignalHitWindowKey::DamageCauser raw actor key 구조 변경
+- Component reference validation / check / ensure 정책 변경
+- Debug log gate 구현
+- Blink / Repulse / ResultOut 기능 구현
+```
+
+`FCombatSignalHitWindowKey::DamageCauser`는 현재 raw actor key를 유지한다. 해당 key를 weak reference 또는 stable id로 바꾸면 hash / equality 의미가 바뀔 수 있으므로 별도 브랜치에서 다룬다.
+
+---
+
+## 후속 작업
+
+권장 후속 순서는 다음과 같다.
+
+```text
+1. refactor/component-reference-validation-policy
+2. refactor/cached-pointer-default-init
+3. refactor/debug-log-policy-v1
+4. refactor/todo-status-cleanup
+```
+
+이번 PR은 W05의 첫 번째 코드 품질 브랜치로, Unreal reference safety 기준을 코드와 문서 양쪽에 반영하는 것을 완료 조건으로 한다.

--- a/Docs/06_notes/N08_Code_Quality_Cleanup_Plan_Note.md
+++ b/Docs/06_notes/N08_Code_Quality_Cleanup_Plan_Note.md
@@ -88,6 +88,8 @@
 
 모든 raw pointer가 잘못은 아니다. 다만 UObject 계열 포인터는 소유 / 강한 참조 / 약한 참조 / 일시 참조 기준을 코드에서 설명할 수 있어야 한다.
 
+세부 판단 기준은 `N09. Unreal Reference Safety Policy Note`를 따른다.
+
 ### 2.2 Component lookup / check 사용
 
 `check`, `FindComponentByClass`, `GetComponentByClass`가 주요 초기화 경로에 넓게 존재한다.

--- a/Docs/06_notes/N09_Unreal_Reference_Safety_Policy_Note.md
+++ b/Docs/06_notes/N09_Unreal_Reference_Safety_Policy_Note.md
@@ -1,0 +1,251 @@
+# N09. Unreal Reference Safety Policy Note
+
+## 목적
+
+이 노트는 `Source/Portfolio`에서 UObject 참조를 어떤 기준으로 보관할지 정리한다.
+
+목표는 모든 raw pointer를 한 번에 교체하는 것이 아니다. 각 UObject 참조가 아래 의미 중 무엇인지 코드와 문서에서 설명 가능하게 만드는 것이다.
+
+```text
+소유 / 유지 참조
+약한 관찰 참조
+런타임 캐시
+일시적 payload
+함수 내부 접근
+에디터 설정 asset / class 참조
+```
+
+---
+
+## 1. 기본 원칙
+
+멤버 필드로 보관하는 UObject 계열 포인터는 명시적인 수명 정책을 가져야 한다.
+
+```text
+보관되는 UObject 참조
+-> UPROPERTY, TObjectPtr, TWeakObjectPtr, TSoftObjectPtr, 또는 의도적인 제외 사유
+```
+
+raw `UObject*`, `AActor*`, Component pointer가 항상 잘못된 것은 아니다. 다만 의미가 모호하게 남으면 안 된다.
+
+---
+
+## 2. UPROPERTY
+
+`UCLASS` 또는 reflected `USTRUCT` 안에 UObject 참조를 보관하고, 해당 참조가 Unreal reflection / serialization / editor / GC tracking 시스템과 연결되어야 한다면 `UPROPERTY`를 사용한다.
+
+```cpp
+UPROPERTY(Transient)
+AActor* OwnerActor_Cached = nullptr;
+```
+
+프로젝트 기준은 다음과 같다.
+
+```text
+런타임 cached UObject 멤버
+-> UPROPERTY(Transient)
+
+CreateDefaultSubobject로 생성하는 native component
+-> UPROPERTY(VisibleAnywhere)
+
+에디터에서 설정하는 asset / tuning data
+-> UPROPERTY(EditAnywhere 또는 EditDefaultsOnly)
+
+저장되지 않아야 하는 runtime state
+-> UPROPERTY(Transient)
+```
+
+`UPROPERTY`는 단순 장식으로 붙이지 않는다. specifier는 Unreal이 해당 필드를 알아야 하는 이유를 설명해야 한다.
+
+---
+
+## 3. TObjectPtr
+
+오브젝트 필드로 유지되는 UObject 참조이고 UE5 스타일 reflected object tracking에 참여하는 것이 자연스럽다면 `TObjectPtr<T>`를 우선 고려한다.
+
+좋은 후보는 다음과 같다.
+
+```text
+USTRUCT data 안의 asset reference
+Actor가 소유하는 component field
+Component가 생성 / 유지하는 executor instance
+UCLASS instance가 오래 보관하는 UObject reference
+```
+
+현재 프로젝트 기준은 다음과 같다.
+
+```text
+새로 추가하거나 수정 중인 retained UObject field는 주변 코드가 이미 TObjectPtr를 쓰거나 변경 위험이 낮을 때 TObjectPtr를 사용할 수 있다.
+기존 raw UPROPERTY field를 한 번에 전부 migration하지 않는다.
+```
+
+이 기준은 코드 안정성을 유지하면서 UE5 pointer style로 점진 이동하기 위한 것이다.
+
+---
+
+## 4. TWeakObjectPtr
+
+참조 대상 UObject를 관찰하지만, 그 대상을 살려두거나 소유한다는 의미를 주면 안 되는 경우 `TWeakObjectPtr<T>`를 사용한다.
+
+좋은 후보는 다음과 같다.
+
+```text
+timer restore target
+hit-window duplicate target cache
+temporary actor tracking map
+AI perception memory처럼 actor 파괴를 막으면 안 되는 추적 데이터
+lookup 비용을 줄이기 위한 optional external actor / component cache
+```
+
+예시는 다음과 같다.
+
+```cpp
+TMap<TWeakObjectPtr<AActor>, FTimerHandle> ActiveHitStopMap;
+TSet<TWeakObjectPtr<AActor>> DamagedTargets;
+```
+
+접근 기준은 다음과 같다.
+
+```cpp
+AActor* Actor = ActorKey.Get();
+if (!IsValid(Actor)) return;
+```
+
+같은 actor가 소유하는 필수 subobject에는 특별한 이유가 없으면 `TWeakObjectPtr`를 우선하지 않는다. 필수 component는 보통 초기화 시점에 검증하는 쪽이 더 명확하다.
+
+---
+
+## 5. Raw Pointer
+
+UObject raw pointer는 보관하지 않거나 Unreal API 경계에 해당하는 경우 허용한다.
+
+허용 사례는 다음과 같다.
+
+```text
+함수 매개변수
+지역 변수
+lookup 함수의 반환값
+UE callback signature
+짧게 소비되는 event payload
+즉시 복사 / 소비되는 non-owning USTRUCT context
+```
+
+예시는 다음과 같다.
+
+```cpp
+void ApplyHitStop(AActor* InActor, float InDuration, float InDilation);
+AActor* TargetActor = ResolveCueTargetActor();
+```
+
+raw pointer를 멤버 필드로 보관한다면 아래 중 하나가 필요하다.
+
+```text
+UPROPERTY(...)
+또는 필드 근처에 명시된 의도적인 non-UPROPERTY 사유
+```
+
+---
+
+## 6. Class / Asset Reference
+
+에디터에서 설정하는 class reference는 `TSubclassOf<T>`를 사용한다.
+
+```cpp
+UPROPERTY(EditAnywhere)
+TSubclassOf<UCAction> ActionExecutorKey = nullptr;
+```
+
+asset / class 참조가 즉시 로드되지 않아야 하는 경우에만 `TSoftObjectPtr<T>` 또는 `TSoftClassPtr<T>`를 사용한다.
+
+현재 프로젝트 기준은 다음과 같다.
+
+```text
+Phase 1에서는 broad soft-reference migration을 하지 않는다.
+명확한 loading / asset dependency 이유가 있을 때만 soft reference를 사용한다.
+```
+
+---
+
+## 7. Non-UObject Smart Pointer
+
+`TSharedPtr`, `TUniquePtr`, `TSharedRef`는 UObject 소유권 표현에 사용하지 않는다.
+
+이 포인터들은 non-UObject C++ data, Slate-style object, 순수 helper object에는 사용할 수 있다. Actor, Component, Asset, Animation, UObject executor에는 사용하지 않는다.
+
+---
+
+## 8. Container
+
+컨테이너 필드도 일반 필드와 같은 기준을 따른다.
+
+```text
+보관되는 UObject element
+-> GC / reflection tracking이 필요하면 UPROPERTY container
+
+관찰만 하는 actor / component key 또는 value
+-> 소유 의미를 피해야 하면 TWeakObjectPtr element type
+
+함수 내부 temporary container
+-> 같은 호출 흐름 안에서 소비된다면 raw pointer element 허용
+```
+
+리뷰 질문은 다음과 같다.
+
+```text
+이 컨테이너가 clear되기 전에 대상 object가 파괴되면 어떻게 되어야 하는가?
+```
+
+답이 "안전하게 skip한다"라면 weak reference가 더 적절하다.
+
+---
+
+## 9. Timer / Delegate
+
+Timer 또는 delegate payload가 외부 actor를 의도치 않게 붙잡으면 안 된다.
+
+프로젝트 기준은 다음과 같다.
+
+```text
+UObject가 소유한 timer가 다른 actor의 state를 복구한다
+-> timer owner object는 일반 member function binding으로 묶는다
+-> 복구 대상 actor는 TWeakObjectPtr로 전달한다
+```
+
+예시는 다음과 같다.
+
+```cpp
+const TWeakObjectPtr<AActor> ActorKey(InActor);
+FTimerDelegate Delegate = FTimerDelegate::CreateUObject(this, &ThisClass::RestoreHitStop, ActorKey);
+```
+
+람다는 named member function보다 코드가 단순해지는 경우에만 사용한다. 리뷰 가능성을 위해 기본적으로는 named member function을 우선한다.
+
+---
+
+## 10. 현재 브랜치 결정
+
+`refactor/unreal-reference-safety-v1`에서는 이 정책의 가장 작고 안전한 일부만 적용한다.
+
+```text
+UCHealthComponent::OwnerActor_Cached
+-> UPROPERTY(Transient)와 nullptr 초기화 추가
+
+UCWorldSubsystem_CombatFeedback hit-stop maps
+-> temporary actor tracking을 weak actor key 기준으로 변경
+
+UCCombatSignalSourceComponent damaged target cache
+-> hit-window duplicate tracking target을 weak reference로 변경
+```
+
+후속 작업으로 분리할 항목은 다음과 같다.
+
+```text
+FCombatSignalHitWindowKey::DamageCauser raw actor key
+-> hash / equality 의미가 바뀔 수 있으므로 별도 브랜치
+
+Project-wide TObjectPtr migration
+-> diff가 넓고 구체적 안전성 이슈와 묶이지 않으면 스타일 변경에 가까우므로 별도 브랜치
+
+Cached pointer nullptr initialization sweep
+-> 별도 quick-win 브랜치
+```

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -454,11 +454,11 @@ AController* UCCombatSignalSourceComponent::ResolveInstigatorController(AActor* 
 
 bool UCCombatSignalSourceComponent::IsDuplicateHit(const FCombatSignalSourceContext& InCombatSignalSourceContext) const
 {
-	const TSet<AActor*>* foundTargets = DamagedTargetContainer.Find(InCombatSignalSourceContext.HitWindowKey);
+	const TSet<TWeakObjectPtr<AActor>>* foundTargets = DamagedTargetContainer.Find(InCombatSignalSourceContext.HitWindowKey);
 
 	if (!foundTargets) return false;
 
-	return foundTargets->Contains(InCombatSignalSourceContext.TargetActor);
+	return foundTargets->Contains(TWeakObjectPtr<AActor>(InCombatSignalSourceContext.TargetActor));
 }
 
 bool UCCombatSignalSourceComponent::IsFriendlyTarget(const FCombatSignalSourceContext& InCombatSignalSourceContext) const

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.h
@@ -20,12 +20,12 @@ private:
 	TMap<FDamageSpecKey, FDamageSpec> DamageSpecContainer;	// TODO: Seperate DataAsset (DB)
 
 private:
-	TMap<FCombatSignalHitWindowKey, TSet<AActor*>> DamagedTargetContainer;
+	TMap<FCombatSignalHitWindowKey, TSet<TWeakObjectPtr<AActor>>> DamagedTargetContainer;
 
 private:
 	/* === Cached Objects === */
 	UPROPERTY(Transient)
-	class ACharacter* OwnerCharacter_Cached;
+	class ACharacter* OwnerCharacter_Cached = nullptr;
 
 protected:
 	void BeginPlay() override;

--- a/Source/Portfolio/Component/CHealthComponent.h
+++ b/Source/Portfolio/Component/CHealthComponent.h
@@ -42,7 +42,8 @@ private:
 
 private:
 	/* === Cached Objects === */
-	class AActor* OwnerActor_Cached;
+	UPROPERTY(Transient)
+	class AActor* OwnerActor_Cached = nullptr;
 
 public:
 	FOnDeadStateChanged OnDeadStateChanged;

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
@@ -45,34 +45,37 @@ void UCWorldSubsystem_CombatFeedback::ApplyHitStop(AActor* InActor, float InDura
 	if (!IsValid(InActor)) return;
 	if (InDuration <= 0.f) return;
 
-	if (!CachedTimeDilationMap.Contains(InActor))
+	const TWeakObjectPtr<AActor> actorKey(InActor);
+
+	if (!CachedTimeDilationMap.Contains(actorKey))
 	{
-		CachedTimeDilationMap.Add(InActor, InActor->CustomTimeDilation);
+		CachedTimeDilationMap.Add(actorKey, InActor->CustomTimeDilation);
 	}
 
 	// Slow InActor
 	InActor->CustomTimeDilation = InDilation;
 
-	if (FTimerHandle* existingHandle = ActiveHitStopMap.Find(InActor))
+	if (FTimerHandle* existingHandle = ActiveHitStopMap.Find(actorKey))
 	{
 		GetWorld()->GetTimerManager().ClearTimer(*existingHandle);
 	}
 
 	FTimerHandle handle;
-	FTimerDelegate delegate = FTimerDelegate::CreateUObject(this, &UCWorldSubsystem_CombatFeedback::RestoreHitStop, InActor);
+	FTimerDelegate delegate = FTimerDelegate::CreateUObject(this, &UCWorldSubsystem_CombatFeedback::RestoreHitStop, actorKey);
 
 	// FLog::Log(TEXT("[UCWorldSubsystem_CombatFeedback] ApplyHitStop"));
 	// PrintHitStopConsumeInfo(InActor, InDuration, InDilation);
 
 	GetWorld()->GetTimerManager().SetTimer(handle, delegate, InDuration, false);
-	ActiveHitStopMap.Add(InActor, handle);
+	ActiveHitStopMap.Add(actorKey, handle);
 }
 
-void UCWorldSubsystem_CombatFeedback::RestoreHitStop(AActor* InActor)
+void UCWorldSubsystem_CombatFeedback::RestoreHitStop(TWeakObjectPtr<AActor> InActorKey)
 {
+	AActor* InActor = InActorKey.Get();
 	if (IsValid(InActor))
 	{
-		const float* cachedDilation = CachedTimeDilationMap.Find(InActor);
+		const float* cachedDilation = CachedTimeDilationMap.Find(InActorKey);
 		InActor->CustomTimeDilation = cachedDilation ? *cachedDilation : 1.f;
 	}
 
@@ -80,8 +83,8 @@ void UCWorldSubsystem_CombatFeedback::RestoreHitStop(AActor* InActor)
 	// PrintHitStopConsumeInfo(InActor, 1.f, 0.f);
 
 	// Restore InActor
-	ActiveHitStopMap.Remove(InActor);
-	CachedTimeDilationMap.Remove(InActor);
+	ActiveHitStopMap.Remove(InActorKey);
+	CachedTimeDilationMap.Remove(InActorKey);
 }
 
 void UCWorldSubsystem_CombatFeedback::PrintHitStopConsumeInfo(AActor* InActor, float InDuration, float InDilation) const

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
@@ -13,8 +13,8 @@ class PORTFOLIO_API UCWorldSubsystem_CombatFeedback : public UWorldSubsystem
 	GENERATED_BODY()
 
 private:
-	TMap<class AActor*, FTimerHandle> ActiveHitStopMap;
-	TMap<class AActor*, float> CachedTimeDilationMap;
+	TMap<TWeakObjectPtr<class AActor>, FTimerHandle> ActiveHitStopMap;
+	TMap<TWeakObjectPtr<class AActor>, float> CachedTimeDilationMap;
 
 public:
 	FOnCombatCameraShakeRequested OnCameraShakeRequested;
@@ -25,7 +25,7 @@ public:
 
 private:
 	void ApplyHitStop(AActor* InActor, float InDuration, float InDilation);
-	void RestoreHitStop(AActor* InActor);
+	void RestoreHitStop(TWeakObjectPtr<AActor> InActorKey);
 
 private:
 	void PrintHitStopConsumeInfo(AActor* InActor, float InDuration, float InDilation) const;


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P28: Unreal Reference Safety 정책 정리**

## 날짜

**2026.06.28**

## 상태

- [x] **완료**

---

## 브랜치

- `refactor/unreal-reference-safety-v1`

---

## 요약

이번 PR은 `Source/Portfolio`의 UObject 참조 중 UHT / GC / runtime lifetime 관점에서 바로 설명이 필요한 부분을 작게 정리한다.

핵심은 모든 raw pointer를 한 번에 교체하는 것이 아니라, 명확한 안전성 이슈와 리뷰 질문이 생길 수 있는 필드만 우선 보완하는 것이다.

---

## 변경 배경

W05 코드 품질 정리 계획에서 첫 번째 코드 작업으로 `Unreal Reference Safety`를 선택했다.

UE C++에서는 UObject 참조가 다음 기준을 명확히 가져야 한다.

```text
- Unreal reflection / GC가 알아야 하는 필드인가
- 런타임 캐시지만 저장되면 안 되는 필드인가
- 참조 대상 actor를 살려두면 안 되는 임시 추적 데이터인가
- raw pointer가 함수 경계 / payload / local access 수준에서만 쓰이는가
```

이번 PR은 이 기준을 문서화하고, 현재 코드에서 바로 수정 가능한 작은 범위에 적용한다.

---

## 변경 범위

### 1. HealthComponent cached owner 참조 보완

`UCHealthComponent::OwnerActor_Cached`에 `UPROPERTY(Transient)`와 `nullptr` 초기화를 추가했다.

```text
변경 전
-> raw AActor* member
-> UPROPERTY 없음
-> 기본 초기화 없음

변경 후
-> UPROPERTY(Transient)
-> nullptr 초기화
```

이 필드는 런타임에 `GetOwner()` 결과를 캐시하는 필드다. 저장 대상은 아니지만 Unreal GC / reflection 관점에서 명확한 런타임 UObject 참조로 보이도록 정리했다.

### 2. CombatFeedback hit-stop actor 추적을 weak reference로 변경

`UCWorldSubsystem_CombatFeedback`의 hit-stop 추적 맵을 raw actor key에서 `TWeakObjectPtr<AActor>` key로 변경했다.

```text
ActiveHitStopMap
CachedTimeDilationMap
```

hit-stop 대상 actor는 subsystem이 소유하는 객체가 아니다. 타이머 대기 중 actor가 먼저 파괴될 수 있으므로, 추적 맵이 actor를 붙잡거나 raw pointer 보관 의미를 주지 않도록 weak reference를 사용한다.

`RestoreHitStop`도 `TWeakObjectPtr<AActor>`를 받아 실행 시점에 actor 유효성을 다시 확인한다.

### 3. CombatSignalSource duplicate hit target cache를 weak reference로 변경

`UCCombatSignalSourceComponent::DamagedTargetContainer`의 target set을 `TSet<TWeakObjectPtr<AActor>>`로 변경했다.

이 컨테이너는 hit window 안에서 이미 damage를 보낸 target을 추적하는 임시 cache다. target actor를 소유하거나 수명을 연장하는 것이 목적이 아니므로 weak reference가 더 적절하다.

### 4. UObject reference safety 기준 문서 추가

다음 노트를 추가했다.

```text
Docs/06_notes/N09_Unreal_Reference_Safety_Policy_Note.md
```

문서에는 다음 기준을 정리했다.

```text
- UPROPERTY 사용 기준
- Transient runtime cache 기준
- TObjectPtr 사용 후보
- TWeakObjectPtr 사용 후보
- raw pointer 허용 범위
- TSoftObjectPtr / TSoftClassPtr 사용 기준
- UObject에 일반 스마트 포인터를 사용하지 않는 기준
- timer / delegate payload 기준
```

### 5. Code Quality Note 연결

`N08_Code_Quality_Cleanup_Plan_Note`의 UObject 참조 안정성 항목에서 세부 기준 문서 `N09`를 참조하도록 갱신했다.

---

## 검증

### 빌드

```text
PortfolioEditor Win64 Development
```

결과:

```text
성공
```

### 정적 확인

```text
git diff --check
```

결과:

```text
성공
```

### 필드 스캔

헤더의 raw UObject pointer member 중 즉시 `UPROPERTY`가 없는 후보를 재스캔했다.

결과:

```text
No missing immediate UPROPERTY candidates for raw UObject pointer fields.
```

---

## 제외 범위

이번 PR에서는 다음 작업을 의도적으로 제외한다.

```text
- 프로젝트 전체 TObjectPtr migration
- 모든 cached pointer의 nullptr 초기화 통일
- FCombatSignalHitWindowKey::DamageCauser raw actor key 구조 변경
- Component reference validation / check / ensure 정책 변경
- Debug log gate 구현
- Blink / Repulse / ResultOut 기능 구현
```

`FCombatSignalHitWindowKey::DamageCauser`는 현재 raw actor key를 유지한다. 해당 key를 weak reference 또는 stable id로 바꾸면 hash / equality 의미가 바뀔 수 있으므로 별도 브랜치에서 다룬다.

---

## 후속 작업

권장 후속 순서는 다음과 같다.

```text
1. refactor/component-reference-validation-policy
2. refactor/cached-pointer-default-init
3. refactor/debug-log-policy-v1
4. refactor/todo-status-cleanup
```

이번 PR은 W05의 첫 번째 코드 품질 브랜치로, Unreal reference safety 기준을 코드와 문서 양쪽에 반영하는 것을 완료 조건으로 한다.
