### PR TITLE
P30: Runtime Component 조회 정책

### DIFF
--- a/Docs/01_Work_List/00_Work_List_Index.md
+++ b/Docs/01_Work_List/00_Work_List_Index.md
@@ -10,6 +10,6 @@
 | W02 | AI 협업 기반 문서 운영 체계 정리 | `W02_Documentation_Update/W02_UE5_Portfolio_Work_List.md` | `docs/portfolio-documentation-update` | P19 | 완료 |
 | W03 | Guard / Parry Action v1 구현 | `W03_Parry/W03_UE5_Portfolio_Work_List.md` | `feature/combat-guard-parry` | P20 | 완료 |
 | W04 | Combat Signal Boundary v1 | `W04_Combat_Signal_Boundary/W04_UE5_Portfolio_Work_List.md` | `refactor/combat-signal-boundary` | P21 | 완료 |
-| W05 | Code Quality 정리 계획 | `W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md` | multiple refactor branches | P27-P29 | 진행 |
+| W05 | Code Quality 정리 계획 | `W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md` | multiple refactor branches | P27-P30 | 진행 |
 
 ---

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -467,7 +467,7 @@ refactor/runtime-component-lookup-policy
 
 ### P30. Runtime Component Lookup Policy
 
-- 상태: 진행 중
+- 상태: 완료
 - 브랜치: `refactor/runtime-component-lookup-policy`
 - PR: `P30_UE5_Portfolio_Pull_Request.md`
 - 목표: P29 이후에도 남는 runtime lookup 경로를 Notify / AnimInstance / AI / WeaponActor 기준으로 분류하고, DI 대상과 runtime query 유지 대상을 구분한다.

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -22,14 +22,15 @@
 우선 브랜치 순서
 1. refactor/unreal-reference-safety-v1
 2. refactor/character-component-reference-di
-3. refactor/debug-log-policy-v1
-4. refactor/todo-status-cleanup
-5. refactor/tuning-constants-cleanup
-6. refactor/naming-typo-api-cleanup
-7. refactor/api-const-consistency
-8. refactor/ai-blackboard-key-registry
-9. perf/ai-update-interval-audit
-10. refactor/enhanced-input-migration
+3. refactor/runtime-component-lookup-policy
+4. refactor/debug-log-policy-v1
+5. refactor/todo-status-cleanup
+6. refactor/tuning-constants-cleanup
+7. refactor/naming-typo-api-cleanup
+8. refactor/api-const-consistency
+9. refactor/ai-blackboard-key-registry
+10. perf/ai-update-interval-audit
+11. refactor/enhanced-input-migration
 ```
 
 ---
@@ -446,9 +447,9 @@ Prompt update는 실제 코드 작업을 1회 이상 진행한 뒤 판단한다.
 - 추가 결과: Blueprint stale native component reference 복구를 `FComponentReferenceHelper`로 분리하고, `BP_CEnemy` asset 갱신 결과를 기록했다.
 - 관련 문서: `N10_Component_Reference_Validation_Policy_Note.md`, `N11_Unreal_Blueprint_Native_Component_Reference_Mismatch_Note.md`, `B14_UE5_Portfolio_Bug_Report.md`
 
-### 후속 분리
+### P30 분리 배경
 
-다음 항목은 P29 범위에 포함하지 않고 후속 브랜치에서 하나의 runtime lookup policy 작업으로 묶는다.
+다음 항목은 P29 범위에 포함하지 않고 P30에서 하나의 runtime lookup policy 작업으로 묶는다.
 
 ```text
 refactor/runtime-component-lookup-policy
@@ -462,4 +463,25 @@ refactor/runtime-component-lookup-policy
 - BehaviorTree Service / Decorator component query 기준
 - CombatSignal dynamic target lookup 허용 기준
 - Runtime component lookup policy 문서화
+```
+
+### P30. Runtime Component Lookup Policy
+
+- 상태: 진행 중
+- 브랜치: `refactor/runtime-component-lookup-policy`
+- PR: `P30_UE5_Portfolio_Pull_Request.md`
+- 목표: P29 이후에도 남는 runtime lookup 경로를 Notify / AnimInstance / AI / WeaponActor 기준으로 분류하고, DI 대상과 runtime query 유지 대상을 구분한다.
+- 관련 문서: `N12_Runtime_Component_Lookup_Policy_Note.md`
+- 제외 범위: Blink / Repulse / ResultOut 구현, UE TakeDamage route 제거, GAS 도입, BehaviorTree 전체 재설계
+
+검토 순서:
+
+```text
+1. Notify / NotifyState component routing 확인
+2. AnimInstance owner / component cache 확인
+3. AI BT Service / Decorator / Task lookup 확인
+4. WeaponActor runtime reference 확인
+5. FindComponentByClass / TryGetPawnOwner / Blackboard 조회 사용처 분류
+6. 필요한 코드 수정만 반영
+7. 문서와 PR 기록 업데이트
 ```

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -35,5 +35,6 @@
 | P27 | Code Quality Cleanup Plan | `P27_UE5_Portfolio_Pull_Request.md` | `docs/code-quality-plan` |  | W05, N08 |
 | P28 | Unreal 참조 안전성 v1 | `P28_UE5_Portfolio_Pull_Request.md` | `refactor/unreal-reference-safety-v1` |  | W05, N08, N09 |
 | P29 | Character Component 참조 주입 / 복구 | `P29_UE5_Portfolio_Pull_Request.md` | `refactor/character-component-reference-di` |  | W05, N10, N11, B14 |
+| P30 | Runtime Component 조회 정책 | `P30_UE5_Portfolio_Pull_Request.md` | `refactor/runtime-component-lookup-policy` |  | W05, N12 |
 
 ---

--- a/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
@@ -10,7 +10,7 @@
 
 ## 상태
 
-- [ ] 진행 중
+- [x] 완료
 
 ---
 
@@ -23,7 +23,11 @@
 ## 커밋
 
 ```text
-TBD
+39d8b024 docs(reference): define runtime component lookup policy
+6908a289 refactor(notify): route timing events through components
+b78cf7eb refactor(animation): clarify anim instance reference cache
+126091b9 refactor(ai): clarify behavior tree runtime lookup
+88075a70 refactor(weapon): clarify spawned actor reference cleanup
 ```
 
 ---
@@ -266,10 +270,11 @@ Docs/04_Pull_Request/00_Pull_Request_Index.md
 ## 검증 계획
 
 ```text
-- rg 기반 lookup 사용처 전수 스캔
-- Notify / AnimInstance / AI / WeaponActor 경로별 코드 확인
-- 변경이 발생한 경우 Unreal C++ build
-- PIE에서 기본 combat loop smoke test
+- rg 기반 lookup 사용처 전수 스캔 완료
+- GetComponentByClass 잔여 사용처 없음 확인
+- Notify / AnimInstance / AI / WeaponActor 경로별 코드 확인 완료
+- PortfolioEditor Win64 Development 빌드 성공
+- PIE 기본 combat loop smoke test는 수동 확인 대상으로 남김
 ```
 
 ---

--- a/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
@@ -126,8 +126,7 @@ NativeUpdateAnimation에서는 invalid owner / component 상황을 safe return�
 검토 대상:
 
 ```text
-Source/Portfolio/Animation
-AnimInstance 관련 파일
+Source/Portfolio/Character/CAnimInstance.*
 ```
 
 진행 내용:
@@ -185,6 +184,28 @@ Overlap target은 event payload에서 해석한다.
 Source/Portfolio/Weapon
 ```
 
+진행 내용:
+
+```text
+UCWeaponComponent
+-> spawned WeaponActor owner로서 EndPlay cleanup 추가
+-> runtime weapon state(collision / trail) 정리 후 spawned actor Destroy
+
+ACWeaponActor
+-> collision delegate bind/cache는 BeginPlay에서 유지
+-> EndPlay / runtime state clear 경로에서 collision window와 trail을 명시적으로 정리
+-> EndPlay에서 collision delegate unbind / collision cache clear
+-> injected owner/source reference clear
+```
+
+후속 보완 대상:
+
+```text
+Actor / Component teardown cleanup
+-> EndPlay delegate / timer / spawned actor cleanup 기준은 별도 refactor에서 처리
+-> WeaponActor collision cleanup과 gameplay collision close API 분리 여부는 후속 작업으로 분리
+```
+
 ### 5. Lookup 사용처 분류
 
 대상 API:
@@ -206,6 +227,25 @@ runtime lookup 유지
 cache 필요
 safe return / reject 필요
 후속 브랜치 분리
+```
+
+진행 내용:
+
+```text
+GetComponentByClass
+-> Source/Portfolio C++ 코드 기준 잔여 사용처 없음
+
+FindComponentByClass
+-> Notify base/helper, AnimInstance cache, AI owner component query, CombatSignal target resolve처럼 runtime context가 필요한 경로에만 유지
+
+Component order
+-> Character reference 구성/주입 계열은 canonical component order를 기준으로 정렬
+-> runtime gameplay flow는 domain 처리 순서를 우선
+
+현재 예외
+-> ACEnemy는 DefenseComponent를 아직 보유하지 않음
+-> 적 방어 기능이 필요해지는 시점에 추가
+-> CombatSignalTarget의 Defense reference는 현재 optional dependency로 유지
 ```
 
 ---

--- a/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
@@ -130,6 +130,16 @@ Source/Portfolio/Animation
 AnimInstance 관련 파일
 ```
 
+진행 내용:
+
+```text
+UCAnimInstance
+-> TryGetPawnOwner 기반 owner resolve 유지
+-> component cache / clear / bind / unbind helper로 분리
+-> movement / state parameter refresh helper로 분리
+-> GetComponentByClass 사용을 FindComponentByClass<T>()로 정리
+```
+
 ### 3. AI BehaviorTree lookup
 
 검토 기준:

