### PR TITLE
P31: Component Lifecycle Cleanup Policy

### DIFF
--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -485,3 +485,51 @@ refactor/runtime-component-lookup-policy
 6. 필요한 코드 수정만 반영
 7. 문서와 PR 기록 업데이트
 ```
+
+### P31. Component Lifecycle Cleanup Policy
+
+- 상태: 준비 중
+- 브랜치: `refactor/component-lifecycle-cleanup-policy`
+- PR: `P31_UE5_Portfolio_Pull_Request.md`
+- 목표: P29~P30 이후 남은 actor / component lifecycle cleanup 기준을 정리하고, `BeginPlay` / `EndPlay` / delegate / timer / spawned actor / runtime cache 정리 정책을 고정한다.
+- 관련 문서: `N13_Component_Lifecycle_Cleanup_Policy_Note.md`, `N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md`
+- 제외 범위: Dead 이후 Actor Destroy 구현, Action / Reaction 실행 종료 정책 재설계, montage stop 정책 변경, Guard / Reaction runtime cleanup 재설계, 모든 injected reference 일괄 null 처리
+
+준비 단계 조회 결과:
+
+```text
+Lifecycle hook 보유 파일: 11개
+Delegate / Timer 사용 파일: 8개
+SpawnActor / NewObject 생성 경로: 3개
+Runtime cleanup 명명 사용처: 약 20개+
+```
+
+우선 검토 대상:
+
+```text
+1. ACAIController
+   -> perception delegate bind / unbind
+   -> TargetDataMap / ControlledPawn_Cached cleanup
+
+2. UCWorldSubsystem_CombatFeedback
+   -> hit stop timer handle cleanup
+   -> cached time dilation restore policy
+
+3. UCActionComponent / UCReactionComponent
+   -> executor object ownership
+   -> active runtime context teardown 기준
+   -> execution 흐름 영향도가 크면 문서화 후 후속 분리
+
+4. 후속 분리 후보
+   -> Dead Destroy Flow
+   -> Execution Runtime Cleanup Boundary
+```
+
+검증 기준:
+
+```text
+- rg 기반 lifecycle / delegate / timer / spawn 사용처 전수 확인
+- git diff --check
+- PortfolioEditor Win64 Development 빌드
+- PIE 기본 combat loop smoke test
+```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -488,7 +488,7 @@ refactor/runtime-component-lookup-policy
 
 ### P31. Component Lifecycle Cleanup Policy
 
-- 상태: 준비 중
+- 상태: 진행 중
 - 브랜치: `refactor/component-lifecycle-cleanup-policy`
 - PR: `P31_UE5_Portfolio_Pull_Request.md`
 - 목표: P29~P30 이후 남은 actor / component lifecycle cleanup 기준을 정리하고, `BeginPlay` / `EndPlay` / delegate / timer / spawned actor / runtime cache 정리 정책을 고정한다.

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -36,5 +36,6 @@
 | P28 | Unreal 참조 안전성 v1 | `P28_UE5_Portfolio_Pull_Request.md` | `refactor/unreal-reference-safety-v1` |  | W05, N08, N09 |
 | P29 | Character Component 참조 주입 / 복구 | `P29_UE5_Portfolio_Pull_Request.md` | `refactor/character-component-reference-di` |  | W05, N10, N11, B14 |
 | P30 | Runtime Component 조회 정책 | `P30_UE5_Portfolio_Pull_Request.md` | `refactor/runtime-component-lookup-policy` |  | W05, N12 |
+| P31 | Component Lifecycle Cleanup Policy | `P31_UE5_Portfolio_Pull_Request.md` | `refactor/component-lifecycle-cleanup-policy` |  | W05, N13, N14 |
 
 ---

--- a/Docs/04_Pull_Request/P31_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P31_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,202 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P31: Component Lifecycle Cleanup Policy**
+
+## 날짜
+
+**2026.06.30**
+
+## 상태
+
+- [ ] 준비 중
+
+---
+
+## 브랜치
+
+- `refactor/component-lifecycle-cleanup-policy`
+
+---
+
+## 커밋
+
+```text
+TBD
+```
+
+---
+
+## 요약
+
+이번 PR은 actor / component lifecycle cleanup 기준을 정리한다.
+
+P29에서는 character component reference 주입과 복구 흐름을 정리했고, P30에서는 runtime lookup을 DI 대상과 구분했다. 이번 작업에서는 그 다음 단계로 `BeginPlay` / `EndPlay` / `OnPossess` / `OnUnPossess` / delegate / timer / spawned actor / runtime cache 정리 기준을 점검한다.
+
+핵심 목표는 cleanup 책임이 있는 지점을 식별하고, 코드와 문서에서 설명 가능한 lifecycle 기준을 남기는 것이다.
+
+---
+
+## 작업 배경
+
+P30과 F05에서 WeaponActor의 runtime actor / collision / trail cleanup 흐름을 정리하면서, 더 넓은 lifecycle cleanup 기준이 필요하다는 점이 드러났다.
+
+특히 다음 질문에 답할 수 있어야 한다.
+
+```text
+BeginPlay에서 bind한 delegate는 어디서 해제되는가?
+OnPossess에서 만든 controller runtime state는 OnUnPossess에서 정리되는가?
+timer로 변경한 actor state는 world teardown에서도 복구 또는 정리되는가?
+spawned actor의 Destroy 책임은 어느 component가 가지는가?
+gameplay cleanup과 object teardown cleanup은 같은 API로 처리해도 되는가?
+```
+
+---
+
+## 사전 조회 결과
+
+```text
+Lifecycle hook 보유 파일: 11개
+Delegate / Timer 사용 파일: 8개
+SpawnActor / NewObject 생성 경로: 3개
+Runtime cleanup 명명 사용처: 약 20개+
+```
+
+---
+
+## 작업 범위
+
+### 1. Lifecycle 사용처 전수 확인
+
+대상:
+
+```text
+BeginPlay
+EndPlay
+NativeInitializeAnimation
+NativeUninitializeAnimation
+OnPossess
+OnUnPossess
+```
+
+확인 기준:
+
+```text
+- setup / bind / cache가 있는지
+- 대응 cleanup이 있는지
+- 없는 경우 의도적으로 없어도 되는지
+```
+
+### 2. Delegate / Timer cleanup 점검
+
+대상:
+
+```text
+AddDynamic
+AddUniqueDynamic
+AddUObject
+RemoveDynamic
+RemoveAll
+SetTimer
+ClearTimer
+```
+
+우선 후보:
+
+```text
+ACAIController
+UCWorldSubsystem_CombatFeedback
+```
+
+### 3. Spawned actor / executor ownership 점검
+
+대상:
+
+```text
+SpawnActor
+Destroy
+NewObject
+```
+
+우선 후보:
+
+```text
+UCWeaponComponent
+UCActionComponent
+UCReactionComponent
+```
+
+`UCWeaponComponent`는 P30/F05에서 보강한 흐름을 기준으로 확인한다. `UCActionComponent` / `UCReactionComponent`는 executor lifecycle이 gameplay execution과 연결되므로 execution 흐름 영향도를 별도로 판단한다.
+
+### 4. Cleanup 명명 기준 정리
+
+구분:
+
+```text
+Gameplay Runtime Cleanup
+-> action / reaction / feedback / guard 같은 실행 중 임시 상태 정리
+
+Lifecycle Teardown Cleanup
+-> EndPlay / OnUnPossess / NativeUninitializeAnimation / subsystem teardown에서 delegate, timer, spawned actor, cache 정리
+```
+
+이번 PR은 `Lifecycle Teardown Cleanup` 기준을 우선 정리한다.
+`Gameplay Runtime Cleanup`은 현재 Action / Reaction interrupt 흐름 위에서 동작하고 있으며, ResultOut / Repulse처럼 외부 결과 전달 사례가 생기면 snapshot, cleanup 순서, result dispatch 시점을 후속 작업에서 다시 검토한다.
+
+Dead 이후 Actor Destroy 프로세스는 후속 작업으로 분리하고, 이번 PR에서는 Destroy flow가 추가될 때 사용할 수 있는 `EndPlay`, `OnUnPossess`, subsystem teardown, delegate / timer / spawned actor cleanup hook의 책임을 정리한다.
+
+Dead Destroy Flow와 Execution Runtime Cleanup Boundary는 후속 노트에서 별도 추적한다.
+
+---
+
+## 예상 수정 후보
+
+```text
+Source/Portfolio/Controller/CAIController.*
+Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.*
+Source/Portfolio/Component/CActionComponent.*
+Source/Portfolio/Component/CReactionComponent.*
+Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+```
+
+코드 변경은 조회 결과에서 수정 필요가 확인된 범위에 반영한다.
+
+---
+
+## 제외 범위
+
+```text
+- Action / Reaction 실행 종료 정책 재설계
+- montage stop 정책 변경
+- Guard / Reaction runtime cleanup 재설계
+- 모든 _Injected reference를 EndPlay에서 일괄 null 처리
+- Blink / Repulse / ResultOut 구현
+- GAS 대응
+```
+
+---
+
+## 검증 계획
+
+```text
+rg 기반 lifecycle / delegate / timer / spawn 사용처 전수 확인
+git diff --check
+PortfolioEditor Win64 Development 빌드
+PIE 기본 combat loop smoke test
+```
+
+---
+
+## 관련 문서
+
+```text
+Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
+Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
+Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
+Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
+Docs/04-02_Fix_Pull_Request/F05_UE5_Portfolio_Pull_Request_Fix.md
+```
+
+---

--- a/Docs/04_Pull_Request/P31_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P31_UE5_Portfolio_Pull_Request.md
@@ -10,7 +10,7 @@
 
 ## 상태
 
-- [ ] 준비 중
+- [x] 완료
 
 ---
 
@@ -23,7 +23,7 @@
 ## 커밋
 
 ```text