--- a/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
@@ -156,6 +156,19 @@ Service / Decorator / Task의 역할에 따라 lookup 실패 처리를 분리한
 Source/Portfolio/AI
 ```
 
+진행 내용:
+
+```text
+BT Service / Task
+-> AI owner / Pawn runtime query 유지
+-> 같은 함수 안의 반복 GetAIOwner()->GetPawn() 패턴을 local variable로 정리
+-> owner component 조회는 FindComponentByClass<T>()로 통일
+
+BT Decorator
+-> Blackboard / Pawn / component 조건 조회 유지
+-> 조회 실패 시 false 반환 정책 유지
+```
+
 ### 4. WeaponActor runtime reference
 
 검토 기준:

--- a/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,216 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P30: Runtime Component 조회 정책**
+
+## 날짜
+
+**2026.06.29**
+
+## 상태
+
+- [ ] 진행 중
+
+---
+
+## 브랜치
+
+- `refactor/runtime-component-lookup-policy`
+
+---
+
+## 커밋
+
+```text
+TBD
+```
+
+---
+
+## 요약
+
+이번 PR은 P29에서 정리한 Character component reference DI 이후에도 남는 runtime lookup 경로를 분류하고, 유지 / 수정 / 문서화 기준을 정리한다.
+
+핵심 목표는 모든 lookup 제거가 아니다.
+
+```text
+Character-owned required component
+-> DI / injected reference
+
+runtime target / external actor
+-> request 시점 lookup 유지
+
+AnimInstance owner / mesh-bound reference
+-> animation lifecycle 기준 cache
+
+AI Blackboard / BehaviorTree state
+-> runtime query 유지
+```
+
+---
+
+## 변경 배경
+
+P29에서 Character가 소유한 component reference는 다음 흐름으로 정리했다.
+
+```text
+RecoverReferences
+-> BuildReferences
+-> InjectReferences
+-> InitializeReferences
+-> ValidateRequiredComponentReferences
+```
+
+하지만 프로젝트에는 다음처럼 runtime lookup이 자연스러운 영역이 남아 있다.
+
+```text
+- Notify / NotifyState routing
+- AnimInstance owner / movement component cache
+- AI BT Service / Decorator / Task의 Blackboard / Pawn / component query
+- CombatSignal dynamic target resolve
+- WeaponActor overlap target 해석
+```
+
+이번 PR은 이 영역을 “전부 DI로 바꾸는 작업”이 아니라, lookup이 필요한 이유와 실패 처리 기준을 명확히 하는 작업이다.
+
+---
+
+## 작업 범위
+
+### 1. Notify / NotifyState routing
+
+검토 기준:
+
+```text
+Notify는 timing trigger 이상을 알지 않는다.
+Notify는 domain 판단을 하지 않는다.
+Notify는 필요한 경우 component routing entry까지만 호출한다.
+```
+
+검토 대상:
+
+```text
+Source/Portfolio/Notify
+```
+
+### 2. AnimInstance reference / cache
+
+검토 기준:
+
+```text
+AnimInstance는 ActorComponent DI 흐름과 다르다.
+TryGetPawnOwner() 기반 owner 확인은 animation lifecycle에 맞는 runtime lookup이다.
+NativeUpdateAnimation에서는 invalid owner / component 상황을 safe return으로 처리한다.
+```
+
+검토 대상:
+
+```text
+Source/Portfolio/Animation
+AnimInstance 관련 파일
+```
+
+### 3. AI BehaviorTree lookup
+
+검토 기준:
+
+```text
+Blackboard value 조회는 runtime query로 유지한다.
+Service / Decorator / Task의 역할에 따라 lookup 실패 처리를 분리한다.
+반복 lookup은 필요한 경우 local variable 또는 cache 기준을 둔다.
+```
+
+검토 대상:
+
+```text
+Source/Portfolio/AI
+```
+
+### 4. WeaponActor runtime reference
+
+검토 기준:
+
+```text
+WeaponActor는 Character component가 아니라 runtime actor다.
+Owner / CombatSignalSource는 WeaponComponent가 생성 직후 주입한다.
+Overlap target은 event payload에서 해석한다.
+```
+
+검토 대상:
+
+```text
+Source/Portfolio/Weapon
+```
+
+### 5. Lookup 사용처 분류
+
+대상 API:
+
+```text
+FindComponentByClass
+GetComponentByClass
+TryGetPawnOwner
+GetOwner
+GetController
+Blackboard GetValueAs...
+```
+
+분류:
+
+```text
+DI 대상
+runtime lookup 유지
+cache 필요
+safe return / reject 필요
+후속 브랜치 분리
+```
+
+---
+
+## 주요 파일
+
+```text
+Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+Docs/04_Pull_Request/00_Pull_Request_Index.md
+```
+
+코드 파일은 실제 검토 후 필요한 범위만 추가한다.
+
+---
+
+## 검증 계획
+
+```text
+- rg 기반 lookup 사용처 전수 스캔
+- Notify / AnimInstance / AI / WeaponActor 경로별 코드 확인
+- 변경이 발생한 경우 Unreal C++ build
+- PIE에서 기본 combat loop smoke test
+```
+
+---
+
+## 관련 문서
+
+```text
+Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+Docs/06_notes/N10_Component_Reference_Validation_Policy_Note.md
+Docs/06_notes/N11_Unreal_Blueprint_Native_Component_Reference_Mismatch_Note.md
+Docs/02_Bug_Report/B14_UE5_Portfolio_Bug_Report.md
+```
+
+---
+
+## 제외 범위
+
+```text
+- Blink 실제 기능 구현
+- Repulse 실제 기능 구현
+- ResultOut 구조 선행 일반화
+- UE TakeDamage route 제거
+- GAS 도입
+- BehaviorTree 전체 재설계
+- AnimBP 구조 재작성
+```

--- a/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
@@ -94,6 +94,25 @@ Notify는 필요한 경우 component routing entry까지만 호출한다.
 Source/Portfolio/Notify
 ```
 
+진행 내용:
+
+```text
+Action Notify
+-> 기존 ActionBase routing 유지
+
+Reaction Feedback Notify
+-> ReactionBase / ReactionStateBase 추가
+-> UCReactionComponent notify routing API 호출로 정리
+
+Health State Notify
+-> HealthBase 추가
+-> UCHealthComponent notify routing API 호출로 정리
+
+Collision Window Notify
+-> WeaponActor 직접 resolve 제거
+-> UCActionComponent -> UCWeaponComponent -> ACWeaponActor 순서로 routing 정리
+```
+
 ### 2. AnimInstance reference / cache
 
 검토 기준:

--- a/Docs/06_notes/N08_Code_Quality_Cleanup_Plan_Note.md
+++ b/Docs/06_notes/N08_Code_Quality_Cleanup_Plan_Note.md
@@ -107,6 +107,10 @@
 
 세부 판단 기준은 `N10. Component Reference Validation Policy Note`를 따른다.
 
+단, 모든 lookup이 제거 대상은 아니다. Notify, AnimInstance, AI BehaviorTree, CombatSignal target resolve처럼 runtime context에 따라 대상이 달라지는 조회는 DI와 분리해서 판단한다.
+
+runtime lookup 분류 기준은 `N12. Runtime Component Lookup Policy Note`를 따른다.
+
 ### 2.3 Debug log / print 함수
 
 `FLog::Log`, `Print...Info`, `SummaryInfo` 계열 함수가 많다.
@@ -183,6 +187,7 @@ AI BT Service 다수가 `0.1s`, `0.2s` interval로 동작한다.
 P0:
   - Unreal Reference Safety
   - Component Reference / Initialization Policy
+  - Runtime Component Lookup Policy
   - Debug / Logging Policy
   - TODO / 미완성 신호 정리
   - Hardcoded tuning value 1차 정리

--- a/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+++ b/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
@@ -119,8 +119,9 @@ Notify는 montage timeline의 timing trigger다.
 정책:
 
 ```text
-Notify는 domain component를 직접 찾지 않는다.
-Notify는 owner actor / mesh context에서 routing entry만 찾는다.
+Notify는 domain 처리를 직접 수행하지 않는다.
+Notify base/helper는 owner actor / mesh context에서 routing component를 찾을 수 있다.
+Notify 본문은 필요한 경우 component routing entry까지만 호출한다.
 실제 판단과 실행은 component / active executor로 넘긴다.
 ```
 
@@ -146,6 +147,27 @@ Notify는 owner actor / mesh context에서 routing entry만 찾는다.
 
 ```text
 Source/Portfolio/Notify
+```
+
+현재 정리 기준:
+
+```text
+Action Notify
+-> UCAnimNotify_ActionBase / UCAnimNotifyState_ActionBase
+-> UCActionComponent notify routing API
+
+Reaction Notify
+-> UCAnimNotify_ReactionBase / UCAnimNotifyState_ReactionBase
+-> UCReactionComponent notify routing API
+
+Health State Notify
+-> UCAnimNotify_HealthBase
+-> UCHealthComponent notify routing API
+
+Collision Window Notify
+-> UCActionComponent collision window routing API
+-> UCWeaponComponent
+-> ACWeaponActor
 ```
 
 ---

--- a/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+++ b/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
@@ -195,6 +195,28 @@ cache는 owner 변경 가능성을 고려해 갱신 조건을 둔다.
 
 AnimInstance의 component cache는 Character DI가 아니다.
 
+현재 정리 기준:
+
+```text
+NativeInitializeAnimation
+-> 기존 delegate 해제
+-> cached reference 초기화
+-> TryGetPawnOwner 기반 owner / component cache
+-> component event binding
+-> 초기 state parameter 갱신
+
+NativeUpdateAnimation
+-> cached owner가 invalid면 safe return
+-> Movement parameter 갱신
+-> State / Guard parameter 갱신
+
+NativeUninitializeAnimation
+-> delegate 해제
+-> cached reference 초기화
+```
+
+`FindComponentByClass<T>()`는 AnimInstance가 mesh owner에서 animation parameter source를 찾기 위한 runtime cache 방식으로 사용한다.
+
 ---
 
 ## 5. AI BT Service / Decorator / Task

--- a/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+++ b/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
@@ -1,0 +1,276 @@
+# N12. Runtime Component Lookup Policy Note
+
+## 목적
+
+P29에서 Character가 소유한 component reference는 owner 쪽에서 구성하고 주입하는 흐름으로 정리했다.
+
+하지만 프로젝트에는 여전히 runtime에서 component나 actor를 조회해야 하는 경로가 남아 있다.
+
+이 문서는 다음 질문에 대한 기준을 고정한다.
+
+```text
+이 참조는 Character DI 대상인가?
+아니면 runtime lookup으로 남겨야 하는가?
+조회 결과를 cache해야 하는가?
+조회 실패 시 reject / ignore / safe return 중 무엇이 맞는가?
+```
+
+---
+
+## 핵심 결론
+
+모든 `FindComponentByClass`, `GetOwner`, `TryGetPawnOwner`, Blackboard 조회를 제거하는 것이 목표가 아니다.
+
+참조 확보 방식은 객체의 소유권과 lifecycle에 따라 나눈다.
+
+```text
+Character-owned required component
+-> Character가 BuildReferences / InjectReferences로 주입
+
+Runtime target / external actor
+-> request 시점에 조회
+
+Animation owner / mesh-bound object
+-> AnimInstance lifecycle에서 owner를 확인하고 cache
+
+AI perception / blackboard state
+-> AIController / Blackboard 기준 runtime query 유지
+
+Blueprint stale native component reference recovery
+-> 예외적 방어선으로만 FindComponentByClass 사용
+```
+
+---
+
+## 1. Character Component DI 대상
+
+다음 조건을 만족하면 DI 대상이다.
+
+```text
+- Character가 생성자에서 만들거나 소유하는 component다.
+- 동일 Character 내부 sibling component가 반복적으로 참조한다.
+- gameplay 실행에 필수 dependency다.
+- 참조 누락이 구조 오류에 가깝다.
+```
+
+예시:
+
+```text
+MovementComponent
+WeaponComponent
+StateComponent
+HealthComponent
+DefenseComponent
+CombatSignalSourceComponent
+CombatSignalTargetComponent
+ActionComponent
+ReactionComponent
+FeedbackComponent
+```
+
+정책:
+
+```text
+ACPlayer / ACEnemy
+-> RecoverReferences
+-> BuildReferences
+-> InjectReferences
+-> component InitializeReferences
+-> ValidateRequiredComponentReferences
+```
+
+component 내부에서 sibling component를 다시 `FindComponentByClass`로 찾지 않는다.
+
+---
+
+## 2. Runtime Lookup 유지 대상
+
+다음 조건이면 runtime lookup을 허용한다.
+
+```text
+- 대상이 현재 Character의 고정 component가 아니다.
+- request / overlap / AI 판단 시점마다 target이 달라질 수 있다.
+- 외부 actor 또는 외부 actor의 component를 resolve하는 흐름이다.
+- lookup 자체가 domain policy의 일부다.
+```
+
+예시:
+
+```text
+CombatSignal target actor에서 target component resolve
+AIController에서 Blackboard target actor resolve
+DamageCauser owner / instigator fallback resolve
+Overlap OtherActor / OtherComp 기반 hit context 구성
+```
+
+정책:
+
+```text
+runtime target lookup은 DI로 바꾸지 않는다.
+lookup 실패는 crash가 아니라 reject / ignore / no-op으로 처리한다.
+```
+
+---
+
+## 3. Notify / NotifyState
+
+Notify는 montage timeline의 timing trigger다.
+
+정책:
+
+```text
+Notify는 domain component를 직접 찾지 않는다.
+Notify는 owner actor / mesh context에서 routing entry만 찾는다.
+실제 판단과 실행은 component / active executor로 넘긴다.
+```
+
+허용되는 책임:
+
+```text
+- timing key 전달
+- command enum 전달
+- window begin / end 전달
+- cue tag 전달
+```
+
+피해야 할 책임:
+
+```text
+- target resolve
+- combat signal build / send
+- action / reaction policy 판단
+- damage / feedback / AI domain 처리
+```
+
+검토 대상:
+
+```text
+Source/Portfolio/Notify
+```
+
+---
+
+## 4. AnimInstance
+
+AnimInstance는 ActorComponent DI 흐름과 다르다.
+
+이유:
+
+```text
+- AnimInstance는 SkeletalMesh / AnimBP lifecycle에 묶인다.
+- owner pawn은 TryGetPawnOwner()로 얻는 것이 일반적이다.
+- mesh 변경, preview, editor context에서 owner가 없을 수 있다.
+```
+
+정책:
+
+```text
+NativeInitializeAnimation / NativeBeginPlay 계열에서 owner를 확인한다.
+NativeUpdateAnimation에서는 invalid owner / component일 때 safe return한다.
+반복 조회가 부담되거나 의미가 고정되면 cache한다.
+cache는 owner 변경 가능성을 고려해 갱신 조건을 둔다.
+```
+
+AnimInstance의 component cache는 Character DI가 아니다.
+
+---
+
+## 5. AI BT Service / Decorator / Task
+
+AI BehaviorTree 계층은 runtime decision layer다.
+
+정책:
+
+```text
+Blackboard value 조회는 runtime query로 유지한다.
+AIController / Pawn / target actor 조회도 runtime query로 유지한다.
+다만 같은 service tick 안에서 반복되는 component lookup은 local variable로 줄인다.
+필수 key / component 누락은 reject / fail / clear blackboard 중 하나로 명시한다.
+```
+
+구분:
+
+```text
+Service
+-> perception / distance / range / state snapshot 갱신
+
+Decorator
+-> 조건 판정
+
+Task
+-> 실행 요청 전달
+```
+
+AI component lookup을 무조건 Character DI로 밀어 넣지 않는다.
+
+---
+
+## 6. WeaponActor
+
+WeaponActor는 Character component가 아니라 runtime actor다.
+
+정책:
+
+```text
+WeaponComponent가 생성한 뒤 필요한 owner reference를 InitializeReferences로 전달한다.
+WeaponActor는 BeginPlay에서 owner component를 다시 찾지 않는다.
+Overlap target / hit component는 event payload에서 해석한다.
+```
+
+검토 기준:
+
+```text
+OwnerCharacter_Injected
+CombatSignalSourceComp_Injected
+Overlap OtherActor / OtherComp
+Socket attach target
+```
+
+---
+
+## 7. 실패 처리 기준
+
+```text
+필수 owner / component 누락
+-> InitializeReferences에서 ensure + validation log
+
+public request entry에서 필수 component 누락
+-> reject / false / safe return
+
+runtime target lookup 실패
+-> request reject / ignored / no-op
+
+Blueprint stale native component reference
+-> recovery log 출력 후 actual component list 기준 복구
+```
+
+`ensure`는 진단 도구이지 런타임 흐름을 멈추는 정책이 아니다.
+
+따라서 public request path에서는 필요한 경우 별도의 `IsValid` gate가 필요하다.
+
+---
+
+## 8. 이번 브랜치 검토 순서
+
+```text
+1. Notify / NotifyState component routing 확인
+2. AnimInstance owner / component cache 확인
+3. AI BT Service / Decorator / Task lookup 확인
+4. WeaponActor runtime reference 확인
+5. FindComponentByClass / TryGetPawnOwner / GetOwner / Blackboard 조회 사용처 분류
+6. 필요한 코드 수정만 반영
+7. 문서와 PR 기록 업데이트
+```
+
+---
+
+## 완료 기준
+
+```text
+- Character-owned component lookup과 runtime target lookup이 구분되어 있다.
+- Notify가 domain component를 직접 찾는 흐름이 남아 있다면 수정하거나 사유를 기록했다.
+- AnimInstance cache는 ActorComponent DI와 다른 기준으로 설명되어 있다.
+- AI BehaviorTree lookup은 Service / Decorator / Task 역할에 맞게 분류되어 있다.
+- 남겨 둔 lookup은 왜 유지되는지 설명 가능하다.
+- 변경 후 Unreal C++ build가 성공한다.
+```

--- a/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+++ b/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
@@ -247,6 +247,24 @@ Task
 
 AI component lookup을 무조건 Character DI로 밀어 넣지 않는다.
 
+현재 정리 기준:
+
+```text
+BT Service
+-> OwnerComp에서 Blackboard / AI owner / Pawn을 runtime query로 얻는다.
+-> 같은 tick 안에서는 AI owner / Pawn을 local variable로 보관한다.
+-> owner component 조회가 필요하면 FindComponentByClass<T>()를 사용한다.
+-> 조회 실패 시 관련 blackboard context를 clear한다.
+
+BT Decorator
+-> Blackboard / Pawn / component를 읽어 조건만 반환한다.
+-> 조회 실패는 false로 처리한다.
+
+BT Task
+-> Blackboard / AI owner / Pawn을 runtime query로 얻는다.
+-> 실행 필수 값이 없으면 Failed를 반환한다.
+```
+
 ---
 
 ## 6. WeaponActor

--- a/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+++ b/Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
@@ -81,6 +81,70 @@ ACPlayer / ACEnemy
 
 component 내부에서 sibling component를 다시 `FindComponentByClass`로 찾지 않는다.
 