-TBD
+refactor(lifecycle): clarify runtime setup and teardown naming
 ```
 
 ---
@@ -165,6 +165,107 @@ Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
 
 ---
 
+## 작업 결과
+
+### 1. Runtime setup / teardown naming 기준 정리
+
+상위 lifecycle 조합 함수는 `Initialize / Uninitialize`를 유지하고, 하위 작업은 실제 동작이 드러나는 이름으로 분리했다.
+
+```text
+상위 lifecycle
+-> InitializeRuntime / UninitializeRuntime
+
+map 구성 / 비움
+-> Build / Clear
+
+초기 상태 설정 / 기본 상태 복구
+-> SetInitial / Reset
+
+delegate 연결 / 해제
+-> Bind / Unbind
+
+logic 시작 / 중단
+-> Start / Stop
+
+spawned actor 생성 / 파괴
+-> Create / Destroy
+```
+
+이 기준에 따라 `ActionComponent`, `ReactionComponent`, `AIController`, `WeaponComponent`의 helper API 이름을 정리했다.
+
+### 2. ACAIController lifecycle cleanup
+
+`OnPossess`에서 구성한 controller runtime을 `OnUnPossess`와 `EndPlay`에서 같은 teardown 경로로 닫도록 정리했다.
+
+```text
+InitializeControllerRuntime
+-> SetPossessionRuntimeState
+-> ClearTargetDataMap
+-> BindPerceptionEvents
+-> SetupBlackboardComponent
+-> SetInitialBlackboardRuntimeValues
+-> StartBehaviorTreeRuntime
+
+UninitializeControllerRuntime
+-> StopBehaviorTreeRuntime
+-> ClearBlackboardRuntimeValues
+-> UnbindPerceptionEvents
+-> ClearTargetDataMap
+-> ResetPossessionRuntimeState
+```
+
+`SetupBlackboardComponent()`는 `UseBlackboard()`로 blackboard component를 준비하고 key validity를 확인하는 단계다. UE에는 `UseBlackboard()`에 직접 대응하는 unregister API가 없으므로 teardown에서는 behavior tree logic을 먼저 멈춘 뒤 runtime key 값을 정리한다.
+
+### 3. Action / Reaction runtime lifecycle
+
+`ActionComponent`와 `ReactionComponent`는 `BeginPlay`에서 runtime map과 initial active state를 구성하고, `EndPlay`에서 broadcast 없는 teardown helper로 상태를 닫는다.
+
+```text
+Action
+-> BuildActionRuntimeMaps
+-> SetInitialActiveActionRuntimeState
+-> ResetActiveActionRuntimeState
+-> ClearActionRuntimeMaps
+
+Reaction
+-> BuildReactionRuntimeMaps
+-> SetInitialActiveReactionRuntimeState
+-> ResetActiveReactionRuntimeState
+-> ClearReactionRuntimeMaps
+```
+
+`ClearActiveActionContext()` / `ClearActiveReactionContext()`는 gameplay event broadcast를 포함하므로 object teardown 경로에서는 직접 호출하지 않는다.
+
+### 4. WeaponComponent runtime teardown
+
+`WeaponComponent`는 `EndPlay`에서 `UninitializeWeaponRuntime()`을 호출하고, 내부에서 runtime weapon state 정리와 spawned weapon actor destroy를 명시적으로 나눴다.
+
+```text
+UninitializeWeaponRuntime
+-> ClearWeaponRuntimeState
+-> DestroyWeaponActor
+```
+
+`ClearWeaponRuntimeState()`는 gameplay 중 action cleanup에서도 호출될 수 있는 public API로 유지하고, object teardown에서만 필요한 actor destroy는 private helper로 분리했다.
+
+### 5. Combat subsystem cleanup
+
+`UCWorldSubsystem_CombatFeedback`은 `Deinitialize`에서 hit stop timer / cached dilation / camera shake delegate를 정리한다.
+
+```text
+ClearFeedbackRuntimeState
+-> ClearHitStop
+-> ClearCameraShake
+```
+
+`UCWorldSubsystem_CombatEngage`는 `Deinitialize`에서 request / assignment / elapsed time을 초기 상태로 되돌린다.
+
+```text
+ClearEngageRuntimeState
+```
+
+---
+
 ## 제외 범위
 
 ```text
@@ -181,10 +282,17 @@ Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
 ## 검증 계획
 
 ```text
-rg 기반 lifecycle / delegate / timer / spawn 사용처 전수 확인
-git diff --check
-PortfolioEditor Win64 Development 빌드
-PIE 기본 combat loop smoke test
+[x] rg 기반 lifecycle / delegate / timer / spawn 사용처 전수 확인
+[x] git diff --check
+[x] PortfolioEditor Win64 Development 빌드
+[x] PIE 기본 combat loop smoke test
+```
+
+PIE 확인 결과:
+
+```text
+- Guard / Parry / Stagger / Damage / Blink cue route 로그 정상 확인
+- crash / ensure / stale reference 로그 없음
 ```
 
 ---

--- a/Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
+++ b/Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
@@ -1,0 +1,233 @@
+# N13. Component Lifecycle Cleanup Policy Note
+
+## 목적
+
+이 문서는 `Source/Portfolio`의 actor / component lifecycle cleanup 기준을 정리하기 위한 작업 노트다.
+
+P29에서는 character-owned component reference 주입과 복구 기준을 정리했고, P30에서는 runtime lookup을 DI 대상과 구분했다. 다음 단계에서는 `BeginPlay` / `EndPlay` / delegate / timer / spawned actor / runtime cache가 어떤 기준으로 초기화되고 해제되어야 하는지 정리한다.
+
+이번 작업은 teardown 시점의 누락 가능성을 줄이고, 코드 리뷰에서 설명 가능한 cleanup 정책을 만드는 데 초점을 둔다.
+
+---
+
+## 기본 원칙
+
+```text
+BeginPlay에서 bind / cache / runtime setup을 수행했다면
+-> EndPlay 또는 대응 lifecycle에서 unbind / clear / teardown을 검토한다.
+
+OnPossess에서 controller-owned runtime state를 구성했다면
+-> OnUnPossess에서 controller-owned runtime state를 정리한다.
+
+spawned actor를 owner component가 생성했다면
+-> owner component lifecycle에서 runtime state 정리 후 Destroy 책임을 가진다.
+
+timer handle을 저장하거나 actor state를 임시 변경했다면
+-> timer 종료 전 world teardown / owner invalid 상황을 고려한다.
+```
+
+---
+
+## Cleanup 분류
+
+## Dead Destroy Flow와의 관계
+
+이번 브랜치는 Dead 이후 Actor Destroy 프로세스의 선행 기반으로 lifecycle cleanup hook을 정리한다.
+
+```text
+이번 브랜치
+-> BeginPlay / EndPlay 대칭성 확인
+-> OnPossess / OnUnPossess 대칭성 확인
+-> NativeInitializeAnimation / NativeUninitializeAnimation 대칭성 확인
+-> delegate / timer / spawned actor / runtime cache cleanup hook 확인
+
+후속 Dead Destroy 작업
+-> Dead state 진입 이후 Destroy 시점 결정
+-> death reaction / feedback 완료 시점 결정
+-> AI stop / possession 해제 / collision 비활성화 정책 결정
+-> weapon / combat signal / hit window 종료 순서 결정
+-> Destroy 호출 이후 EndPlay teardown 검증
+```
+
+즉 P31은 Destroy가 발생했을 때 호출될 teardown hook과 cleanup 책임을 명확히 하는 준비 작업이다.
+
+Dead 이후 실제 Destroy 프로세스와 실행 중 상태 전환 cleanup 순서 정책은 별도 후속 노트에서 추적한다.
+
+관련 후속 노트:
+
+```text
+Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
+```
+
+### 1. Gameplay Runtime Cleanup
+
+전투 행동이 정상 종료되거나 중단될 때 임시 gameplay state를 정리하는 흐름이다.
+
+예시:
+
+```text
+Action / Reaction ClearRuntime
+Action / Reaction CleanupRuntimeEffects
+WeaponComponent ClearRuntimeWeaponState
+FeedbackComponent ClearRuntimeFeedback
+DefenseComponent ClearGuardState
+```
+
+이 경로는 action / reaction interrupt 구조 안에서 이미 동작하고 있다.
+
+overlay, feedback window, weapon collision, hit context, result-out 같은 상태가 늘어나면 다음 기준을 더 명확히 해야 한다.
+
+```text
+Before
+-> 어떤 action / reaction / overlay / weapon context가 active였는가
+
+Transition
+-> 어떤 원인으로 종료 또는 중단됐는가
+-> 어떤 상태를 먼저 snapshot하는가
+-> 어떤 상태를 닫고 어떤 상태를 유지하는가
+-> 외부 결과 dispatch는 cleanup 전후 어느 시점에 수행하는가
+
+After
+-> 최종 execution state는 무엇인가
+-> overlay / weapon / feedback / runtime cache가 의도한 상태로 정리됐는가
+```
+
+이번 브랜치에서는 object lifecycle teardown 기준을 우선 정리한다.
+gameplay runtime cleanup의 순서 정책은 ResultOut / Repulse처럼 실제 결과 전달 사례가 생긴 뒤 후속 작업에서 다룬다.
+
+### 2. Lifecycle Teardown Cleanup
+
+객체가 world에서 종료되거나 owner 관계가 끊기는 시점에 dangling delegate, timer, spawned actor, stale cache를 정리하는 흐름이다.
+
+예시:
+
+```text
+Actor EndPlay
+ActorComponent EndPlay
+AnimInstance NativeUninitializeAnimation
+AIController OnUnPossess
+WorldSubsystem Deinitialize
+```
+
+이번 작업의 주 검토 대상이다.
+
+---
+
+## 준비 단계 조회 결과
+
+```text
+Lifecycle hook 보유 파일: 11개
+Delegate / Timer 사용 파일: 8개
+SpawnActor / NewObject 생성 경로: 3개
+Runtime cleanup 명명 사용처: 약 20개+
+```
+
+---
+
+## 우선 검토 대상
+
+### ACAIController
+
+현재 구조:
+
+```text
+OnPossess
+-> ControlledPawn_Cached 설정
+-> perception delegate bind
+-> blackboard / behavior tree 초기화
+
+OnUnPossess
+-> ControlledPawn_Cached = nullptr
+```
+
+검토 포인트:
+
+```text
+- perception delegate unbind 필요 여부
+- TargetDataMap cleanup 필요 여부
+- OnPossess가 재호출될 때 중복 AddDynamic 가능성
+- BeginPlay가 비어 있는 경우 유지 또는 제거 여부
+```
+
+### UCWorldSubsystem_CombatFeedback
+
+현재 구조:
+
+```text
+ApplyHitStop
+-> actor별 CustomTimeDilation 저장
+-> timer 등록
+
+RestoreHitStop
+-> actor가 유효하면 dilation 복구
+-> handle / cached dilation 제거
+```
+
+검토 포인트:
+
+```text
+- subsystem teardown 시 ActiveHitStopMap 정리 필요 여부
+- world cleanup 중 timer callback이 호출되지 않는 경우 dilation restore 보장 여부
+- invalid actor key가 남았을 때 map cleanup 기준
+```
+
+### UCActionComponent / UCReactionComponent
+
+현재 구조:
+
+```text
+BeginPlay
+-> data map / executor map build
+
+NewObject
+-> action / reaction executor 생성
+```
+
+검토 포인트:
+
+```text
+- executor object ownership은 component outer 기준으로 유지 가능한지
+- EndPlay에서 active context clear가 필요한지
+- gameplay runtime cleanup과 teardown cleanup을 섞지 않아야 하는 지점
+```
+
+이 영역은 gameplay execution과 연결되므로, 먼저 lifecycle 책임을 문서화하고 수정 필요 여부를 별도로 판단한다.
+
+---
+
+## 이번 브랜치 포함 범위
+
+```text
+- lifecycle cleanup 정책 문서화
+- delegate / timer / spawned actor 사용처 전수 목록화
+- ACAIController cleanup 보강 여부 판단 및 수정 필요 항목 반영
+- UCWorldSubsystem_CombatFeedback teardown 보강 여부 판단 및 수정 필요 항목 반영
+- Action / Reaction executor lifecycle은 검토 결과를 문서화하고, execution 영향도가 크면 후속 분리
+```
+
+---
+
+## 제외 범위
+
+```text
+- Action / Reaction 실행 종료 정책 재설계
+- montage stop 정책 변경
+- Guard / Reaction runtime cleanup 재설계
+- 모든 _Injected reference를 EndPlay에서 일괄 null 처리
+- Blink / Repulse / ResultOut 구현
+```
+
+---
+
+## 검증 기준
+
+```text
+rg -n "BeginPlay|EndPlay|NativeUninitializeAnimation|OnUnPossess" Source/Portfolio -g "*.cpp" -g "*.h"
+rg -n "AddDynamic|AddUniqueDynamic|AddUObject|RemoveDynamic|RemoveAll|SetTimer|ClearTimer" Source/Portfolio -g "*.cpp" -g "*.h"
+rg -n "SpawnActor|Destroy\\(|NewObject" Source/Portfolio -g "*.cpp" -g "*.h"
+git diff --check
+PortfolioEditor Win64 Development build
+PIE basic combat loop smoke test
+```
+
+---