+### Component Order
+
+Character-owned component를 나열할 때는 다음 순서를 기본값으로 둔다.
+
+```text
+OwnerCharacter
+
+Movement
+Weapon
+State
+Health
+Defense
+ObservableOverlay
+
+CombatSignalSource
+CombatSignalTarget
+
+ActionOrchestrator
+ReactionOrchestrator
+
+Action
+Reaction
+
+HitFeedback
+ActionFeedback
+ReactionFeedback
+```
+
+이 순서는 다음 영역에 우선 적용한다.
+
+```text
+Character field declaration
+Character constructor CreateDefaultSubobject
+RecoverReferences
+BuildReferences
+InjectReferences
+FCharacterComponentReferences
+InitializeReferences 내부 대입
+ValidateRequiredReferences 배열
+component getter 나열
+```
+
+단, runtime gameplay flow는 component order보다 domain 처리 순서를 우선한다.
+
+예외:
+
+```text
+ACEnemy
+-> 현재 DefenseComponent를 보유하지 않는다.
+-> 적 방어 기능이 필요해지는 시점에 추가한다.
+-> CombatSignalTarget의 Defense reference는 현재 optional dependency로 취급한다.
+
+WeaponActor
+-> Character-owned component가 아니라 WeaponComponent가 spawn하는 runtime actor다.
+-> Character component order 대상이 아니다.
+
+AnimInstance
+-> ActorComponent DI가 아니라 TryGetPawnOwner 기반 animation lifecycle cache다.
+
+Notify / AI BT / CombatSignal target resolve
+-> runtime context에서 owner / target / Blackboard / payload를 해석하는 경로다.
+-> Character component order를 강제하지 않는다.
+```
+
 ---
 
 ## 2. Runtime Lookup 유지 대상
@@ -286,6 +350,31 @@ OwnerCharacter_Injected
 CombatSignalSourceComp_Injected
 Overlap OtherActor / OtherComp
 Socket attach target
+```
+
+현재 정리 기준:
+
+```text
+WeaponComponent
+-> WeaponActor를 runtime actor로 spawn한다.
+-> spawn 직후 OwnerCharacter / CombatSignalSource reference를 주입한다.
+-> EndPlay에서 WeaponActor runtime state(collision / trail)를 정리하고 spawned actor를 Destroy한다.
+
+WeaponActor
+-> BeginPlay에서 collision component delegate를 bind하고 cache한다.
+-> EndPlay / runtime state clear 경로에서 collision window와 trail을 명시적으로 닫는다.
+-> EndPlay에서 collision delegate를 unbind하고 collision cache / injected reference를 비운다.
+-> owner component를 다시 lookup하지 않고 injected reference를 사용한다.
+-> overlap target은 event payload의 OtherActor / OtherComp 기준으로 해석한다.
+```
+
+후속 보완 대상:
+
+```text
+Actor / Component teardown cleanup
+-> EndPlay에서 delegate / timer / spawned actor / runtime cache 정리 기준을 별도 점검한다.
+-> gameplay cleanup API와 teardown-safe cleanup API를 분리할 필요가 있는지 확인한다.
+-> WeaponActor collision window close와 EndPlay cleanup은 별도 refactor에서 다룬다.
 ```
 
 ---

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -29,7 +29,8 @@ void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, ui
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return;
 
-	APawn* ownerPawn = OwnerComp.GetAIOwner() ? OwnerComp.GetAIOwner()->GetPawn() : nullptr;
+	const AAIController* aiOwner = OwnerComp.GetAIOwner();
+	APawn* ownerPawn = IsValid(aiOwner) ? aiOwner->GetPawn() : nullptr;
 	if (!IsValid(ownerPawn))
 	{
 		ClearDeadContext(blackboardComp);
@@ -204,7 +205,7 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeReactionContext(APawn* I
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 
-	UCReactionComponent* reactionComp = Cast<UCReactionComponent>(InOwnerPawn->GetComponentByClass(UCReactionComponent::StaticClass()));
+	UCReactionComponent* reactionComp = InOwnerPawn->FindComponentByClass<UCReactionComponent>();
 	if (!IsValid(reactionComp)) return EContextBuildResult::NoData;
 
 	InOutAIContext.bIsActiveReaction = reactionComp->IsActive();
@@ -216,7 +217,7 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeDeadContext(APawn* InOwn
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 
-	UCHealthComponent* healthComp = Cast<UCHealthComponent>(InOwnerPawn->GetComponentByClass(UCHealthComponent::StaticClass()));
+	UCHealthComponent* healthComp = InOwnerPawn->FindComponentByClass<UCHealthComponent>();
 	if (!IsValid(healthComp)) return EContextBuildResult::NoData;
 
 	InOutAIContext.DeadState = healthComp->GetDeadState();

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -24,7 +24,8 @@ void UCBTService_UpdateEngageContext::TickNode(UBehaviorTreeComponent& OwnerComp
 	UBlackboardComponent* blackBoardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackBoardComp)) return;
 
-	APawn* ownerPawn = OwnerComp.GetAIOwner() ? OwnerComp.GetAIOwner()->GetPawn() : nullptr;
+	const AAIController* aiOwner = OwnerComp.GetAIOwner();
+	APawn* ownerPawn = IsValid(aiOwner) ? aiOwner->GetPawn() : nullptr;
 	if (!IsValid(ownerPawn))
 	{
 		ClearEngageContext(blackBoardComp);

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdatePatrolContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdatePatrolContext.cpp
@@ -25,7 +25,8 @@ void UCBTService_UpdatePatrolContext::TickNode(UBehaviorTreeComponent& OwnerComp
 	UBlackboardComponent* blackBoardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackBoardComp)) return;
 
-	APawn* ownerPawn = OwnerComp.GetAIOwner() ? OwnerComp.GetAIOwner()->GetPawn() : nullptr;
+	const AAIController* aiOwner = OwnerComp.GetAIOwner();
+	APawn* ownerPawn = IsValid(aiOwner) ? aiOwner->GetPawn() : nullptr;
 	if (!IsValid(ownerPawn))
 	{
 		ClearPatrolContext(blackBoardComp);

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
@@ -20,7 +20,8 @@ EBTNodeResult::Type UCBTTask_SelectPatrolPoint::ExecuteTask(UBehaviorTreeCompone
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return EBTNodeResult::Failed;
 
-	APawn* ownerPawn = OwnerComp.GetAIOwner() ? OwnerComp.GetAIOwner()->GetPawn() : nullptr;
+	const AAIController* aiOwner = OwnerComp.GetAIOwner();
+	APawn* ownerPawn = IsValid(aiOwner) ? aiOwner->GetPawn() : nullptr;
 	if (!IsValid(ownerPawn)) return EBTNodeResult::Failed;
 
 	bool bUsePatrol = blackboardComp->GetValueAsBool(CAIKey::Patrol::bUsePatrol);

--- a/Source/Portfolio/Character/CAnimInstance.cpp
+++ b/Source/Portfolio/Character/CAnimInstance.cpp
@@ -12,27 +12,19 @@ void UCAnimInstance::NativeInitializeAnimation()
 {
 	Super::NativeInitializeAnimation();
 
-	OwnerCharacter_Cached = Cast<ACharacter>(TryGetPawnOwner());
-	if (!IsValid(OwnerCharacter_Cached)) return;
+	UnbindComponentEvents();
+	ClearCachedReferences();
 
-	MovementComp_Cached = Cast<UCMovementComponent>(OwnerCharacter_Cached->GetComponentByClass(UCMovementComponent::StaticClass()));
-	WeaponComp_Cached = Cast<UCWeaponComponent>(OwnerCharacter_Cached->GetComponentByClass(UCWeaponComponent::StaticClass()));
-	HealthComp_Cached = Cast<UCHealthComponent>(OwnerCharacter_Cached->GetComponentByClass(UCHealthComponent::StaticClass()));
-	DefenseComp_Cached = Cast<UCDefenseComponent>(OwnerCharacter_Cached->GetComponentByClass(UCDefenseComponent::StaticClass()));
+	if (!CacheOwnerAndComponents()) return;
 
-	if (IsValid(WeaponComp_Cached))
-	{
-		WeaponComp_Cached->OnWeaponTypeChanged.AddUniqueDynamic(this, &UCAnimInstance::OnWeaponTypeChanged);
-		CurrentWeaponType = WeaponComp_Cached->GetCurrentWeaponType();
-	}
+	BindComponentEvents();
+	RefreshStateParameters();
 }
 
 void UCAnimInstance::NativeUninitializeAnimation()
 {
-	if (IsValid(WeaponComp_Cached))
-	{
-		WeaponComp_Cached->OnWeaponTypeChanged.RemoveDynamic(this, &UCAnimInstance::OnWeaponTypeChanged);
-	}
+	UnbindComponentEvents();
+	ClearCachedReferences();
 
 	Super::NativeUninitializeAnimation();
 }
@@ -43,11 +35,62 @@ void UCAnimInstance::NativeUpdateAnimation(float DeltaSeconds)
 
 	if (!IsValid(OwnerCharacter_Cached)) return;
 
+	RefreshMovementParameters();
+	RefreshStateParameters();
+}
+
+bool UCAnimInstance::CacheOwnerAndComponents()
+{
+	OwnerCharacter_Cached = Cast<ACharacter>(TryGetPawnOwner());
+	if (!IsValid(OwnerCharacter_Cached)) return false;
+
+	MovementComp_Cached = OwnerCharacter_Cached->FindComponentByClass<UCMovementComponent>();
+	WeaponComp_Cached = OwnerCharacter_Cached->FindComponentByClass<UCWeaponComponent>();
+	HealthComp_Cached = OwnerCharacter_Cached->FindComponentByClass<UCHealthComponent>();
+	DefenseComp_Cached = OwnerCharacter_Cached->FindComponentByClass<UCDefenseComponent>();
+
+	return true;
+}
+
+void UCAnimInstance::ClearCachedReferences()
+{
+	OwnerCharacter_Cached = nullptr;
+	MovementComp_Cached = nullptr;
+	WeaponComp_Cached = nullptr;
+	HealthComp_Cached = nullptr;
+	DefenseComp_Cached = nullptr;
+}
+
+void UCAnimInstance::BindComponentEvents()
+{
+	if (!IsValid(WeaponComp_Cached)) return;
+
+	WeaponComp_Cached->OnWeaponTypeChanged.AddUniqueDynamic(this, &UCAnimInstance::OnWeaponTypeChanged);
+	CurrentWeaponType = WeaponComp_Cached->GetCurrentWeaponType();
+}
+
+void UCAnimInstance::UnbindComponentEvents()
+{
+	if (!IsValid(WeaponComp_Cached)) return;
+
+	WeaponComp_Cached->OnWeaponTypeChanged.RemoveDynamic(this, &UCAnimInstance::OnWeaponTypeChanged);
+}
+
+void UCAnimInstance::RefreshMovementParameters()
+{
 	if (IsValid(MovementComp_Cached))
 	{
 		Speed = MovementComp_Cached->GetCurrentSpeed();
 		Direction = MovementComp_Cached->GetCurrentDirection();
 		bIsInAir = MovementComp_Cached->IsFalling();
+	}
+}
+
+void UCAnimInstance::RefreshStateParameters()
+{
+	if (IsValid(WeaponComp_Cached))
+	{
+		CurrentWeaponType = WeaponComp_Cached->GetCurrentWeaponType();
 	}
 
 	if (IsValid(HealthComp_Cached))

--- a/Source/Portfolio/Character/CAnimInstance.h
+++ b/Source/Portfolio/Character/CAnimInstance.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Animation/AnimInstance.h"
-#include "Type/CweaponStructure.h"
+#include "Type/CWeaponStructure.h"
 #include "CAnimInstance.generated.h"
 
 UCLASS()
@@ -13,13 +13,13 @@ class PORTFOLIO_API UCAnimInstance : public UAnimInstance
 protected:
 	/* === Injection Datas === */
 	UPROPERTY(BlueprintReadOnly, Category = "Movement")
-	float Speed;
+	float Speed = 0.f;
 
 	UPROPERTY(BlueprintReadOnly, Category = "Movement")
-	float Direction;
+	float Direction = 0.f;
 
 	UPROPERTY(BlueprintReadOnly, Category = "Movement")
-	bool bIsInAir;
+	bool bIsInAir = false;
 
 protected:
 	UPROPERTY(BlueprintReadOnly, Category = "State")
@@ -34,24 +34,36 @@ protected:
 private:
 	/* === Cached Objects === */
 	UPROPERTY(Transient)
-	class ACharacter* OwnerCharacter_Cached;
+	class ACharacter* OwnerCharacter_Cached = nullptr;
 
 	UPROPERTY(Transient)
-	class UCMovementComponent* MovementComp_Cached;
+	class UCMovementComponent* MovementComp_Cached = nullptr;
 
 	UPROPERTY(Transient)
-	class UCWeaponComponent* WeaponComp_Cached;
+	class UCWeaponComponent* WeaponComp_Cached = nullptr;
 
 	UPROPERTY(Transient)
-	class UCHealthComponent* HealthComp_Cached;
+	class UCHealthComponent* HealthComp_Cached = nullptr;
 
 	UPROPERTY(Transient)
-	class UCDefenseComponent* DefenseComp_Cached;
+	class UCDefenseComponent* DefenseComp_Cached = nullptr;
 
 public:
 	void NativeInitializeAnimation() override;
 	void NativeUninitializeAnimation() override;
 	void NativeUpdateAnimation(float DeltaSeconds) override;
+
+private:
+	// Reference Cache
+	bool CacheOwnerAndComponents();
+	void ClearCachedReferences();
+	void BindComponentEvents();
+	void UnbindComponentEvents();
+
+private:
+	// Parameter Refresh
+	void RefreshMovementParameters();
+	void RefreshStateParameters();
 
 private:
 	/* === [IN] Custom Delgate Events === */

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -307,6 +307,23 @@ void UCActionComponent::HandleActionFeedbackWindowEnd(FName InTriggerKey)
 	activeExecutor->HandleNotifyFeedback(EActionFeedbackTiming::TriggerWindowEnd, InTriggerKey);
 }
 
+void UCActionComponent::HandleActionCollisionWindowBegin(FName InCollisionName)
+{
+	if (!IsValid(WeaponComp_Injected)) return;
+
+	UCAction* activeExecutor = GetActiveActionExecutor();
+	if (!IsValid(activeExecutor)) return;
+
+	WeaponComp_Injected->OpenCollisionWindow(InCollisionName);
+}
+
+void UCActionComponent::HandleActionCollisionWindowEnd()
+{
+	if (!IsValid(WeaponComp_Injected)) return;
+
+	WeaponComp_Injected->CloseCollisionWindow();
+}
+
 bool UCActionComponent::HandleActionCombatSignalCue(FName InCueTag)
 {
 	if (InCueTag.IsNone()) return false;

--- a/Source/Portfolio/Component/CActionComponent.h
+++ b/Source/Portfolio/Component/CActionComponent.h
@@ -133,6 +133,9 @@ public:
 	void HandleActionFeedbackWindowBegin(FName InTriggerKey);
 	void HandleActionFeedbackWindowEnd(FName InTriggerKey);
 
+	void HandleActionCollisionWindowBegin(FName InCollisionName);
+	void HandleActionCollisionWindowEnd();
+
 	bool HandleActionCombatSignalCue(FName InCueTag);
 
 public:

--- a/Source/Portfolio/Component/CHealthComponent.cpp
+++ b/Source/Portfolio/Component/CHealthComponent.cpp
@@ -212,6 +212,11 @@ void UCHealthComponent::EnterAliveState()
 	ChangeDeadState(EDeadState::Alive);
 }
 
+void UCHealthComponent::HandleDeadStateNotify(EDeadState InDeadState)
+{
+	ChangeDeadState(InDeadState);
+}
+
 void UCHealthComponent::UpdateDeadState()
 {
 	bool bDeadFlag = (CurrentHP <= 0.f);

--- a/Source/Portfolio/Component/CHealthComponent.h
+++ b/Source/Portfolio/Component/CHealthComponent.h
@@ -88,6 +88,10 @@ public:
 	void EnterDeadState();
 	void EnterAliveState();
 
+public:
+	// Notify Routing
+	void HandleDeadStateNotify(EDeadState InDeadState);
+
 private:
 	void UpdateDeadState();
 	void ChangeDeadState(EDeadState InNewDeadState);

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -42,6 +42,19 @@ bool UCWeaponComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+void UCWeaponComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	ClearRuntimeWeaponState();
+
+	if (IsValid(WeaponActor))
+	{
+		WeaponActor->Destroy();
+		WeaponActor = nullptr;
+	}
+
+	Super::EndPlay(EndPlayReason);
+}
+
 ACWeaponActor* UCWeaponComponent::GetWeaponActor()
 {
 	return IsValid(WeaponActor) ? WeaponActor : nullptr;
@@ -107,6 +120,7 @@ void UCWeaponComponent::ClearRuntimeWeaponState()
 	if (IsValid(WeaponActor))
 	{
 		WeaponActor->CollisionDisabled();
+		WeaponActor->ToggleTrailActive(false);
 	}
 }
 

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -110,6 +110,20 @@ void UCWeaponComponent::ClearRuntimeWeaponState()
 	}
 }
 
+void UCWeaponComponent::OpenCollisionWindow(FName InCollisionName)
+{
+	if (!IsValid(WeaponActor)) return;
+
+	WeaponActor->CollisionEnabled(InCollisionName);
+}
+
+void UCWeaponComponent::CloseCollisionWindow()
+{
+	if (!IsValid(WeaponActor)) return;
+
+	WeaponActor->CollisionDisabled();
+}
+
 void UCWeaponComponent::ChangeWeaponType(EWeaponType InNewWeaponType)
 {
 	if (!IsValid(OwnerCharacter_Injected)) return;

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -77,6 +77,10 @@ public:
 	void ClearContext();
 	void ClearRuntimeWeaponState();
 
+public:
+	void OpenCollisionWindow(FName InCollisionName);
+	void CloseCollisionWindow();
+
 private:
 	void ChangeWeaponType(EWeaponType InNewWeaponType);
 

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -53,6 +53,10 @@ public:
 private:
 	bool ValidateRequiredComponentReferences() const;
 
+protected:
+	// Lifecycle
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
 public:
 	/* === Check / Query === */
 	FORCEINLINE bool CheckCurrentWeaponType(EWeaponType InNewWeaponType) const { return CurrentWeaponType == InNewWeaponType; }

--- a/Source/Portfolio/Notify/CAnimNotifyState_Collision.cpp
+++ b/Source/Portfolio/Notify/CAnimNotifyState_Collision.cpp
@@ -1,10 +1,7 @@
 #include "Notify/CAnimNotifyState_Collision.h"
 #include "ProjectGlobal.h"
 
-#include "GameFramework/Character.h"
-
-#include "Component/CWeaponComponent.h"
-#include "Weapon/CWeaponActor.h"
+#include "Component/CActionComponent.h"
 
 UCAnimNotifyState_Collision::UCAnimNotifyState_Collision()
 {
@@ -19,31 +16,18 @@ void UCAnimNotifyState_Collision::NotifyBegin(USkeletalMeshComponent* MeshComp, 
 {
 	Super::NotifyBegin(MeshComp, Animation, TotalDuration, EventReference);
 
-	ACWeaponActor* weaponActor = GetWeaponActor(MeshComp);
-	if (!IsValid(weaponActor)) return;
+	UCActionComponent* actionComp = GetActionComponent(MeshComp);
+	if (!CanProcessActionNotify(actionComp)) return;
 
-	weaponActor->CollisionEnabled(CollisionName);
+	actionComp->HandleActionCollisionWindowBegin(CollisionName);
 }
 
 void UCAnimNotifyState_Collision::NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference)
 {
 	Super::NotifyEnd(MeshComp, Animation, EventReference);
 
-	ACWeaponActor* weaponActor = GetWeaponActor(MeshComp);
-	if (!IsValid(weaponActor)) return;
+	UCActionComponent* actionComp = GetActionComponent(MeshComp);
+	if (!IsValid(actionComp)) return;
 
-	weaponActor->CollisionDisabled();
-}
-
-ACWeaponActor* UCAnimNotifyState_Collision::GetWeaponActor(USkeletalMeshComponent* InMeshComp) const
-{
-	if (!IsValid(InMeshComp)) return nullptr;
-
-	ACharacter* ownerCharacter = Cast<ACharacter>(InMeshComp->GetOwner());
-	if (!IsValid(ownerCharacter)) return nullptr;
-
-	UCWeaponComponent* weaponComp = ownerCharacter->FindComponentByClass<UCWeaponComponent>();
-	if (!IsValid(weaponComp)) return nullptr;
-
-	return weaponComp->GetWeaponActor();
+	actionComp->HandleActionCollisionWindowEnd();
 }

--- a/Source/Portfolio/Notify/CAnimNotifyState_Collision.cpp
+++ b/Source/Portfolio/Notify/CAnimNotifyState_Collision.cpp
@@ -27,7 +27,7 @@ void UCAnimNotifyState_Collision::NotifyEnd(USkeletalMeshComponent* MeshComp, UA
 	Super::NotifyEnd(MeshComp, Animation, EventReference);
 
 	UCActionComponent* actionComp = GetActionComponent(MeshComp);
-	if (!IsValid(actionComp)) return;
+	if (!CanProcessActionNotify(actionComp)) return;
 
 	actionComp->HandleActionCollisionWindowEnd();
 }

--- a/Source/Portfolio/Notify/CAnimNotifyState_Collision.h
+++ b/Source/Portfolio/Notify/CAnimNotifyState_Collision.h
@@ -22,7 +22,4 @@ public:
 public:
 	void NotifyBegin(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, float TotalDuration, const FAnimNotifyEventReference& EventReference) override;
 	void NotifyEnd(USkeletalMeshComponent* MeshComp, UAnimSequenceBase* Animation, const FAnimNotifyEventReference& EventReference) override;
-
-private:
-	class ACWeaponActor* GetWeaponActor(USkeletalMeshComponent* InMeshComp) const;
 };

--- a/Source/Portfolio/Notify/CAnimNotifyState_ReactionBase.cpp
+++ b/Source/Portfolio/Notify/CAnimNotifyState_ReactionBase.cpp
@@ -1,0 +1,38 @@
+#include "Notify/CAnimNotifyState_ReactionBase.h"
+#include "ProjectGlobal.h"
+
+#include "GameFramework/Character.h"
+
+#include "Component/CReactionComponent.h"
+
+UCAnimNotifyState_ReactionBase::UCAnimNotifyState_ReactionBase()
+{
+}
+
+bool UCAnimNotifyState_ReactionBase::CanProcessReactionNotify(const UCReactionComponent* InReactionComp) const
+{
+	if (!IsValid(InReactionComp)) return false;
+	if (!InReactionComp->IsActive()) return false;
+
+	if (TriggerReactionType == EReactionType::None || TriggerReactionType == EReactionType::Max)
+	{
+		FLog::Log(TEXT("[AnimNotifyState_ReactionBase] Invalid TriggerReactionType."));
+		return false;
+	}
+
+	const EReactionType reactionType = InReactionComp->GetActiveReactionType();
+
+	if (TriggerReactionType != EReactionType::All && reactionType != TriggerReactionType) return false;
+
+	return true;
+}
+
+UCReactionComponent* UCAnimNotifyState_ReactionBase::GetReactionComponent(USkeletalMeshComponent* InMeshComp) const
+{
+	if (!IsValid(InMeshComp)) return nullptr;
+
+	ACharacter* ownerCharacter = Cast<ACharacter>(InMeshComp->GetOwner());
+	if (!IsValid(ownerCharacter)) return nullptr;
+
+	return ownerCharacter->FindComponentByClass<UCReactionComponent>();
+}

--- a/Source/Portfolio/Notify/CAnimNotifyState_ReactionBase.h
+++ b/Source/Portfolio/Notify/CAnimNotifyState_ReactionBase.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Notify/CAnimNotifyState.h"
+#include "Type/CWeaponStructure.h"
+#include "CAnimNotifyState_ReactionBase.generated.h"
+
+UCLASS(Abstract)
+class PORTFOLIO_API UCAnimNotifyState_ReactionBase : public UCAnimNotifyState
+{
+	GENERATED_BODY()
+
+public:
+	UCAnimNotifyState_ReactionBase();
+
+protected:
+	UPROPERTY(EditAnywhere, Category = "Trigger")
+	EReactionType TriggerReactionType = EReactionType::All;
+
+protected:
+	bool CanProcessReactionNotify(const class UCReactionComponent* InReactionComp) const;
+
+protected:
+	class UCReactionComponent* GetReactionComponent(USkeletalMeshComponent* InMeshComp) const;
+};

--- a/Source/Portfolio/Notify/CAnimNotifyState_ReactionFeedback.cpp
+++ b/Source/Portfolio/Notify/CAnimNotifyState_ReactionFeedback.cpp
@@ -1,8 +1,6 @@
 #include "Notify/CAnimNotifyState_ReactionFeedback.h"
 #include "ProjectGlobal.h"
 
-#include "GameFramework/Character.h"
-
 #include "Component/CReactionComponent.h"
 
 UCAnimNotifyState_ReactionFeedback::UCAnimNotifyState_ReactionFeedback()
@@ -18,13 +16,8 @@ void UCAnimNotifyState_ReactionFeedback::NotifyBegin(USkeletalMeshComponent* Mes
 {
 	Super::NotifyBegin(MeshComp, Animation, TotalDuration, EventReference);
 
-	if (!IsValid(MeshComp)) return;
-
-	ACharacter* ownerCharacter = Cast<ACharacter>(MeshComp->GetOwner());
-	if (!IsValid(ownerCharacter)) return;
-
-	UCReactionComponent* reactionComp = ownerCharacter->FindComponentByClass<UCReactionComponent>();
-	if (!IsValid(reactionComp)) return;
+	UCReactionComponent* reactionComp = GetReactionComponent(MeshComp);
+	if (!CanProcessReactionNotify(reactionComp)) return;
 
 	reactionComp->HandleReactionFeedbackWindowBegin(TriggerKey);
 }
@@ -33,13 +26,8 @@ void UCAnimNotifyState_ReactionFeedback::NotifyEnd(USkeletalMeshComponent* MeshC
 {
 	Super::NotifyEnd(MeshComp, Animation, EventReference);
 
-	if (!IsValid(MeshComp)) return;
-
-	ACharacter* ownerCharacter = Cast<ACharacter>(MeshComp->GetOwner());
-	if (!IsValid(ownerCharacter)) return;
-
-	UCReactionComponent* reactionComp = ownerCharacter->FindComponentByClass<UCReactionComponent>();
-	if (!IsValid(reactionComp)) return;
+	UCReactionComponent* reactionComp = GetReactionComponent(MeshComp);
+	if (!CanProcessReactionNotify(reactionComp)) return;
 
 	reactionComp->HandleReactionFeedbackWindowEnd(TriggerKey);
 }

--- a/Source/Portfolio/Notify/CAnimNotifyState_ReactionFeedback.h
+++ b/Source/Portfolio/Notify/CAnimNotifyState_ReactionFeedback.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Notify/CAnimNotifyState.h"
+#include "Notify/CAnimNotifyState_ReactionBase.h"
 #include "CAnimNotifyState_ReactionFeedback.generated.h"
 
 UCLASS()
-class PORTFOLIO_API UCAnimNotifyState_ReactionFeedback : public UCAnimNotifyState
+class PORTFOLIO_API UCAnimNotifyState_ReactionFeedback : public UCAnimNotifyState_ReactionBase
 {
 	GENERATED_BODY()
 	

--- a/Source/Portfolio/Notify/CAnimNotify_EnterAliveState.cpp
+++ b/Source/Portfolio/Notify/CAnimNotify_EnterAliveState.cpp
@@ -1,7 +1,6 @@
 #include "Notify/CAnimNotify_EnterAliveState.h"
 #include "ProjectGlobal.h"
 
-#include "GameFramework/Actor.h"
 #include "Component/CHealthComponent.h"
 
 UCAnimNotify_EnterAliveState::UCAnimNotify_EnterAliveState()
@@ -17,13 +16,8 @@ void UCAnimNotify_EnterAliveState::Notify(USkeletalMeshComponent* MeshComp, UAni
 {
 	Super::Notify(MeshComp, Animation, EventReference);
 
-	if (!IsValid(MeshComp)) return;
-
-	AActor* ownerActor = MeshComp->GetOwner();
-	if (!IsValid(ownerActor)) return;
-
-	UCHealthComponent* healthComp = Cast<UCHealthComponent>(ownerActor->GetComponentByClass(UCHealthComponent::StaticClass()));
+	UCHealthComponent* healthComp = GetHealthComponent(MeshComp);
 	if (!IsValid(healthComp)) return;
 
-	healthComp->EnterAliveState();
+	healthComp->HandleDeadStateNotify(EDeadState::Alive);
 }

--- a/Source/Portfolio/Notify/CAnimNotify_EnterAliveState.h
+++ b/Source/Portfolio/Notify/CAnimNotify_EnterAliveState.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Notify/CAnimNotify.h"
+#include "Notify/CAnimNotify_HealthBase.h"
 #include "CAnimNotify_EnterAliveState.generated.h"
 
 UCLASS()
-class PORTFOLIO_API UCAnimNotify_EnterAliveState : public UCAnimNotify
+class PORTFOLIO_API UCAnimNotify_EnterAliveState : public UCAnimNotify_HealthBase
 {
 	GENERATED_BODY()
 	

--- a/Source/Portfolio/Notify/CAnimNotify_EnterDeadState.cpp
+++ b/Source/Portfolio/Notify/CAnimNotify_EnterDeadState.cpp
@@ -1,7 +1,6 @@
 #include "Notify/CAnimNotify_EnterDeadState.h"
 #include "ProjectGlobal.h"
 
-#include "GameFramework/Actor.h"
 #include "Component/CHealthComponent.h"
 
 UCAnimNotify_EnterDeadState::UCAnimNotify_EnterDeadState()
@@ -17,13 +16,8 @@ void UCAnimNotify_EnterDeadState::Notify(USkeletalMeshComponent* MeshComp, UAnim
 {
 	Super::Notify(MeshComp, Animation, EventReference);
 
-	if (!IsValid(MeshComp)) return;
-
-	AActor* ownerActor = MeshComp->GetOwner();
-	if (!IsValid(ownerActor)) return;
-
-	UCHealthComponent* healthComp = Cast<UCHealthComponent>(ownerActor->GetComponentByClass(UCHealthComponent::StaticClass()));
+	UCHealthComponent* healthComp = GetHealthComponent(MeshComp);
 	if (!IsValid(healthComp)) return;
 
-	healthComp->EnterDeadState();
+	healthComp->HandleDeadStateNotify(EDeadState::Dead);
 }

--- a/Source/Portfolio/Notify/CAnimNotify_EnterDeadState.h
+++ b/Source/Portfolio/Notify/CAnimNotify_EnterDeadState.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Notify/CAnimNotify.h"
+#include "Notify/CAnimNotify_HealthBase.h"
 #include "CAnimNotify_EnterDeadState.generated.h"
 
 UCLASS()
-class PORTFOLIO_API UCAnimNotify_EnterDeadState : public UCAnimNotify
+class PORTFOLIO_API UCAnimNotify_EnterDeadState : public UCAnimNotify_HealthBase
 {
 	GENERATED_BODY()
 	

--- a/Source/Portfolio/Notify/CAnimNotify_HealthBase.cpp
+++ b/Source/Portfolio/Notify/CAnimNotify_HealthBase.cpp
@@ -1,0 +1,20 @@
+#include "Notify/CAnimNotify_HealthBase.h"
+#include "ProjectGlobal.h"
+
+#include "GameFramework/Character.h"
+
+#include "Component/CHealthComponent.h"
+
+UCAnimNotify_HealthBase::UCAnimNotify_HealthBase()
+{
+}
+
+UCHealthComponent* UCAnimNotify_HealthBase::GetHealthComponent(USkeletalMeshComponent* InMeshComp) const
+{
+	if (!IsValid(InMeshComp)) return nullptr;
+
+	ACharacter* ownerCharacter = Cast<ACharacter>(InMeshComp->GetOwner());
+	if (!IsValid(ownerCharacter)) return nullptr;
+
+	return ownerCharacter->FindComponentByClass<UCHealthComponent>();
+}

--- a/Source/Portfolio/Notify/CAnimNotify_HealthBase.h
+++ b/Source/Portfolio/Notify/CAnimNotify_HealthBase.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Notify/CAnimNotify.h"
+#include "CAnimNotify_HealthBase.generated.h"
+
+UCLASS(Abstract)
+class PORTFOLIO_API UCAnimNotify_HealthBase : public UCAnimNotify
+{
+	GENERATED_BODY()
+
+public:
+	UCAnimNotify_HealthBase();
+
+protected:
+	class UCHealthComponent* GetHealthComponent(USkeletalMeshComponent* InMeshComp) const;
+};

--- a/Source/Portfolio/Notify/CAnimNotify_ReactionBase.cpp
+++ b/Source/Portfolio/Notify/CAnimNotify_ReactionBase.cpp
@@ -1,0 +1,38 @@
+#include "Notify/CAnimNotify_ReactionBase.h"
+#include "ProjectGlobal.h"
+
+#include "GameFramework/Character.h"
+
+#include "Component/CReactionComponent.h"
+
+UCAnimNotify_ReactionBase::UCAnimNotify_ReactionBase()
+{
+}
+
+bool UCAnimNotify_ReactionBase::CanProcessReactionNotify(const UCReactionComponent* InReactionComp) const
+{
+	if (!IsValid(InReactionComp)) return false;
+	if (!InReactionComp->IsActive()) return false;
+
+	if (TriggerReactionType == EReactionType::None || TriggerReactionType == EReactionType::Max)
+	{
+		FLog::Log(TEXT("[AnimNotify_ReactionBase] Invalid TriggerReactionType."));
+		return false;
+	}
+
+	const EReactionType reactionType = InReactionComp->GetActiveReactionType();
+
+	if (TriggerReactionType != EReactionType::All && reactionType != TriggerReactionType) return false;
+
+	return true;
+}
+
+UCReactionComponent* UCAnimNotify_ReactionBase::GetReactionComponent(USkeletalMeshComponent* InMeshComp) const
+{
+	if (!IsValid(InMeshComp)) return nullptr;
+
+	ACharacter* ownerCharacter = Cast<ACharacter>(InMeshComp->GetOwner());
+	if (!IsValid(ownerCharacter)) return nullptr;
+
+	return ownerCharacter->FindComponentByClass<UCReactionComponent>();
+}

--- a/Source/Portfolio/Notify/CAnimNotify_ReactionBase.h
+++ b/Source/Portfolio/Notify/CAnimNotify_ReactionBase.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Notify/CAnimNotify.h"
+#include "Type/CWeaponStructure.h"
+#include "CAnimNotify_ReactionBase.generated.h"
+
+UCLASS(Abstract)
+class PORTFOLIO_API UCAnimNotify_ReactionBase : public UCAnimNotify
+{
+	GENERATED_BODY()
+
+public:
+	UCAnimNotify_ReactionBase();
+
+protected:
+	UPROPERTY(EditAnywhere, Category = "Trigger")
+	EReactionType TriggerReactionType = EReactionType::All;
+
+protected:
+	bool CanProcessReactionNotify(const class UCReactionComponent* InReactionComp) const;
+
+protected:
+	class UCReactionComponent* GetReactionComponent(USkeletalMeshComponent* InMeshComp) const;
+};

--- a/Source/Portfolio/Notify/CAnimNotify_ReactionFeedback.cpp
+++ b/Source/Portfolio/Notify/CAnimNotify_ReactionFeedback.cpp
@@ -1,8 +1,6 @@
 #include "Notify/CAnimNotify_ReactionFeedback.h"
 #include "ProjectGlobal.h"
 
-#include "GameFramework/Character.h"
-
 #include "Component/CReactionComponent.h"
 
 UCAnimNotify_ReactionFeedback::UCAnimNotify_ReactionFeedback()
@@ -18,13 +16,8 @@ void UCAnimNotify_ReactionFeedback::Notify(USkeletalMeshComponent* MeshComp, UAn
 {
 	Super::Notify(MeshComp, Animation, EventReference);
 
-	if (!IsValid(MeshComp)) return;
-
-	ACharacter* ownerCharacter = Cast<ACharacter>(MeshComp->GetOwner());
-	if (!IsValid(ownerCharacter)) return;
-
-	UCReactionComponent* reactionComp = ownerCharacter->FindComponentByClass<UCReactionComponent>();
-	if (!IsValid(reactionComp)) return;
+	UCReactionComponent* reactionComp = GetReactionComponent(MeshComp);
+	if (!CanProcessReactionNotify(reactionComp)) return;
 
 	reactionComp->HandleReactionFeedback(TriggerKey);
 }

--- a/Source/Portfolio/Notify/CAnimNotify_ReactionFeedback.h
+++ b/Source/Portfolio/Notify/CAnimNotify_ReactionFeedback.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Notify/CAnimNotify.h"
+#include "Notify/CAnimNotify_ReactionBase.h"
 #include "CAnimNotify_ReactionFeedback.generated.h"
 
 UCLASS()
-class PORTFOLIO_API UCAnimNotify_ReactionFeedback : public UCAnimNotify
+class PORTFOLIO_API UCAnimNotify_ReactionFeedback : public UCAnimNotify_ReactionBase
 {
 	GENERATED_BODY()
 

--- a/Source/Portfolio/Weapon/CWeaponActor.cpp
+++ b/Source/Portfolio/Weapon/CWeaponActor.cpp
@@ -63,12 +63,26 @@ void ACWeaponActor::BeginPlay()
 	Super::BeginPlay();
 
 	ConfigureCollisionComponents();
-	ConfigureTrailComponentState();
+	ConfigureTrailInitialState();
+}
+
+void ACWeaponActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	CollisionDisabled();
+	ToggleTrailActive(false);
+	ClearCollisionComponents();
+
+	OwnerCharacter_Injected = nullptr;
+	CombatSignalSourceComp_Injected = nullptr;
+
+	Super::EndPlay(EndPlayReason);
 }
 
 void ACWeaponActor::ConfigureCollisionComponents()
 {
 	if (!IsValid(RootSceneComponent)) return;
+
+	ClearCollisionComponents();
 
 	TArray<USceneComponent*> children;
 	RootSceneComponent->GetChildrenComponents(true, children);
@@ -86,13 +100,26 @@ void ACWeaponActor::ConfigureCollisionComponents()
 	}
 }
 
-void ACWeaponActor::ConfigureTrailComponentState()
+void ACWeaponActor::ClearCollisionComponents()
+{
+	for (UShapeComponent* collision : Collisions_Cached)
+	{
+		if (!IsValid(collision)) continue;
+
+		collision->OnComponentBeginOverlap.RemoveDynamic(this, &ACWeaponActor::OnComponentBeginOverlap);
+		collision->OnComponentEndOverlap.RemoveDynamic(this, &ACWeaponActor::OnComponentEndOverlap);
+		collision->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	}
+
+	Collisions_Cached.Empty();
+}
+
+void ACWeaponActor::ConfigureTrailInitialState()
 {
 	if (!IsValid(TrailComponent)) return;
 	if (!bDisableTrailOnBeginPlay) return;
 
-	TrailComponent->Deactivate();
-	TrailComponent->SetVisibility(false);
+	ToggleTrailActive(false);
 }
 
 const FOverlapContext& ACWeaponActor::GetLastOverlapContext() const

--- a/Source/Portfolio/Weapon/CWeaponActor.h
+++ b/Source/Portfolio/Weapon/CWeaponActor.h
@@ -102,6 +102,16 @@ public:
 protected:
 	// Lifecycle
 	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+private:
+	// Collision Component
+	void ConfigureCollisionComponents();
+	void ClearCollisionComponents();
+
+private:
+	// Trail
+	void ConfigureTrailInitialState();
 
 public:
 	/* === IHitContextProducer (Getter) === */
@@ -148,10 +158,6 @@ public:
 
 	UFUNCTION()
 	void OnComponentEndOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex);
-
-private:
-	void ConfigureCollisionComponents();
-	void ConfigureTrailComponentState();
 
 private:
 	FOverlapContext BuildOverlapContext(AActor* InOwnerActor, AActor* InDamageCauser, UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult) const;


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P30: Runtime Component 조회 정책**

## 날짜

**2026.06.29**

## 상태

- [x] 완료

---

## 브랜치

- `refactor/runtime-component-lookup-policy`

---

## 커밋

```text
39d8b024 docs(reference): define runtime component lookup policy
6908a289 refactor(notify): route timing events through components
b78cf7eb refactor(animation): clarify anim instance reference cache
126091b9 refactor(ai): clarify behavior tree runtime lookup
88075a70 refactor(weapon): clarify spawned actor reference cleanup
```

---

## 요약

이번 PR은 P29에서 정리한 Character component reference DI 이후에도 남는 runtime lookup 경로를 분류하고, 유지 / 수정 / 문서화 기준을 정리한다.

핵심 목표는 모든 lookup 제거가 아니다.

```text
Character-owned required component
-> DI / injected reference