--- a/Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
+++ b/Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
@@ -28,6 +28,58 @@ timer handle을 저장하거나 actor state를 임시 변경했다면
 
 ---
 
+## Naming 기준
+
+이번 작업에서는 `Initialize`를 모든 setup helper에 일괄 적용하지 않는다.
+
+상위 lifecycle 조합 함수는 `Initialize / Uninitialize`를 사용하고, 하위 helper는 실제 동작의 반대말이 자연스럽게 보이도록 구분한다.
+
+```text
+Runtime lifecycle 조합
+-> InitializeXXXRuntime
+-> UninitializeXXXRuntime
+
+map / container 구성과 비움
+-> BuildXXXMap
+-> ClearXXXMap
+
+초기 상태 설정과 기본 상태 복구
+-> SetInitialXXXState
+-> ResetXXXState
+
+delegate / event 연결과 해제
+-> BindXXXEvents
+-> UnbindXXXEvents
+
+logic 시작과 중단
+-> StartXXXRuntime
+-> StopXXXRuntime
+
+spawned actor 생성과 파괴
+-> CreateXXX
+-> DestroyXXX
+```
+
+이 기준을 적용하면 `Initialize`의 반대편에 `Clear`, `Reset`, `Unbind`, `Stop`, `Destroy`가 섞여 보이는 문제가 줄어든다.
+
+예시:
+
+```text
+InitializeControllerRuntime
+-> SetPossessionRuntimeState
+-> BindPerceptionEvents
+-> SetInitialBlackboardRuntimeValues
+-> StartBehaviorTreeRuntime
+
+UninitializeControllerRuntime
+-> StopBehaviorTreeRuntime
+-> ClearBlackboardRuntimeValues
+-> UnbindPerceptionEvents
+-> ResetPossessionRuntimeState
+```
+
+---
+
 ## Cleanup 분류
 
 ## Dead Destroy Flow와의 관계
@@ -68,7 +120,7 @@ Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
 ```text
 Action / Reaction ClearRuntime
 Action / Reaction CleanupRuntimeEffects
-WeaponComponent ClearRuntimeWeaponState
+WeaponComponent ClearWeaponRuntimeState
 FeedbackComponent ClearRuntimeFeedback
 DefenseComponent ClearGuardState
 ```
@@ -132,12 +184,19 @@ Runtime cleanup 명명 사용처: 약 20개+
 
 ```text
 OnPossess
--> ControlledPawn_Cached 설정
--> perception delegate bind
--> blackboard / behavior tree 초기화
+-> SetPossessionRuntimeState
+-> ClearTargetDataMap
+-> BindPerceptionEvents
+-> SetupBlackboardComponent
+-> SetInitialBlackboardRuntimeValues
+-> StartBehaviorTreeRuntime
 
 OnUnPossess
--> ControlledPawn_Cached = nullptr
+-> StopBehaviorTreeRuntime
+-> ClearBlackboardRuntimeValues
+-> UnbindPerceptionEvents
+-> ClearTargetDataMap
+-> ResetPossessionRuntimeState
 ```
 
 검토 포인트:
@@ -177,7 +236,12 @@ RestoreHitStop
 
 ```text
 BeginPlay
--> data map / executor map build
+-> BuildActionRuntimeMaps / BuildReactionRuntimeMaps
+-> SetInitialActiveActionRuntimeState / SetInitialActiveReactionRuntimeState
+
+EndPlay
+-> ResetActiveActionRuntimeState / ResetActiveReactionRuntimeState
+-> ClearActionRuntimeMaps / ClearReactionRuntimeMaps
 
 NewObject
 -> action / reaction executor 생성

--- a/Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
+++ b/Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
@@ -1,0 +1,312 @@
+# N14. Dead Destroy and Execution Cleanup Follow-up Note
+
+## 목적
+
+이 문서는 P31 작업 중 논의된 후속 작업 후보를 정리한다.
+
+P31은 actor / component lifecycle teardown 기준을 정리하는 작업이다. 이 과정에서 별도 작업으로 분리해야 할 두 가지 필요성이 확인됐다.
+
+```text
+1. Dead 이후 Actor Destroy 프로세스 정리
+2. Action / Reaction 상태 전환 중 gameplay runtime cleanup 순서 정책 정리
+```
+
+두 작업은 모두 cleanup과 관련되지만 성격이 다르다.
+
+```text
+Dead Destroy Flow
+-> 객체 생명주기 종료와 Destroy 호출 전후의 teardown 흐름
+
+Execution Runtime Cleanup Boundary
+-> 전투 실행 중 action / reaction / overlay / feedback / weapon state가 전환될 때의 cleanup 순서
+```
+
+---
+
+## 1. Dead Destroy Flow
+
+### 문제 / 필요성
+
+현재 Dead는 전투 상태와 reaction 흐름 안에서 처리된다. Dead 이후 actor가 언제, 어떤 절차로 Destroy되는지는 후속 구현 범위에서 고정한다.
+
+Dead 이후 Destroy를 구현하려면 다음 흐름을 정책으로 정해야 한다.
+
+```text
+Dead state 진입
+-> death reaction / feedback 처리
+-> AI / behavior tree / perception 정지
+-> combat collision / weapon actor / hit window 정리
+-> character collision / mesh 상태 처리
+-> delay / corpse 유지 / ragdoll / pooling 여부 결정
+-> Destroy 호출
+-> EndPlay teardown 검증
+```
+
+### 현재 상태와 예상되는 문제
+
+현재 프로젝트에는 다음 기반이 있다.
+
+```text
+HealthComponent
+-> Dead state event 발생
+
+StateComponent
+-> Dead execution state 반영
+
+ReactionComponent / Reaction
+-> Dead reaction 실행 가능
+
+WeaponComponent / WeaponActor
+-> spawned weapon actor cleanup 경로 보유
+
+AIController
+-> OnPossess / OnUnPossess lifecycle 보유
+```
+
+Dead 이후 Destroy flow가 추가되면 다음 문제를 검토해야 한다.
+
+```text
+- death feedback이 끝나기 전에 actor가 Destroy될 수 있음
+- AI perception delegate / blackboard / behavior tree가 죽은 pawn을 계속 참조할 수 있음
+- weapon collision 또는 hit window가 열린 상태로 남을 수 있음
+- EndPlay cleanup과 gameplay cleanup이 중복 호출될 수 있음
+- corpse 유지, delay destroy, ragdoll, pooling 중 어떤 정책을 쓸지 불명확할 수 있음
+```
+
+### 해결 방향
+
+Dead 이후 Destroy는 별도 feature 또는 refactor branch에서 다룬다.
+
+P31에서는 Destroy가 발생했을 때 호출될 lifecycle cleanup hook을 점검한다.
+
+후속 Destroy 작업에서는 다음 정책을 먼저 결정한다.
+
+```text
+Destroy trigger
+-> Dead state 진입 즉시
+-> death reaction 종료 후
+-> feedback 완료 후
+-> 일정 delay 후
+
+Destroy target
+-> character actor 전체 Destroy
+-> corpse 유지 후 component 비활성화
+-> pooling 후보 유지
+
+Cleanup ordering
+-> gameplay 종료 cleanup
+-> AI / perception 중지
+-> collision 비활성화
+-> weapon actor 정리
+-> feedback / VFX 종료 또는 분리
+-> actor Destroy
+```
+
+### 작업 프로세스 제안
+
+```text
+1. Dead state 진입 경로 전수 확인
+2. death reaction / feedback 완료 시점 확인
+3. AIController / BehaviorTree / Blackboard 종료 기준 확인
+4. collision / weapon / combat signal cleanup 순서 설계
+5. Destroy 시점 정책 결정
+6. EndPlay teardown과 중복 cleanup 여부 검증
+7. PIE에서 Dead -> cleanup -> Destroy smoke test
+```
+
+### 목표
+
+```text
+- Dead 이후 actor 종료 흐름을 명확히 한다.
+- Destroy 호출 전 필요한 gameplay cleanup을 정책화한다.
+- Destroy 이후 EndPlay teardown이 중복 호출되어도 안전한지 확인한다.
+- AI / weapon / collision / feedback이 죽은 actor를 계속 참조하지 않게 한다.
+```
+
+### 종료 조건
+
+```text
+- Dead state 진입 후 Destroy 시점이 문서와 코드에서 설명 가능하다.
+- death feedback / reaction이 의도한 시점까지 보존된다.
+- weapon collision / hit window / combat signal 경로가 닫힌다.
+- AIController / BT / perception 쪽 stale reference가 남지 않는다.
+- PIE에서 Dead 이후 crash 또는 stale collision이 재현되지 않는다.
+```
+
+### 구현 및 예상 수정 대상
+
+```text
+Source/Portfolio/Component/CHealthComponent.*
+Source/Portfolio/Component/CStateComponent.*
+Source/Portfolio/Component/CReactionComponent.*
+Source/Portfolio/Reaction/CReaction_Dead.*
+Source/Portfolio/Character/Enemy/CEnemy.*
+Source/Portfolio/Controller/CAIController.*
+Source/Portfolio/Component/CWeaponComponent.*
+Source/Portfolio/Weapon/CWeaponActor.*
+Source/Portfolio/System/Combat/*
+```
+
+후속 브랜치 후보:
+
+```text
+feature/dead-actor-destroy-flow
+refactor/dead-destroy-lifecycle-flow
+```
+
+---
+
+## 2. Execution Runtime Cleanup Boundary
+
+### 문제 / 필요성
+
+Action / Reaction interrupt 흐름은 이미 구현되어 있다.
+
+overlay, feedback window, weapon collision, hit context, ResultOut, Repulse 같은 상태와 결과 전달이 늘어나면 interrupt 과정의 cleanup 순서가 더 중요해진다.
+
+현재 cleanup은 다음 지점에 나뉘어 있다.
+
+```text
+Action / Reaction ClearRuntime
+Action / Reaction CleanupRuntimeEffects
+WeaponComponent ClearRuntimeWeaponState
+FeedbackComponent ClearRuntimeFeedback
+DefenseComponent ClearGuardState
+```
+
+이 흐름은 지금 구조에서 동작한다. 상태 간 영향이 커지면 다음 질문에 답해야 한다.
+
+```text
+cleanup 전에 어떤 데이터를 snapshot해야 하는가?
+weapon collision / hit context는 언제 닫아야 하는가?
+feedback은 cleanup 전 데이터로 실행하는가, cleanup 후 안정 상태에서 실행하는가?
+result-out dispatch는 active context clear 전인가 후인가?
+overlay는 reaction / dead / repulse 진입 시 유지하는가 지우는가?
+```
+
+### 현재 상태와 예상되는 문제
+
+현재는 action / reaction lifecycle이 안정적으로 종료되는 것이 핵심이었다.
+
+초기 구조에서는 overlay, external result dispatch, complex feedback dependency가 상대적으로 적었기 때문에 action / reaction이 자신의 runtime state를 정리하면 충분했다.
+
+다음 기능이 확장되면 cleanup 순서가 결과 품질에 직접 영향을 줄 수 있다.
+
+```text
+Guard overlay
+Parry / Repulse
+TimingCue
+CombatSignal outcome
+ResultOut
+Execution / Balance
+Dead / Stagger priority
+```
+
+예상 문제:
+
+```text
+- ClearRuntime 이후 feedback에 필요한 active action data가 사라질 수 있음
+- WeaponContext를 지운 뒤 result-out packet을 만들 수 있음
+- collision close가 늦어져 이미 중단된 공격이 추가 hit를 만들 수 있음
+- overlay cleanup이 reaction / dead / repulse 우선순위와 충돌할 수 있음
+- finish event listener가 cleanup 전후 상태를 다르게 해석할 수 있음
+```
+
+### 해결 방향
+
+gameplay runtime cleanup을 다음 단계로 나눠 정책화한다.
+
+```text
+Before
+-> active action / reaction / overlay / weapon / feedback context snapshot
+
+Transition
+-> 종료 또는 중단 원인 확정
+-> collision / hit window / feedback window 정리
+-> movement / state / overlay 적용 또는 복구
+-> result-out / consequence dispatch
+
+After
+-> active context clear
+-> runtime cache clear
+-> terminal event broadcast 또는 후처리
+```
+
+정확한 순서는 기능 사례가 생긴 뒤 확정한다.
+
+우선 적용 시점은 Repulse v1 또는 minimal ResultOut 구현 이후가 적절하다. 이때 attacker result, target outcome, reaction / feedback / weapon cleanup 순서가 실제 요구사항으로 드러난다.
+
+### 작업 프로세스 제안
+
+```text
+1. Action / Reaction 종료 및 interrupt 경로 전수 확인
+2. ClearRuntime / CleanupRuntimeEffects 호출 순서 정리
+3. Weapon / Feedback / Defense cleanup 호출 지점 목록화
+4. ResultOut / Repulse 사례에서 필요한 snapshot 데이터 정의
+5. cleanup 전후 상태표 작성
+6. result dispatch / feedback dispatch / active context clear 순서 결정
+7. 필요한 API 분리 또는 이름 보정
+8. PIE에서 interrupt / parry / dead / stagger smoke test
+```
+
+### 목표
+
+```text
+- action / reaction 상태 전환 전후의 데이터 보존 기준을 명확히 한다.
+- cleanup 순서를 정책으로 고정한다.
+- result dispatch와 feedback dispatch가 필요한 context를 잃지 않게 한다.
+- weapon collision / hit context / overlay / feedback runtime state가 의도한 시점에 정리되게 한다.
+```
+
+### 종료 조건
+
+```text
+- interrupt 전후 snapshot 기준이 문서화되어 있다.
+- ClearRuntime / CleanupRuntimeEffects / ClearRuntimeWeaponState / ClearRuntimeFeedback / ClearGuardState 호출 순서가 설명 가능하다.
+- ResultOut / Repulse 사례에서 필요한 데이터가 cleanup 전에 확보된다.
+- cleanup 이후 stale hit window, stale overlay, stale feedback state가 남지 않는다.
+- 기존 Action / Reaction interrupt smoke test가 통과한다.
+```
+
+### 구현 및 예상 수정 대상
+
+```text
+Source/Portfolio/Action/CAction.*
+Source/Portfolio/Action/CAction_Guard.*
+Source/Portfolio/Reaction/CReaction.*
+Source/Portfolio/Component/CActionComponent.*
+Source/Portfolio/Component/CReactionComponent.*
+Source/Portfolio/Component/CWeaponComponent.*
+Source/Portfolio/Component/CActionFeedbackComponent.*
+Source/Portfolio/Component/CReactionFeedbackComponent.*
+Source/Portfolio/Component/CDefenseComponent.*
+Source/Portfolio/Component/CCombatSignalTargetComponent.*
+Source/Portfolio/Component/CCombatSignalSourceComponent.*
+Source/Portfolio/Type/*
+```
+
+후속 브랜치 후보:
+
+```text
+refactor/execution-runtime-cleanup-boundary
+```
+
+---
+
+## P31과의 관계
+
+P31은 다음 후속 작업에서 사용할 cleanup hook을 신뢰할 수 있게 만드는 것을 목표로 한다.
+
+```text
+P31
+-> object lifecycle teardown cleanup 기준
+-> BeginPlay / EndPlay / OnPossess / OnUnPossess / timer / delegate / spawned actor cleanup
+
+Dead Destroy Flow
+-> Dead 이후 actor 종료 프로세스와 Destroy 전후 cleanup 순서
+
+Execution Runtime Cleanup Boundary
+-> 전투 상태 전환 중 snapshot / cleanup / result dispatch / active context clear 순서
+```
+
+---

--- a/Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
+++ b/Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
@@ -169,7 +169,7 @@ overlay, feedback window, weapon collision, hit context, ResultOut, Repulse 같�
 ```text
 Action / Reaction ClearRuntime
 Action / Reaction CleanupRuntimeEffects
-WeaponComponent ClearRuntimeWeaponState
+WeaponComponent ClearWeaponRuntimeState
 FeedbackComponent ClearRuntimeFeedback
 DefenseComponent ClearGuardState
 ```
@@ -262,7 +262,7 @@ After
 
 ```text
 - interrupt 전후 snapshot 기준이 문서화되어 있다.
-- ClearRuntime / CleanupRuntimeEffects / ClearRuntimeWeaponState / ClearRuntimeFeedback / ClearGuardState 호출 순서가 설명 가능하다.
+- ClearRuntime / CleanupRuntimeEffects / ClearWeaponRuntimeState / ClearRuntimeFeedback / ClearGuardState 호출 순서가 설명 가능하다.
 - ResultOut / Repulse 사례에서 필요한 데이터가 cleanup 전에 확보된다.
 - cleanup 이후 stale hit window, stale overlay, stale feedback state가 남지 않는다.
 - 기존 Action / Reaction interrupt smoke test가 통과한다.

--- a/Source/Portfolio/Action/CAction.cpp
+++ b/Source/Portfolio/Action/CAction.cpp
@@ -268,7 +268,7 @@ void UCAction::CleanupRuntimeEffects()
 {
 	if (IsValid(WeaponComp_Injected))
 	{
-		WeaponComp_Injected->ClearRuntimeWeaponState();
+		WeaponComp_Injected->ClearWeaponRuntimeState();
 	}
 
 	if (IsValid(ActionFeedbackComp_Injected))

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -69,12 +69,14 @@ void UCActionComponent::BeginPlay()
 {
 	Super::BeginPlay();
 
-	// Rebuild All
-	BuildActionDataMap(true);
-	BuildActionExecutorMap(true);
+	InitializeActionRuntime();
+}
 
-	// Init Action State
-	ActiveActionType = EActionType::Idle;
+void UCActionComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	UninitializeActionRuntime();
+
+	Super::EndPlay(EndPlayReason);
 }
 
 void UCActionComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
@@ -88,6 +90,49 @@ void UCActionComponent::TickComponent(float DeltaTime, ELevelTick TickType, FAct
 
 		actionExecutor->Tick(DeltaTime);
 	}
+}
+
+// Runtime Lifecycle
+
+void UCActionComponent::InitializeActionRuntime()
+{
+	BuildActionRuntimeMaps();
+	SetInitialActiveActionRuntimeState();
+}
+
+void UCActionComponent::UninitializeActionRuntime()
+{
+	ResetActiveActionRuntimeState();
+	ClearActionRuntimeMaps();
+}
+
+// Runtime Map
+
+void UCActionComponent::BuildActionRuntimeMaps()
+{
+	BuildActionDataMap(true);
+	BuildActionExecutorMap(true);
+}
+
+void UCActionComponent::ClearActionRuntimeMaps()
+{
+	ActionExecutorMap.Reset();
+	ActionDataMap.Reset();
+}
+
+// Active Runtime State
+
+void UCActionComponent::SetInitialActiveActionRuntimeState()
+{
+	ActiveActionType = EActionType::Idle;
+}
+
+void UCActionComponent::ResetActiveActionRuntimeState()
+{
+	ActiveActionType = EActionType::None;
+	ActiveActionIndex = INDEX_NONE;
+	ActiveActionData = FActionData();
+	ActiveActionExecutor = nullptr;
 }
 
 // Query

--- a/Source/Portfolio/Component/CActionComponent.h
+++ b/Source/Portfolio/Component/CActionComponent.h
@@ -93,6 +93,7 @@ private:
 protected:
 	// Lifecycle
 	void BeginPlay() override;
+	void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 public:
@@ -148,6 +149,20 @@ public:
 public:
 	// Event Broadcast
 	void BroadcastActionEvent(EActionType InType, int32 InIndex, EActionEventType InEventType);
+
+private:
+	// Runtime Lifecycle
+	void InitializeActionRuntime();
+	void UninitializeActionRuntime();
+
+private:
+	// Runtime Map
+	void BuildActionRuntimeMaps();
+	void ClearActionRuntimeMaps();
+
+	// Active Runtime State
+	void SetInitialActiveActionRuntimeState();
+	void ResetActiveActionRuntimeState();
 
 private:
 	// Data Build (temporary: move to DataAsset)

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -59,12 +59,56 @@ void UCReactionComponent::BeginPlay()
 {
 	Super::BeginPlay();
 
-	// Rebuild All
+	InitializeReactionRuntime();
+}
+
+void UCReactionComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	UninitializeReactionRuntime();
+
+	Super::EndPlay(EndPlayReason);
+}
+
+// Runtime Lifecycle
+
+void UCReactionComponent::InitializeReactionRuntime()
+{
+	BuildReactionRuntimeMaps();
+	SetInitialActiveReactionRuntimeState();
+}
+
+void UCReactionComponent::UninitializeReactionRuntime()
+{
+	ResetActiveReactionRuntimeState();
+	ClearReactionRuntimeMaps();
+}
+
+// Runtime Map
+
+void UCReactionComponent::BuildReactionRuntimeMaps()
+{
 	BuildReactionDataMap(true);
 	BuildReactionExecutorMap(true);
+}
 
-	// Init Reaction State
+void UCReactionComponent::ClearReactionRuntimeMaps()
+{
+	ReactionExecutorMap.Reset();
+	ReactionDataMap.Reset();
+}
+
+// Active Runtime State
+
+void UCReactionComponent::SetInitialActiveReactionRuntimeState()
+{
 	ActiveReactionType = EReactionType::Idle;
+}
+
+void UCReactionComponent::ResetActiveReactionRuntimeState()
+{
+	ActiveReactionType = EReactionType::None;
+	ActiveReactionData = FReactionData();
+	ActiveReactionExecutor = nullptr;
 }
 
 // Query

--- a/Source/Portfolio/Component/CReactionComponent.h
+++ b/Source/Portfolio/Component/CReactionComponent.h
@@ -79,6 +79,7 @@ private:
 protected:
 	// Lifecycle
 	void BeginPlay() override;
+	void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 public:
 	// Query
@@ -117,6 +118,21 @@ public:
 	void HandleReactionFeedback(FName InTriggerKey);
 	void HandleReactionFeedbackWindowBegin(FName InTriggerKey);
 	void HandleReactionFeedbackWindowEnd(FName InTriggerKey);
+
+private:
+	// Runtime Lifecycle
+	void InitializeReactionRuntime();
+	void UninitializeReactionRuntime();
+
+private:
+	// Runtime Map
+	void BuildReactionRuntimeMaps();
+	void ClearReactionRuntimeMaps();
+
+private:
+	// Active Runtime State
+	void SetInitialActiveReactionRuntimeState();
+	void ResetActiveReactionRuntimeState();
 
 private:
 	// Data Build (temporary: move to DataAsset)

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -42,17 +42,24 @@ bool UCWeaponComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+void UCWeaponComponent::BeginPlay()
+{
+	Super::BeginPlay();
+}
+
 void UCWeaponComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-	ClearRuntimeWeaponState();
-
-	if (IsValid(WeaponActor))
-	{
-		WeaponActor->Destroy();
-		WeaponActor = nullptr;
-	}
+	UninitializeWeaponRuntime();
 
 	Super::EndPlay(EndPlayReason);
+}
+
+// Runtime Lifecycle
+
+void UCWeaponComponent::UninitializeWeaponRuntime()
+{
+	ClearWeaponRuntimeState();
+	DestroyWeaponActor();
 }
 
 ACWeaponActor* UCWeaponComponent::GetWeaponActor()
@@ -113,7 +120,7 @@ void UCWeaponComponent::ClearContext()
 	provider->SetLastActionContext(FActionContext());
 }
 
-void UCWeaponComponent::ClearRuntimeWeaponState()
+void UCWeaponComponent::ClearWeaponRuntimeState()
 {
 	ClearContext();
 
@@ -122,6 +129,16 @@ void UCWeaponComponent::ClearRuntimeWeaponState()
 		WeaponActor->CollisionDisabled();
 		WeaponActor->ToggleTrailActive(false);
 	}
+}
+
+// Weapon Actor
+
+void UCWeaponComponent::DestroyWeaponActor()
+{
+	if (!IsValid(WeaponActor)) return;
+
+	WeaponActor->Destroy();
+	WeaponActor = nullptr;
 }
 
 void UCWeaponComponent::OpenCollisionWindow(FName InCollisionName)

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -55,6 +55,7 @@ private:
 
 protected:
 	// Lifecycle
+	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 public:
@@ -79,7 +80,7 @@ public:
 public:
 	void PushContext(const FActionContext& InActionContext);
 	void ClearContext();
-	void ClearRuntimeWeaponState();
+	void ClearWeaponRuntimeState();
 
 public:
 	void OpenCollisionWindow(FName InCollisionName);
@@ -87,6 +88,13 @@ public:
 
 private:
 	void ChangeWeaponType(EWeaponType InNewWeaponType);
+
+private:
+	// Runtime Lifecycle
+	void UninitializeWeaponRuntime();
+
+	// Weapon Actor
+	void DestroyWeaponActor();
 
 private:
 	FWeaponContext BuildWeaponContext() const;

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -6,6 +6,7 @@
 #include "Perception/AISenseConfig_Sight.h"
 #include "Perception/AIPerceptionTypes.h"
 #include "BehaviorTree/BlackboardComponent.h"
+#include "BrainComponent.h"
 
 #include "Character/Enemy/CEnemy.h"
 #include "AI/Patrol/CPatrolPath.h"
@@ -39,21 +40,25 @@ void ACAIController::OnPossess(APawn* InPawn)
 {
 	Super::OnPossess(InPawn);
 
-	if (!IsValid(InPawn)) return;
-
-	ControlledPawn_Cached = InPawn;
-
-	if (!InitializePerception()) return;
-	if (!InitializeBlackBoard()) return;
-	if (!InitializeBlackBoardValue()) return;
-	if (!InitializeBehaviorTree()) return;
+	if (!InitializeControllerRuntime(InPawn))
+	{
+		UninitializeControllerRuntime();
+		return;
+	}
 }
 
 void ACAIController::OnUnPossess()
 {
-	Super::OnUnPossess();
+	UninitializeControllerRuntime();
 
-	ControlledPawn_Cached = nullptr;
+	Super::OnUnPossess();
+}
+
+void ACAIController::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	UninitializeControllerRuntime();
+
+	Super::EndPlay(EndPlayReason);
 }
 
 bool ACAIController::InitializeSightConfig()
@@ -90,18 +95,75 @@ bool ACAIController::InitializeSightConfig()
 // 6. Task Node			: Executes the decided actions
 // -----------------------------------------------------------------------------
 
-bool ACAIController::InitializePerception()
-{
-	if (!IsValid(AIPerceptionComp)) return false;
+// Runtime Lifecycle
 
-	AIPerceptionComp->OnPerceptionUpdated.AddDynamic(this, &ACAIController::OnPerceptionUpdated);
-	AIPerceptionComp->OnTargetPerceptionUpdated.AddDynamic(this, &ACAIController::OnTargetPerceptionUpdated);
-	AIPerceptionComp->OnTargetPerceptionForgotten.AddDynamic(this, &ACAIController::OnTargetPerceptionForgotten);
+bool ACAIController::InitializeControllerRuntime(APawn* InPawn)
+{
+	if (!SetPossessionRuntimeState(InPawn)) return false;
+
+	ClearTargetDataMap();
+
+	if (!BindPerceptionEvents()) return false;
+	if (!SetupBlackboardComponent()) return false;
+	if (!SetInitialBlackboardRuntimeValues()) return false;
+	if (!StartBehaviorTreeRuntime()) return false;
 
 	return true;
 }
 
-bool ACAIController::InitializeBlackBoard()
+void ACAIController::UninitializeControllerRuntime()
+{
+	StopBehaviorTreeRuntime();
+	ClearBlackboardRuntimeValues();
+	UnbindPerceptionEvents();
+
+	ClearTargetDataMap();
+
+	ResetPossessionRuntimeState();
+}
+
+// Possession Runtime
+
+bool ACAIController::SetPossessionRuntimeState(APawn* InPawn)
+{
+	if (!IsValid(InPawn)) return false;
+
+	ControlledPawn_Cached = InPawn;
+	return true;
+}
+
+void ACAIController::ResetPossessionRuntimeState()
+{
+	ControlledPawn_Cached = nullptr;
+}
+
+// Perception Binding
+
+bool ACAIController::BindPerceptionEvents()
+{
+	if (!IsValid(AIPerceptionComp)) return false;
+
+	UnbindPerceptionEvents();
+
+	AIPerceptionComp->OnPerceptionUpdated.AddUniqueDynamic(this, &ACAIController::OnPerceptionUpdated);
+	AIPerceptionComp->OnTargetPerceptionUpdated.AddUniqueDynamic(this, &ACAIController::OnTargetPerceptionUpdated);
+	AIPerceptionComp->OnTargetPerceptionForgotten.AddUniqueDynamic(this, &ACAIController::OnTargetPerceptionForgotten);
+
+	return true;
+}
+
+void ACAIController::UnbindPerceptionEvents()
+{
+	if (!IsValid(AIPerceptionComp)) return;
+
+	AIPerceptionComp->OnPerceptionUpdated.RemoveDynamic(this, &ACAIController::OnPerceptionUpdated);
+	AIPerceptionComp->OnTargetPerceptionUpdated.RemoveDynamic(this, &ACAIController::OnTargetPerceptionUpdated);
+	AIPerceptionComp->OnTargetPerceptionForgotten.RemoveDynamic(this, &ACAIController::OnTargetPerceptionForgotten);
+}
+
+// Blackboard Setup
+
+bool ACAIController::SetupBlackboardComponent()
 {
 	if (!BlackboardAsset) return false;
 	if (!ValidateBlackboardKeys(BlackboardAsset)) return false;
@@ -113,14 +175,9 @@ bool ACAIController::InitializeBlackBoard()
 	return bUsed && IsValid(blackboardComp);
 }
 
-bool ACAIController::InitializeBehaviorTree()
-{
-	if (!BehaviorTreeAsset) return false;
+// Blackboard Runtime Value
 
-	return RunBehaviorTree(BehaviorTreeAsset);
-}
-
-bool ACAIController::InitializeBlackBoardValue()
+bool ACAIController::SetInitialBlackboardRuntimeValues()
 {
 	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return false;
@@ -221,6 +278,93 @@ bool ACAIController::InitializeBlackBoardValue()
 	return true;
 }
 
+void ACAIController::ClearBlackboardRuntimeValues()
+{
+	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
+	if (!IsValid(blackboardComp)) return;
+
+	// Targeting
+	blackboardComp->ClearValue(CAIKey::Targeting::TargetActor);
+	blackboardComp->ClearValue(CAIKey::Targeting::TargetPriority);
+
+	// State
+	blackboardComp->ClearValue(CAIKey::State::AIIntentState);
+
+	// Perception
+	blackboardComp->ClearValue(CAIKey::Perception::bHasLOS);
+	blackboardComp->ClearValue(CAIKey::Perception::LastSeenTime);
+	blackboardComp->ClearValue(CAIKey::Perception::LastKnownLocation);
+
+	// Metric
+	blackboardComp->ClearValue(CAIKey::Metric::DistanceToTarget);
+	blackboardComp->ClearValue(CAIKey::Metric::DistanceToHome);
+
+	// Navigation
+	blackboardComp->ClearValue(CAIKey::Navigation::HomeLocation);
+	blackboardComp->ClearValue(CAIKey::Navigation::bReturnHome);
+
+	// Patrol
+	blackboardComp->ClearValue(CAIKey::Patrol::bUsePatrol);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolPath);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolMode);
+	blackboardComp->ClearValue(CAIKey::Patrol::bPatrolReverse);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolLocation);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolIndex);
+
+	// Investigate
+	blackboardComp->ClearValue(CAIKey::Investigate::bUseInvestigate);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateDuration);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateMaxIndex);
+	blackboardComp->ClearValue(CAIKey::Investigate::bCanInvestigate);
+	blackboardComp->ClearValue(CAIKey::Investigate::bIsInvestigating);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateLocation);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateIndex);
+
+	// Chase
+	blackboardComp->ClearValue(CAIKey::Chase::ChaseOffsetRange);
+	blackboardComp->ClearValue(CAIKey::Chase::ChaseEnterBuffer);
+	blackboardComp->ClearValue(CAIKey::Chase::ChaseExitBuffer);
+
+	// Alert
+	blackboardComp->ClearValue(CAIKey::Alert::bUseAlertStep);
+	blackboardComp->ClearValue(CAIKey::Alert::StepForwardDistance);
+	blackboardComp->ClearValue(CAIKey::Alert::StepSideDistance);
+	blackboardComp->ClearValue(CAIKey::Alert::bInAlertRange);
+	blackboardComp->ClearValue(CAIKey::Alert::AlertStepLocation);
+
+	// Engage
+	blackboardComp->ClearValue(CAIKey::Engage::bShouldEngage);
+	blackboardComp->ClearValue(CAIKey::Engage::bCanCombatAction);
+	blackboardComp->ClearValue(CAIKey::Engage::bIsCombatAction);
+	blackboardComp->ClearValue(CAIKey::Engage::bInEngageRange);
+	blackboardComp->ClearValue(CAIKey::Engage::NextCombatActionTime);
+
+	// Reaction
+	blackboardComp->ClearValue(CAIKey::Reaction::bIsActiveReaction);
+
+	// Dead
+	blackboardComp->ClearValue(CAIKey::Dead::DeadState);
+}
+
+// Behavior Tree Runtime
+
+bool ACAIController::StartBehaviorTreeRuntime()
+{
+	if (!BehaviorTreeAsset) return false;
+
+	return RunBehaviorTree(BehaviorTreeAsset);
+}
+
+void ACAIController::StopBehaviorTreeRuntime()
+{
+	UBrainComponent* brainComp = GetBrainComponent();
+	if (!IsValid(brainComp)) return;
+
+	brainComp->StopLogic(TEXT("StopBehaviorTreeRuntime"));
+}
+
+// Perception Event Callback
+
 void ACAIController::OnPerceptionUpdated(const TArray<AActor*>& UpdatedActors)
 {
 	// [Disable OnPerceptionUpdated]
@@ -251,11 +395,15 @@ void ACAIController::OnTargetPerceptionForgotten(AActor* Actor)
 	// - TargetForgotten is Controlled by bHasLOS and bHasMemory
 }
 
+// Query
+
 EPerceptionBuildResult ACAIController::BuildPerceptionContext(FTargetData& OutTargetData)
 {
 	UpdateTargetDataMap();
 	return SelectTopPriority(OutTargetData);
 }
+
+// Blackboard Validation
 
 bool ACAIController::ValidateBlackboardKeys(const UBlackboardData* InBlackboardAsset) const
 {
@@ -417,6 +565,8 @@ bool ACAIController::ValidateBlackboardKey(const UBlackboardData* InBlackboardAs
 	return IsValid(InBlackboardAsset) && (InBlackboardAsset->GetKeyID(InKeyName) != FBlackboard::InvalidKey);
 }
 
+// Target Data
+
 void ACAIController::UpdateTargetDataMap()
 {
 	// -----------------------------------------------------------------------------
@@ -493,6 +643,11 @@ void ACAIController::UpdateTargetDataMap()
 	}
 }
 
+void ACAIController::ClearTargetDataMap()
+{
+	TargetDataMap.Reset();
+}
+
 EPerceptionBuildResult ACAIController::SelectTopPriority(FTargetData& OutTargetData)
 {
 	OutTargetData = FTargetData();
@@ -525,6 +680,7 @@ EPerceptionBuildResult ACAIController::SelectTopPriority(FTargetData& OutTargetD
 	return EPerceptionBuildResult::Success;
 }
 
+// Debug
 
 void ACAIController::PrintPerceptionUpdatedSummary(const TArray<AActor*>& UpdatedActors) const
 {

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -46,24 +46,43 @@ public:
 	ACAIController();
 
 protected:
+	// Lifecycle
 	void BeginPlay() override;
-
-protected:
 	void OnPossess(class APawn* InPawn) override;
 	void OnUnPossess() override;
+	void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 protected:
+	// Config Setup
 	bool InitializeSightConfig();
 
 private:
-	bool InitializePerception();
-	bool InitializeBlackBoard();
-	bool InitializeBehaviorTree();
+	// Runtime Lifecycle
+	bool InitializeControllerRuntime(class APawn* InPawn);
+	void UninitializeControllerRuntime();
 
 private:
-	bool InitializeBlackBoardValue();
+	// Possession Runtime
+	bool SetPossessionRuntimeState(class APawn* InPawn);
+	void ResetPossessionRuntimeState();
+
+	// Perception Binding
+	bool BindPerceptionEvents();
+	void UnbindPerceptionEvents();
+
+	// Blackboard Setup
+	bool SetupBlackboardComponent();
+
+	// Blackboard Runtime Value
+	bool SetInitialBlackboardRuntimeValues();
+	void ClearBlackboardRuntimeValues();
+
+	// Behavior Tree Runtime
+	bool StartBehaviorTreeRuntime();
+	void StopBehaviorTreeRuntime();
 
 private:
+	// Perception Event Callback
 	UFUNCTION()
 	void OnPerceptionUpdated(const TArray<class AActor*>& InUpdatedActors);
 
@@ -74,17 +93,22 @@ private:
 	void OnTargetPerceptionForgotten(class AActor* Actor);
 
 public:
+	// Query
 	EPerceptionBuildResult BuildPerceptionContext(FTargetData& OutTargetData);
 
 private:
+	// Blackboard Validation
 	bool ValidateBlackboardKeys(const UBlackboardData* InBlackboardAsset) const;
 	bool ValidateBlackboardKey(const UBlackboardData* InBlackboardAsset, const FName& InKeyName) const;
 
 private:
+	// Target Data
 	void UpdateTargetDataMap();
+	void ClearTargetDataMap();
 	EPerceptionBuildResult SelectTopPriority(FTargetData& OutTargetData);
 
 private:
+	// Debug
 	void PrintPerceptionUpdatedSummary(const TArray<class AActor*>& UpdatedActors) const;
 	void PrintTargetPerceptionUpdatedSummary(class AActor* Actor, const FAIStimulus& Stimulus) const;
 	void PrintTargetPerceptionForgotten(AActor* Actor) const;

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -7,6 +7,18 @@
 
 #include "Type/CWorldSubSystemStructure.h"
 
+void UCWorldSubsystem_CombatEngage::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+}
+
+void UCWorldSubsystem_CombatEngage::Deinitialize()
+{
+	ClearEngageRuntimeState();
+
+	Super::Deinitialize();
+}
+
 void UCWorldSubsystem_CombatEngage::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
@@ -24,18 +36,7 @@ TStatId UCWorldSubsystem_CombatEngage::GetStatId() const
 	RETURN_QUICK_DECLARE_CYCLE_STAT(UCWorldSubsystem_CombatEngage, STATGROUP_Tickables);
 }
 
-void UCWorldSubsystem_CombatEngage::Initialize(FSubsystemCollectionBase& Collection)
-{
-	Super::Initialize(Collection);
-}
-
-void UCWorldSubsystem_CombatEngage::Deinitialize()
-{
-	RequestContainer.Reset();
-	AssignmentContainer.Reset();
-
-	Super::Deinitialize();
-}
+// Query
 
 FEngageAssignmentContext UCWorldSubsystem_CombatEngage::GetAssignment(const ACAIController* InCAIController) const
 {
@@ -47,6 +48,8 @@ FEngageAssignmentContext UCWorldSubsystem_CombatEngage::GetAssignment(const ACAI
 	return *found;
 }
 
+// Request
+
 void UCWorldSubsystem_CombatEngage::SubmitRequest(const FEngageRequestContext & InEngageRequestContext)
 {
 	if (!IsValid(InEngageRequestContext.RequestController)) return;
@@ -54,6 +57,8 @@ void UCWorldSubsystem_CombatEngage::SubmitRequest(const FEngageRequestContext & 
 	// Override Request
 	RequestContainer.FindOrAdd(InEngageRequestContext.RequestController) = InEngageRequestContext;
 }
+
+// Assignment
 
 void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 {
@@ -112,6 +117,17 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 	// 3. Clear RequestContainer
 	RequestContainer.Reset();
 }
+
+// Runtime State
+
+void UCWorldSubsystem_CombatEngage::ClearEngageRuntimeState()
+{
+	ElapsedTime = 0.f;
+	RequestContainer.Reset();
+	AssignmentContainer.Reset();
+}
+
+// Debug
 
 void UCWorldSubsystem_CombatEngage::PrintEngageContext(const ACAIController* InCAIController, const AActor* InActor, const int& InPriority, const int& InIndex, const float& InDistance, const ECombatRole& InCombatRole) const
 {

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
@@ -28,18 +28,32 @@ private:
 	TMap<class ACAIController*, FEngageAssignmentContext> AssignmentContainer;
 
 public:
+	// Lifecycle
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
+
+public:
+	// Tick
 	virtual void Tick(float DeltaTime) override;
 	virtual TStatId GetStatId() const override;
 
 public:
+	// Query
 	FEngageAssignmentContext GetAssignment(const class ACAIController* InCAIController) const;
 
 public:
+	// Request
 	void SubmitRequest(const FEngageRequestContext & InEngageRequestContext);
+
+public:
+	// Assignment
 	void RebuildAssignments();
 
 private:
+	// Runtime State
+	void ClearEngageRuntimeState();
+
+private:
+	// Debug
 	void PrintEngageContext(const ACAIController* InCAIController, const AActor* InActor, const int& InPriority, const int& InIndex, const float& InDistance, const ECombatRole& InCombatRole) const;
 };

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
@@ -5,6 +5,20 @@
 
 #include "Type/CWorldSubSystemStructure.h"
 
+void UCWorldSubsystem_CombatFeedback::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+}
+
+void UCWorldSubsystem_CombatFeedback::Deinitialize()
+{
+	ClearFeedbackRuntimeState();
+
+	Super::Deinitialize();
+}
+
+// Request
+
 void UCWorldSubsystem_CombatFeedback::RequestHitStop(const FHitStopRequest& InHitStopRequest)
 {
 	// FLog::Log(TEXT("[UCWorldSubsystem_CombatFeedback] Request HitStop"));
@@ -39,6 +53,8 @@ void UCWorldSubsystem_CombatFeedback::RequestCameraShake(const FCameraShakeReque
 {
 	OnCameraShakeRequested.Broadcast(InCameraShakeRequest);
 }
+
+// HitStop
 
 void UCWorldSubsystem_CombatFeedback::ApplyHitStop(AActor* InActor, float InDuration, float InDilation)
 {
@@ -86,6 +102,48 @@ void UCWorldSubsystem_CombatFeedback::RestoreHitStop(TWeakObjectPtr<AActor> InAc
 	ActiveHitStopMap.Remove(InActorKey);
 	CachedTimeDilationMap.Remove(InActorKey);
 }
+
+void UCWorldSubsystem_CombatFeedback::ClearHitStop()
+{
+	if (UWorld* world = GetWorld())
+	{
+		FTimerManager& timerManager = world->GetTimerManager();
+
+		for (const TPair<TWeakObjectPtr<AActor>, FTimerHandle>& pair : ActiveHitStopMap)
+		{
+			FTimerHandle timerHandle = pair.Value;
+			timerManager.ClearTimer(timerHandle);
+		}
+	}
+
+	for (const TPair<TWeakObjectPtr<AActor>, float>& pair : CachedTimeDilationMap)
+	{
+		AActor* actor = pair.Key.Get();
+		if (!IsValid(actor)) continue;
+
+		actor->CustomTimeDilation = pair.Value;
+	}
+
+	ActiveHitStopMap.Reset();
+	CachedTimeDilationMap.Reset();
+}
+
+// CameraShake
+
+void UCWorldSubsystem_CombatFeedback::ClearCameraShake()
+{
+	OnCameraShakeRequested.Clear();
+}
+
+// Runtime State
+
+void UCWorldSubsystem_CombatFeedback::ClearFeedbackRuntimeState()
+{
+	ClearHitStop();
+	ClearCameraShake();
+}
+
+// Debug
 
 void UCWorldSubsystem_CombatFeedback::PrintHitStopConsumeInfo(AActor* InActor, float InDuration, float InDilation) const
 {

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
@@ -17,16 +17,34 @@ private:
 	TMap<TWeakObjectPtr<class AActor>, float> CachedTimeDilationMap;
 
 public:
+	// Delegate
 	FOnCombatCameraShakeRequested OnCameraShakeRequested;
 
 public:
+	// Lifecycle
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+public:
+	// Request
 	void RequestHitStop(const FHitStopRequest& InHitStopRequest);
 	void RequestCameraShake(const FCameraShakeRequest& InCameraShakeRequest);
 
 private:
+	// HitStop
 	void ApplyHitStop(AActor* InActor, float InDuration, float InDilation);
 	void RestoreHitStop(TWeakObjectPtr<AActor> InActorKey);
+	void ClearHitStop();
 
 private:
+	// CameraShake
+	void ClearCameraShake();
+
+private:
+	// Runtime State
+	void ClearFeedbackRuntimeState();
+
+private:
+	// Debug
 	void PrintHitStopConsumeInfo(AActor* InActor, float InDuration, float InDilation) const;
 };

--- a/Source/Portfolio/Weapon/CWeaponActor.cpp
+++ b/Source/Portfolio/Weapon/CWeaponActor.cpp
@@ -118,15 +118,12 @@ void ACWeaponActor::ClearCollisionComponents()
 void ACWeaponActor::InitializeTrailState()
 {
 	if (!bDisableTrailOnBeginPlay) return;
-	if (!IsValid(TrailComponent)) return;
 
 	ToggleTrailActive(false);
 }
 
 void ACWeaponActor::ClearTrailState()
 {
-	if (!IsValid(TrailComponent)) return;
-
 	ToggleTrailActive(false);
 }
 


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P31: Component Lifecycle Cleanup Policy**

## 날짜

**2026.06.30**

## 상태

- [x] 완료

---

## 브랜치

- `refactor/component-lifecycle-cleanup-policy`

---

## 커밋

```text
refactor(lifecycle): clarify runtime setup and teardown naming
```

---

## 요약

이번 PR은 actor / component lifecycle cleanup 기준을 정리한다.

P29에서는 character component reference 주입과 복구 흐름을 정리했고, P30에서는 runtime lookup을 DI 대상과 구분했다. 이번 작업에서는 그 다음 단계로 `BeginPlay` / `EndPlay` / `OnPossess` / `OnUnPossess` / delegate / timer / spawned actor / runtime cache 정리 기준을 점검한다.

핵심 목표는 cleanup 책임이 있는 지점을 식별하고, 코드와 문서에서 설명 가능한 lifecycle 기준을 남기는 것이다.

---

## 작업 배경

P30과 F05에서 WeaponActor의 runtime actor / collision / trail cleanup 흐름을 정리하면서, 더 넓은 lifecycle cleanup 기준이 필요하다는 점이 드러났다.

특히 다음 질문에 답할 수 있어야 한다.

```text
BeginPlay에서 bind한 delegate는 어디서 해제되는가?
OnPossess에서 만든 controller runtime state는 OnUnPossess에서 정리되는가?
timer로 변경한 actor state는 world teardown에서도 복구 또는 정리되는가?
spawned actor의 Destroy 책임은 어느 component가 가지는가?
gameplay cleanup과 object teardown cleanup은 같은 API로 처리해도 되는가?
```

---

## 사전 조회 결과

```text
Lifecycle hook 보유 파일: 11개
Delegate / Timer 사용 파일: 8개
SpawnActor / NewObject 생성 경로: 3개
Runtime cleanup 명명 사용처: 약 20개+
```

---

## 작업 범위

### 1. Lifecycle 사용처 전수 확인

대상:

```text
BeginPlay
EndPlay
NativeInitializeAnimation
NativeUninitializeAnimation
OnPossess
OnUnPossess
```

확인 기준:

```text
- setup / bind / cache가 있는지
- 대응 cleanup이 있는지
- 없는 경우 의도적으로 없어도 되는지
```

### 2. Delegate / Timer cleanup 점검

대상:

```text
AddDynamic
AddUniqueDynamic
AddUObject
RemoveDynamic
RemoveAll
SetTimer
ClearTimer
```

우선 후보:

```text
ACAIController
UCWorldSubsystem_CombatFeedback
```

### 3. Spawned actor / executor ownership 점검

대상:

```text
SpawnActor
Destroy
NewObject
```

우선 후보:

```text
UCWeaponComponent
UCActionComponent
UCReactionComponent
```

`UCWeaponComponent`는 P30/F05에서 보강한 흐름을 기준으로 확인한다. `UCActionComponent` / `UCReactionComponent`는 executor lifecycle이 gameplay execution과 연결되므로 execution 흐름 영향도를 별도로 판단한다.

### 4. Cleanup 명명 기준 정리

구분:

```text
Gameplay Runtime Cleanup
-> action / reaction / feedback / guard 같은 실행 중 임시 상태 정리

Lifecycle Teardown Cleanup
-> EndPlay / OnUnPossess / NativeUninitializeAnimation / subsystem teardown에서 delegate, timer, spawned actor, cache 정리
```

이번 PR은 `Lifecycle Teardown Cleanup` 기준을 우선 정리한다.
`Gameplay Runtime Cleanup`은 현재 Action / Reaction interrupt 흐름 위에서 동작하고 있으며, ResultOut / Repulse처럼 외부 결과 전달 사례가 생기면 snapshot, cleanup 순서, result dispatch 시점을 후속 작업에서 다시 검토한다.

Dead 이후 Actor Destroy 프로세스는 후속 작업으로 분리하고, 이번 PR에서는 Destroy flow가 추가될 때 사용할 수 있는 `EndPlay`, `OnUnPossess`, subsystem teardown, delegate / timer / spawned actor cleanup hook의 책임을 정리한다.

Dead Destroy Flow와 Execution Runtime Cleanup Boundary는 후속 노트에서 별도 추적한다.

---

## 예상 수정 후보

```text
Source/Portfolio/Controller/CAIController.*
Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.*
Source/Portfolio/Component/CActionComponent.*
Source/Portfolio/Component/CReactionComponent.*
Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
```

코드 변경은 조회 결과에서 수정 필요가 확인된 범위에 반영한다.

---

## 작업 결과

### 1. Runtime setup / teardown naming 기준 정리

상위 lifecycle 조합 함수는 `Initialize / Uninitialize`를 유지하고, 하위 작업은 실제 동작이 드러나는 이름으로 분리했다.

```text
상위 lifecycle
-> InitializeRuntime / UninitializeRuntime

map 구성 / 비움
-> Build / Clear

초기 상태 설정 / 기본 상태 복구
-> SetInitial / Reset

delegate 연결 / 해제
-> Bind / Unbind

logic 시작 / 중단
-> Start / Stop

spawned actor 생성 / 파괴
-> Create / Destroy
```

이 기준에 따라 `ActionComponent`, `ReactionComponent`, `AIController`, `WeaponComponent`의 helper API 이름을 정리했다.

### 2. ACAIController lifecycle cleanup

`OnPossess`에서 구성한 controller runtime을 `OnUnPossess`와 `EndPlay`에서 같은 teardown 경로로 닫도록 정리했다.

```text
InitializeControllerRuntime
-> SetPossessionRuntimeState
-> ClearTargetDataMap
-> BindPerceptionEvents
-> SetupBlackboardComponent
-> SetInitialBlackboardRuntimeValues
-> StartBehaviorTreeRuntime

UninitializeControllerRuntime
-> StopBehaviorTreeRuntime
-> ClearBlackboardRuntimeValues
-> UnbindPerceptionEvents
-> ClearTargetDataMap
-> ResetPossessionRuntimeState
```

`SetupBlackboardComponent()`는 `UseBlackboard()`로 blackboard component를 준비하고 key validity를 확인하는 단계다. UE에는 `UseBlackboard()`에 직접 대응하는 unregister API가 없으므로 teardown에서는 behavior tree logic을 먼저 멈춘 뒤 runtime key 값을 정리한다.

### 3. Action / Reaction runtime lifecycle

`ActionComponent`와 `ReactionComponent`는 `BeginPlay`에서 runtime map과 initial active state를 구성하고, `EndPlay`에서 broadcast 없는 teardown helper로 상태를 닫는다.

```text
Action
-> BuildActionRuntimeMaps
-> SetInitialActiveActionRuntimeState
-> ResetActiveActionRuntimeState
-> ClearActionRuntimeMaps

Reaction
-> BuildReactionRuntimeMaps
-> SetInitialActiveReactionRuntimeState
-> ResetActiveReactionRuntimeState
-> ClearReactionRuntimeMaps
```

`ClearActiveActionContext()` / `ClearActiveReactionContext()`는 gameplay event broadcast를 포함하므로 object teardown 경로에서는 직접 호출하지 않는다.

### 4. WeaponComponent runtime teardown

`WeaponComponent`는 `EndPlay`에서 `UninitializeWeaponRuntime()`을 호출하고, 내부에서 runtime weapon state 정리와 spawned weapon actor destroy를 명시적으로 나눴다.

```text
UninitializeWeaponRuntime
-> ClearWeaponRuntimeState
-> DestroyWeaponActor
```

`ClearWeaponRuntimeState()`는 gameplay 중 action cleanup에서도 호출될 수 있는 public API로 유지하고, object teardown에서만 필요한 actor destroy는 private helper로 분리했다.

### 5. Combat subsystem cleanup

`UCWorldSubsystem_CombatFeedback`은 `Deinitialize`에서 hit stop timer / cached dilation / camera shake delegate를 정리한다.

```text
ClearFeedbackRuntimeState
-> ClearHitStop
-> ClearCameraShake
```

`UCWorldSubsystem_CombatEngage`는 `Deinitialize`에서 request / assignment / elapsed time을 초기 상태로 되돌린다.

```text
ClearEngageRuntimeState
```

---

## 제외 범위

```text
- Action / Reaction 실행 종료 정책 재설계
- montage stop 정책 변경
- Guard / Reaction runtime cleanup 재설계
- 모든 _Injected reference를 EndPlay에서 일괄 null 처리
- Blink / Repulse / ResultOut 구현
- GAS 대응
```

---

## 검증 계획

```text
[x] rg 기반 lifecycle / delegate / timer / spawn 사용처 전수 확인
[x] git diff --check
[x] PortfolioEditor Win64 Development 빌드
[x] PIE 기본 combat loop smoke test
```

PIE 확인 결과:

```text
- Guard / Parry / Stagger / Damage / Blink cue route 로그 정상 확인
- crash / ensure / stale reference 로그 없음
```

---

## 관련 문서

```text
Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
Docs/06_notes/N14_Dead_Destroy_And_Execution_Cleanup_Followup_Note.md
Docs/06_notes/N12_Runtime_Component_Lookup_Policy_Note.md
Docs/04_Pull_Request/P30_UE5_Portfolio_Pull_Request.md
Docs/04-02_Fix_Pull_Request/F05_UE5_Portfolio_Pull_Request_Fix.md
```

---