runtime target / external actor
-> request 시점 lookup 유지

AnimInstance owner / mesh-bound reference
-> animation lifecycle 기준 cache

AI Blackboard / BehaviorTree state
-> runtime query 유지
```

---

## 변경 배경

P29에서 Character가 소유한 component reference는 다음 흐름으로 정리했다.

```text
RecoverReferences
-> BuildReferences
-> InjectReferences
-> InitializeReferences
-> ValidateRequiredComponentReferences
```

하지만 프로젝트에는 다음처럼 runtime lookup이 자연스러운 영역이 남아 있다.

```text
- Notify / NotifyState routing
- AnimInstance owner / movement component cache
- AI BT Service / Decorator / Task의 Blackboard / Pawn / component query
- CombatSignal dynamic target resolve
- WeaponActor overlap target 해석
```

이번 PR은 이 영역을 “전부 DI로 바꾸는 작업”이 아니라, lookup이 필요한 이유와 실패 처리 기준을 명확히 하는 작업이다.

---

## 작업 범위

### 1. Notify / NotifyState routing

검토 기준:

```text
Notify는 timing trigger 이상을 알지 않는다.
Notify는 domain 판단을 하지 않는다.
Notify는 필요한 경우 component routing entry까지만 호출한다.
```

검토 대상:

```text
Source/Portfolio/Notify
```

진행 내용:

```text
Action Notify
-> 기존 ActionBase routing 유지

Reaction Feedback Notify
-> ReactionBase / ReactionStateBase 추가
-> UCReactionComponent notify routing API 호출로 정리

Health State Notify
-> HealthBase 추가
-> UCHealthComponent notify routing API 호출로 정리

Collision Window Notify
-> WeaponActor 직접 resolve 제거
-> UCActionComponent -> UCWeaponComponent -> ACWeaponActor 순서로 routing 정리
```

### 2. AnimInstance reference / cache

검토 기준:

```text
AnimInstance는 ActorComponent DI 흐름과 다르다.
TryGetPawnOwner() 기반 owner 확인은 animation lifecycle에 맞는 runtime lookup이다.
NativeUpdateAnimation에서는 invalid owner / component 상황을 safe return으로 처리한다.
```

검토 대상:

```text
Source/Portfolio/Character/CAnimInstance.*
```

진행 내용:

```text
UCAnimInstance
-> TryGetPawnOwner 기반 owner resolve 유지
-> component cache / clear / bind / unbind helper로 분리
-> movement / state parameter refresh helper로 분리
-> GetComponentByClass 사용을 FindComponentByClass<T>()로 정리
```

### 3. AI BehaviorTree lookup

검토 기준:

```text
Blackboard value 조회는 runtime query로 유지한다.
Service / Decorator / Task의 역할에 따라 lookup 실패 처리를 분리한다.
반복 lookup은 필요한 경우 local variable 또는 cache 기준을 둔다.
```

검토 대상:

```text
Source/Portfolio/AI
```

진행 내용:

```text
BT Service / Task
-> AI owner / Pawn runtime query 유지
-> 같은 함수 안의 반복 GetAIOwner()->GetPawn() 패턴을 local variable로 정리
-> owner component 조회는 FindComponentByClass<T>()로 통일

BT Decorator
-> Blackboard / Pawn / component 조건 조회 유지
-> 조회 실패 시 false 반환 정책 유지
```

### 4. WeaponActor runtime reference

검토 기준:

```text
WeaponActor는 Character component가 아니라 runtime actor다.
Owner / CombatSignalSource는 WeaponComponent가 생성 직후 주입한다.
Overlap target은 event payload에서 해석한다.
```

검토 대상:

```text
Source/Portfolio/Weapon
```

진행 내용:

```text
UCWeaponComponent
-> spawned WeaponActor owner로서 EndPlay cleanup 추가
-> runtime weapon state(collision / trail) 정리 후 spawned actor Destroy

ACWeaponActor
-> collision delegate bind/cache는 BeginPlay에서 유지
-> EndPlay / runtime state clear 경로에서 collision window와 trail을 명시적으로 정리
-> EndPlay에서 collision delegate unbind / collision cache clear
-> injected owner/source reference clear
```

후속 보완 대상:

```text
Actor / Component teardown cleanup
-> EndPlay delegate / timer / spawned actor cleanup 기준은 별도 refactor에서 처리
-> WeaponActor collision cleanup과 gameplay collision close API 분리 여부는 후속 작업으로 분리
```

### 5. Lookup 사용처 분류

대상 API:

```text
FindComponentByClass
GetComponentByClass
TryGetPawnOwner
GetOwner
GetController
Blackboard GetValueAs...
```

분류:

```text
DI 대상
runtime lookup 유지
cache 필요
safe return / reject 필요
후속 브랜치 분리
```

진행 내용:

```text
GetComponentByClass
-> Source/Portfolio C++ 코드 기준 잔여 사용처 없음

FindComponentByClass
-> Notify base/helper, AnimInstance cache, AI owner component query, CombatSignal target resolve처럼 runtime context가 필요한 경로에만 유지

Component order
-> Character reference 구성/주입 계열은 canonical component order를 기준으로 정렬
-> runtime gameplay flow는 domain 처리 순서를 우선

현재 예외
-> ACEnemy는 DefenseComponent를 아직 보유하지 않음
-> 적 방어 기능이 필요해지는 시점에 추가
-> CombatSignalTarget의 Defense reference는 현재 optional dependency로 유지
```

---

## 주요 파일

```text
Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
Docs/04_Pull_Request/00_Pull_Request_Index.md
```

코드 파일은 실제 검토 후 필요한 범위만 추가한다.

---

## 검증 계획

```text
- rg 기반 lookup 사용처 전수 스캔 완료
- GetComponentByClass 잔여 사용처 없음 확인
- Notify / AnimInstance / AI / WeaponActor 경로별 코드 확인 완료
- PortfolioEditor Win64 Development 빌드 성공
- PIE 기본 combat loop smoke test는 수동 확인 대상으로 남김
```

---

## 관련 문서

```text
Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
Docs/06_notes/N10_Component_Reference_Validation_Policy_Note.md
Docs/06_notes/N11_Unreal_Blueprint_Native_Component_Reference_Mismatch_Note.md
Docs/02_Bug_Report/B14_UE5_Portfolio_Bug_Report.md
```

---

## 제외 범위

```text
- Blink 실제 기능 구현
- Repulse 실제 기능 구현
- ResultOut 구조 선행 일반화
- UE TakeDamage route 제거
- GAS 도입
- BehaviorTree 전체 재설계
- AnimBP 구조 재작성
```
