### PR TITLE
P32: AI Blackboard Key Registry 정책 정리

### DIFF
--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -542,7 +542,7 @@ Runtime cleanup 명명 사용처: 약 20개+
 - 상태: 진행 중
 - 브랜치: `refactor/ai-blackboard-key-registry`
 - PR: `P32_UE5_Portfolio_Pull_Request.md`
-- 목표: `CAIKey` 정의를 spec 기반으로 정리하고, blackboard required key 검증 기준을 registry 중심으로 묶어 키 추가 / 삭제 시 누락 위험을 줄인다. Initial runtime value 설정과 teardown clear registry화는 후속 후보로 검토한다.
+- 목표: `CAIKey` 정의를 spec 기반으로 정리하고, blackboard required key 검증 기준과 initial runtime value 설정 흐름을 정리하여 키 추가 / 삭제 시 누락 위험을 줄인다. Teardown clear registry화는 후속 후보로 검토한다.
 - 관련 문서: `N15_AI_Blackboard_Key_Registry_Policy_Note.md`, `N16_AI_Blackboard_Key_Contract_Decision_Note.md`
 - 제외 범위: BehaviorTree asset 재설계, BT Service / Task 행동 로직 변경, AI update interval 튜닝, Enhanced Input migration
 
@@ -551,11 +551,14 @@ Runtime cleanup 명명 사용처: 약 20개+
 ```text
 핵심 파일:
 1. Source/Portfolio/AI/Blackboard/CAIKey.h
-2. Source/Portfolio/Controller/CAIController.*
-3. Source/Portfolio/AI/BehaviorTree/Service/*
-4. Source/Portfolio/AI/BehaviorTree/Task/*
-5. Source/Portfolio/AI/BehaviorTree/Decorator/*
-6. Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+2. Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
+3. Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
+4. Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+5. Source/Portfolio/Controller/CAIController.*
+6. Source/Portfolio/AI/BehaviorTree/Service/*
+7. Source/Portfolio/AI/BehaviorTree/Task/*
+8. Source/Portfolio/AI/BehaviorTree/Decorator/*
+9. Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 
 blackboard key 직접 사용 파일:
 23개
@@ -568,12 +571,17 @@ blackboard key 직접 사용 파일:
    -> key category namespace는 유지
    -> key name / key type / required 기준은 `FAIBlackboardKeySpec`로 결합
 
-2. ACAIController
+2. CAIKeyTypes.h / CAIKeyFactory.h / CAIKeyRegistry.h
+   -> key spec 타입, 생성 helper, 전체 등록 / 검증 책임 분리
+
+3. ACAIController
    -> required key validation은 registry 순회로 이동
-   -> SetInitialBlackboardRuntimeValues 수동 나열은 후속 후보
+   -> InitializeBlackboardRuntimeValues는 registry 1회 순회에서 fixed / owner-location / custom policy를 분기
+   -> custom policy는 custom value 적용 후 pending 검증
+   -> fixed / owner initial value는 registry 순회로 적용
    -> ClearBlackboardRuntimeValues 수동 나열은 후속 후보
 
-3. BT Service / Task / Decorator
+4. BT Service / Task / Decorator
    -> CAIKey를 직접 읽고 쓰는 runtime 사용처
    -> 이번 작업에서는 로직 변경 없이 registry 기준과 맞는지 확인
 ```
@@ -582,7 +590,7 @@ blackboard key 직접 사용 파일:
 
 ```text
 - CAIKey spec / registry / ValidateRequiredKeys 사용처 정적 확인
-- SetInitialBlackboardRuntimeValues / ClearBlackboardRuntimeValues 누락 여부 확인
+- InitializeBlackboardRuntimeValues / ClearBlackboardRuntimeValues 누락 여부 확인
 - git diff --check
 - PortfolioEditor Win64 Development 빌드
 - PIE AI basic loop smoke test

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -554,11 +554,12 @@ Runtime cleanup 명명 사용처: 약 20개+
 2. Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
 3. Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
 4. Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
-5. Source/Portfolio/Controller/CAIController.*
-6. Source/Portfolio/AI/BehaviorTree/Service/*
-7. Source/Portfolio/AI/BehaviorTree/Task/*
-8. Source/Portfolio/AI/BehaviorTree/Decorator/*
-9. Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+5. Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
+6. Source/Portfolio/Controller/CAIController.*
+7. Source/Portfolio/AI/BehaviorTree/Service/*
+8. Source/Portfolio/AI/BehaviorTree/Task/*
+9. Source/Portfolio/AI/BehaviorTree/Decorator/*
+10. Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 
 blackboard key 직접 사용 파일:
 23개
@@ -571,15 +572,14 @@ blackboard key 직접 사용 파일:
    -> key category namespace는 유지
    -> key name / key type / required 기준은 `FAIBlackboardKeySpec`로 결합
 
-2. CAIKeyTypes.h / CAIKeyFactory.h / CAIKeyRegistry.h
-   -> key spec 타입, 생성 helper, 전체 등록 / 검증 책임 분리
+2. CAIKeyTypes.h / CAIKeyFactory.h / CAIKeyRegistry.h / CAIBlackboardValueHelper.h
+   -> key spec 타입, 생성 helper, 전체 등록 / 검증 / value 적용 책임 분리
 
 3. ACAIController
    -> required key validation은 registry 순회로 이동
-   -> InitializeBlackboardRuntimeValues는 registry 1회 순회에서 fixed / owner-location / custom policy를 분기
-   -> custom policy는 custom value 적용 후 pending 검증
-   -> fixed / owner initial value는 registry 순회로 적용
-   -> ClearBlackboardRuntimeValues는 bClearOnRuntimeTeardown 기준 registry 순회로 적용
+   -> InitializeBlackboardValues는 helper common 초기화 / controller custom 초기화 / helper pending 검증 흐름으로 정리
+   -> fixed / owner / clear 공통 적용은 helper로 분리
+   -> custom value source 적용은 controller에 유지
 
 4. BT Service / Task / Decorator
    -> CAIKey를 직접 읽고 쓰는 runtime 사용처
@@ -590,7 +590,7 @@ blackboard key 직접 사용 파일:
 
 ```text
 - CAIKey spec / registry / ValidateRequiredKeys 사용처 정적 확인
-- InitializeBlackboardRuntimeValues / ClearBlackboardRuntimeValues 누락 여부 확인
+- InitializeBlackboardValues / ClearBlackboardValues 누락 여부 확인
 - git diff --check
 - PortfolioEditor Win64 Development 빌드
 - PIE AI basic loop smoke test

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -542,7 +542,7 @@ Runtime cleanup 명명 사용처: 약 20개+
 - 상태: 진행 중
 - 브랜치: `refactor/ai-blackboard-key-registry`
 - PR: `P32_UE5_Portfolio_Pull_Request.md`
-- 목표: `CAIKey` 정의를 spec 기반으로 정리하고, blackboard required key 검증 기준과 initial runtime value 설정 흐름을 정리하여 키 추가 / 삭제 시 누락 위험을 줄인다. Teardown clear registry화는 후속 후보로 검토한다.
+- 목표: `CAIKey` 정의를 spec 기반으로 정리하고, blackboard required key 검증 기준과 initial / clear runtime value 흐름을 정리하여 키 추가 / 삭제 시 누락 위험을 줄인다.
 - 관련 문서: `N15_AI_Blackboard_Key_Registry_Policy_Note.md`, `N16_AI_Blackboard_Key_Contract_Decision_Note.md`
 - 제외 범위: BehaviorTree asset 재설계, BT Service / Task 행동 로직 변경, AI update interval 튜닝, Enhanced Input migration
 
@@ -579,7 +579,7 @@ blackboard key 직접 사용 파일:
    -> InitializeBlackboardRuntimeValues는 registry 1회 순회에서 fixed / owner-location / custom policy를 분기
    -> custom policy는 custom value 적용 후 pending 검증
    -> fixed / owner initial value는 registry 순회로 적용
-   -> ClearBlackboardRuntimeValues 수동 나열은 후속 후보
+   -> ClearBlackboardRuntimeValues는 bClearOnRuntimeTeardown 기준 registry 순회로 적용
 
 4. BT Service / Task / Decorator
    -> CAIKey를 직접 읽고 쓰는 runtime 사용처

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -23,14 +23,17 @@
 1. refactor/unreal-reference-safety-v1
 2. refactor/character-component-reference-di
 3. refactor/runtime-component-lookup-policy
-4. refactor/debug-log-policy-v1
-5. refactor/todo-status-cleanup
+4. refactor/ai-blackboard-key-registry
+5. perf/ai-update-interval-audit
 6. refactor/tuning-constants-cleanup
-7. refactor/naming-typo-api-cleanup
-8. refactor/api-const-consistency
-9. refactor/ai-blackboard-key-registry
-10. perf/ai-update-interval-audit
-11. refactor/enhanced-input-migration
+7. refactor/api-const-consistency
+8. refactor/debug-log-policy-v1
+9. refactor/naming-typo-api-cleanup
+10. refactor/todo-status-cleanup
+11. docs/pr-record-format-sweep
+
+별도 후순위:
+- refactor/enhanced-input-migration
 ```
 
 ---
@@ -488,7 +491,7 @@ refactor/runtime-component-lookup-policy
 
 ### P31. Component Lifecycle Cleanup Policy
 
-- 상태: 진행 중
+- 상태: 완료
 - 브랜치: `refactor/component-lifecycle-cleanup-policy`
 - PR: `P31_UE5_Portfolio_Pull_Request.md`
 - 목표: P29~P30 이후 남은 actor / component lifecycle cleanup 기준을 정리하고, `BeginPlay` / `EndPlay` / delegate / timer / spawned actor / runtime cache 정리 정책을 고정한다.
@@ -532,4 +535,54 @@ Runtime cleanup 명명 사용처: 약 20개+
 - git diff --check
 - PortfolioEditor Win64 Development 빌드
 - PIE 기본 combat loop smoke test
+```
+
+### P32. AI Blackboard Key Registry
+
+- 상태: 준비 중
+- 브랜치: `refactor/ai-blackboard-key-registry`
+- PR: `P32_UE5_Portfolio_Pull_Request.md`
+- 목표: `CAIKey` 정의, blackboard required key 검증, initial runtime value 설정, teardown clear 기준을 registry 중심으로 묶어 키 추가 / 삭제 시 누락 위험을 줄인다.
+- 관련 문서: `N15_AI_Blackboard_Key_Registry_Policy_Note.md`
+- 제외 범위: BehaviorTree asset 재설계, BT Service / Task 행동 로직 변경, AI update interval 튜닝, Enhanced Input migration
+
+준비 단계 조회 결과:
+
+```text
+핵심 파일:
+1. Source/Portfolio/AI/Blackboard/CAIKey.h
+2. Source/Portfolio/Controller/CAIController.*
+3. Source/Portfolio/AI/BehaviorTree/Service/*
+4. Source/Portfolio/AI/BehaviorTree/Task/*
+5. Source/Portfolio/AI/BehaviorTree/Decorator/*
+6. Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+
+blackboard key 직접 사용 파일:
+23개
+```
+
+우선 검토 대상:
+
+```text
+1. CAIKey.h
+   -> key name만 있고 key type / required / initial / clear 정책은 없음
+
+2. ACAIController
+   -> ValidateBlackboardKeys 수동 나열
+   -> SetInitialBlackboardRuntimeValues 수동 나열
+   -> ClearBlackboardRuntimeValues 수동 나열
+
+3. BT Service / Task / Decorator
+   -> CAIKey를 직접 읽고 쓰는 runtime 사용처
+   -> 이번 작업에서는 로직 변경 없이 registry 기준과 맞는지 확인
+```
+
+검증 기준:
+
+```text
+- CAIKey / registry / ValidateBlackboardKeys 사용처 정적 확인
+- SetInitialBlackboardRuntimeValues / ClearBlackboardRuntimeValues 누락 여부 확인
+- git diff --check
+- PortfolioEditor Win64 Development 빌드
+- PIE AI basic loop smoke test
 ```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -539,11 +539,11 @@ Runtime cleanup 명명 사용처: 약 20개+
 
 ### P32. AI Blackboard Key Registry
 
-- 상태: 준비 중
+- 상태: 진행 중
 - 브랜치: `refactor/ai-blackboard-key-registry`
 - PR: `P32_UE5_Portfolio_Pull_Request.md`
-- 목표: `CAIKey` 정의, blackboard required key 검증, initial runtime value 설정, teardown clear 기준을 registry 중심으로 묶어 키 추가 / 삭제 시 누락 위험을 줄인다.
-- 관련 문서: `N15_AI_Blackboard_Key_Registry_Policy_Note.md`
+- 목표: `CAIKey` 정의를 spec 기반으로 정리하고, blackboard required key 검증 기준을 registry 중심으로 묶어 키 추가 / 삭제 시 누락 위험을 줄인다. Initial runtime value 설정과 teardown clear registry화는 후속 후보로 검토한다.
+- 관련 문서: `N15_AI_Blackboard_Key_Registry_Policy_Note.md`, `N16_AI_Blackboard_Key_Contract_Decision_Note.md`
 - 제외 범위: BehaviorTree asset 재설계, BT Service / Task 행동 로직 변경, AI update interval 튜닝, Enhanced Input migration
 
 준비 단계 조회 결과:
@@ -565,12 +565,13 @@ blackboard key 직접 사용 파일:
 
 ```text
 1. CAIKey.h
-   -> key name만 있고 key type / required / initial / clear 정책은 없음
+   -> key category namespace는 유지
+   -> key name / key type / required 기준은 `FAIBlackboardKeySpec`로 결합
 
 2. ACAIController
-   -> ValidateBlackboardKeys 수동 나열
-   -> SetInitialBlackboardRuntimeValues 수동 나열
-   -> ClearBlackboardRuntimeValues 수동 나열
+   -> required key validation은 registry 순회로 이동
+   -> SetInitialBlackboardRuntimeValues 수동 나열은 후속 후보
+   -> ClearBlackboardRuntimeValues 수동 나열은 후속 후보
 
 3. BT Service / Task / Decorator
    -> CAIKey를 직접 읽고 쓰는 runtime 사용처
@@ -580,7 +581,7 @@ blackboard key 직접 사용 파일:
 검증 기준:
 
 ```text
-- CAIKey / registry / ValidateBlackboardKeys 사용처 정적 확인
+- CAIKey spec / registry / ValidateRequiredKeys 사용처 정적 확인
 - SetInitialBlackboardRuntimeValues / ClearBlackboardRuntimeValues 누락 여부 확인
 - git diff --check
 - PortfolioEditor Win64 Development 빌드

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -37,5 +37,6 @@
 | P29 | Character Component 참조 주입 / 복구 | `P29_UE5_Portfolio_Pull_Request.md` | `refactor/character-component-reference-di` |  | W05, N10, N11, B14 |
 | P30 | Runtime Component 조회 정책 | `P30_UE5_Portfolio_Pull_Request.md` | `refactor/runtime-component-lookup-policy` |  | W05, N12 |
 | P31 | Component Lifecycle Cleanup Policy | `P31_UE5_Portfolio_Pull_Request.md` | `refactor/component-lifecycle-cleanup-policy` |  | W05, N13, N14 |
+| P32 | AI Blackboard Key Registry | `P32_UE5_Portfolio_Pull_Request.md` | `refactor/ai-blackboard-key-registry` |  | W05, N15 |
 
 ---

--- a/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
@@ -11,7 +11,7 @@
 ## 상태
 
 - [x] 작업 방향 수립
-- [ ] 코드 / 문서 반영
+- [x] 코드 / 문서 반영
 - [ ] 검증 완료
 
 ---
@@ -34,7 +34,7 @@ TBD
 
 이번 PR은 AI blackboard key 정의 / 검증 / 초기화 / 정리 기준을 registry 중심으로 정리한다.
 
-현재 `CAIKey`는 key name vocabulary 역할을 하지만, required key 검증과 runtime value 초기화 / 정리는 `ACAIController`에서 수동으로 길게 나열되어 있다. 이 구조는 key 추가 또는 삭제 시 누락 위험이 크고, BehaviorTree key 계약을 코드에서 설명하기 어렵다.
+현재 `CAIKey`는 key category vocabulary 역할을 하지만, required key 검증과 runtime value 초기화 / 정리는 `ACAIController`에서 수동으로 길게 나열되어 있다. 이 구조는 key 추가 또는 삭제 시 누락 위험이 크고, BehaviorTree key 계약을 코드에서 설명하기 어렵다.
 
 핵심 목표는 AI 행동 로직을 바꾸지 않고, blackboard key 계약을 한 곳에서 읽고 검증할 수 있게 만드는 것이다.
 
@@ -49,6 +49,7 @@ P31에서 `ACAIController` lifecycle cleanup을 정리하면서 blackboard setup
 ```text
 CAIKey.h
 -> key name만 정의
+-> key type / required 여부는 별도 위치에 있음
 
 ACAIController::ValidateBlackboardKeys
 -> required key를 수동 나열
@@ -87,7 +88,7 @@ blackboard key 직접 사용 파일:
 
 ## 작업 범위
 
-### 1. Blackboard key registry 도입
+### 1. Blackboard key spec / registry 도입
 
 목표:
 
@@ -101,14 +102,25 @@ blackboard key 직접 사용 파일:
 
 를 한 곳에서 확인할 수 있게 한다.
 
-후보:
+변경:
 
 ```text
 Source/Portfolio/AI/Blackboard/CAIKey.h
+-> FAIBlackboardKeySpec 기반 key 정의
+-> CAIKey::Category::KeySpec.KeyName 사용
+
 Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+-> 전체 key spec 등록
+-> required key validation
 ```
 
-registry가 너무 커지면 별도 파일로 분리한다.
+`CAIKey`는 category namespace 사용감을 유지하고, `CAIKeyRegistry`는 전체 key 목록과 검증 흐름을 담당한다.
+
+`CAIKey`를 자유 FName / DataAsset 기반 입력으로 풀지 않은 이유는 별도 결정 문서에 정리했다.
+
+```text
+Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
+```
 
 ### 2. Required key validation 단일화
 
@@ -117,9 +129,9 @@ registry가 너무 커지면 별도 파일로 분리한다.
 변경 방향:
 
 ```text
-registry의 required key 목록 순회
--> ValidateBlackboardKey 호출
--> 누락 key 로그 또는 ensure 정책 적용
+CAIKeyRegistry::GetKeySpecs 순회
+-> CAIKeyRegistry::ValidateRequiredKeys 호출
+-> 누락 key 이름과 expected type ensure
 ```
 
 ### 3. Initial / Clear runtime value 기준 정리
@@ -128,11 +140,12 @@ registry의 required key 목록 순회
 
 ```text
 SetInitialBlackboardRuntimeValues
--> registry 기반 공통 초기값 적용
--> enemy instance에서 가져와야 하는 tuning 값은 별도 apply helper 유지
+-> 이번 커밋에서는 기존 흐름 유지
+-> 후속 작업에서 fixed value / owner value / enemy setting value 분리 검토
 
 ClearBlackboardRuntimeValues
--> registry 기반 clear 대상 순회
+-> 이번 커밋에서는 기존 흐름 유지
+-> 후속 작업에서 clear 대상 registry 순회 검토
 ```
 
 ### 4. BT Service / Task / Decorator 사용처 확인
@@ -145,6 +158,7 @@ BT 노드의 blackboard read / write 로직은 이번 PR에서 기능 변경하�
 - registry에 없는 key를 직접 사용하지 않는지
 - key type과 GetValueAs / SetValueAs API가 일치하는지
 - controller 초기화 / clear 대상에서 누락된 key가 없는지
+- Blackboard API 호출부가 `CAIKey::Category::KeySpec.KeyName` 형태로 정리됐는지
 ```
 
 ---
@@ -166,11 +180,20 @@ BT 노드의 blackboard read / write 로직은 이번 PR에서 기능 변경하�
 
 ```text
 rg 기반 CAIKey / blackboard 사용처 전수 확인
-registry required key와 ValidateBlackboardKeys 경로 확인
-registry initial / clear 대상과 controller runtime value 경로 확인
+registry required key와 ValidateRequiredKeys 경로 확인
+CAIKey spec과 Blackboard API KeyName 전달 경로 확인
 git diff --check
 PortfolioEditor Win64 Development 빌드
 PIE AI basic loop smoke test
+```
+
+현재 확인:
+
+```text
+git diff --check 통과
+PortfolioEditor Win64 Development 빌드 통과
+required key 누락 시 ensureMsgf 경로 적용
+PIE AI basic loop smoke test 대기
 ```
 
 ---
@@ -180,6 +203,7 @@ PIE AI basic loop smoke test
 ```text
 Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
 Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
+Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
 Docs/04_Pull_Request/P31_UE5_Portfolio_Pull_Request.md
 Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
 ```

--- a/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
@@ -12,7 +12,7 @@
 
 - [x] 작업 방향 수립
 - [x] 코드 / 문서 반영
-- [ ] 검증 완료
+- [x] 검증 완료
 
 ---
 
@@ -54,10 +54,10 @@ CAIKey.h
 ACAIController::ValidateBlackboardKeys
 -> required key를 수동 나열
 
-ACAIController::InitializeBlackboardRuntimeValues
+ACAIController::InitializeBlackboardValues
 -> 초기 runtime 값을 수동 나열
 
-ACAIController::ClearBlackboardRuntimeValues
+ACAIController::ClearBlackboardValues
 -> clear 대상을 수동 나열
 ```
 
@@ -123,6 +123,10 @@ Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
 Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
 -> 전체 key spec 등록
 -> required key validation
+
+Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
+-> initial / custom / clear blackboard value 적용 helper
+-> custom pending key mark / validate
 ```
 
 `CAIKey`는 category namespace 사용감을 유지하고, `CAIKeyRegistry`는 전체 key 목록과 검증 흐름을 담당한다.
@@ -135,7 +139,7 @@ Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
 
 ### 2. Required key validation 단일화
 
-현재 `ValidateBlackboardKeys()`는 모든 required key를 수동 변수로 선언하고 다시 `bAllValid`에 합산한다.
+기존 `ValidateBlackboardKeys()`는 모든 required key를 수동 변수로 선언하고 다시 `bAllValid`에 합산했다.
 
 변경 방향:
 
@@ -150,14 +154,15 @@ CAIKeyRegistry::GetKeySpecs 순회
 초기값이 필요한 key와 단순 clear만 필요한 key를 구분한다.
 
 ```text
-InitializeBlackboardRuntimeValues
--> ApplyInitialBlackboardValues: registry 1회 순회
+InitializeBlackboardValues
+-> CAIBlackboardValueHelper::InitializeValues: registry 1회 순회
 -> Fixed / FromOwnerLocation / Custom policy 분기
 -> Custom key는 pending set에 등록
--> ApplyCustomBlackboardValues에서 처리된 custom key 제거
--> 남은 custom key가 있으면 ensure
+-> InitializeCustomBlackboardValues에서 처리된 custom key 제거
+-> CAIBlackboardValueHelper::ValidateCustomKeysApplied로 누락 검증
 
-ClearBlackboardRuntimeValues
+ClearBlackboardValues
+-> CAIBlackboardValueHelper::ClearValues 호출
 -> CAIKeyRegistry::GetKeySpecs 순회
 -> bClearOnRuntimeTeardown 대상만 ClearValue
 ```
@@ -197,6 +202,7 @@ rg 기반 CAIKey / blackboard 사용처 전수 확인
 registry required key와 ValidateRequiredKeys 경로 확인
 CAIKey spec과 Blackboard API KeyName 전달 경로 확인
 CAIKeyTypes / CAIKeyFactory / CAIKey / CAIKeyRegistry 책임 분리 확인
+CAIBlackboardValueHelper initial / custom / clear helper 경로 확인
 initial blackboard value policy / default value 순회 확인
 blackboard clear 대상 bClearOnRuntimeTeardown 순회 확인
 git diff --check
@@ -211,9 +217,12 @@ git diff --check 통과
 PortfolioEditor Win64 Development 빌드 통과
 required key 누락 시 ensureMsgf 경로 적용
 initial blackboard value fixed / owner는 registry 순회 적용
-custom value는 명시 helper 유지
+custom value source 적용은 controller에 유지
+common blackboard value 적용 / pending 검증은 CAIBlackboardValueHelper로 분리
 clear runtime value는 bClearOnRuntimeTeardown 기준 registry 순회 적용
-PIE AI basic loop smoke test 대기
+PIE AI basic loop smoke test 통과
+combat damage / guard / parry / stagger / enemy Blink cue delivery 정상 확인
+player Blink cue reject는 player-side target resolve 부재로 인한 기존 기능 범위 밖 동작으로 분류
 ```
 
 ---

--- a/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
@@ -2,7 +2,7 @@
 
 ## 제목
 
-**P32: AI Blackboard Key Registry**
+**P32: AI Blackboard Key Registry 정책 정리**
 
 ## 날짜
 
@@ -25,7 +25,14 @@
 ## 커밋
 
 ```text
-TBD
+docs(ai): plan blackboard key registry cleanup
+refactor(ai): add blackboard key registry
+refactor(ai): validate blackboard keys through registry
+refactor(ai): define blackboard key specs
+refactor(ai): organize blackboard key initialization policy
+refactor(ai): apply blackboard clear policy from registry
+refactor(ai): centralize blackboard key registry
+style(ai): normalize blackboard include casing
 ```
 
 ---

--- a/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
@@ -54,7 +54,7 @@ CAIKey.h
 ACAIController::ValidateBlackboardKeys
 -> required key를 수동 나열
 
-ACAIController::SetInitialBlackboardRuntimeValues
+ACAIController::InitializeBlackboardRuntimeValues
 -> 초기 runtime 값을 수동 나열
 
 ACAIController::ClearBlackboardRuntimeValues
@@ -69,7 +69,10 @@ ACAIController::ClearBlackboardRuntimeValues
 
 ```text
 핵심 key 정의:
+Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
+Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
 Source/Portfolio/AI/Blackboard/CAIKey.h
+Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
 
 blackboard setup / validate / initialize / clear:
 Source/Portfolio/Controller/CAIController.*
@@ -107,7 +110,15 @@ blackboard key 직접 사용 파일:
 ```text
 Source/Portfolio/AI/Blackboard/CAIKey.h
 -> FAIBlackboardKeySpec 기반 key 정의
+-> CAIKeyFactory helper 기반 key spec 생성
+-> RuntimeValue key는 possession 초기화에서 제외
 -> CAIKey::Category::KeySpec.KeyName 사용
+
+Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
+-> EAIBlackboardKeyValueType / EAIBlackboardInitialValuePolicy / FAIBlackboardKeySpec 정의
+
+Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
+-> fixed / runtime / owner / custom key spec 생성 helper 분리
 
 Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
 -> 전체 key spec 등록
@@ -139,9 +150,12 @@ CAIKeyRegistry::GetKeySpecs 순회
 초기값이 필요한 key와 단순 clear만 필요한 key를 구분한다.
 
 ```text
-SetInitialBlackboardRuntimeValues
--> 이번 커밋에서는 기존 흐름 유지
--> 후속 작업에서 fixed value / owner value / enemy setting value 분리 검토
+InitializeBlackboardRuntimeValues
+-> ApplyInitialBlackboardValues: registry 1회 순회
+-> Fixed / FromOwnerLocation / Custom policy 분기
+-> Custom key는 pending set에 등록
+-> ApplyCustomBlackboardValues에서 처리된 custom key 제거
+-> 남은 custom key가 있으면 ensure
 
 ClearBlackboardRuntimeValues
 -> 이번 커밋에서는 기존 흐름 유지
@@ -182,6 +196,8 @@ BT 노드의 blackboard read / write 로직은 이번 PR에서 기능 변경하�
 rg 기반 CAIKey / blackboard 사용처 전수 확인
 registry required key와 ValidateRequiredKeys 경로 확인
 CAIKey spec과 Blackboard API KeyName 전달 경로 확인
+CAIKeyTypes / CAIKeyFactory / CAIKey / CAIKeyRegistry 책임 분리 확인
+initial blackboard value policy / default value 순회 확인
 git diff --check
 PortfolioEditor Win64 Development 빌드
 PIE AI basic loop smoke test
@@ -193,6 +209,8 @@ PIE AI basic loop smoke test
 git diff --check 통과
 PortfolioEditor Win64 Development 빌드 통과
 required key 누락 시 ensureMsgf 경로 적용
+initial blackboard value fixed / owner는 registry 순회 적용
+custom value는 명시 helper 유지
 PIE AI basic loop smoke test 대기
 ```
 

--- a/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,187 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P32: AI Blackboard Key Registry**
+
+## 날짜
+
+**2026.06.30**
+
+## 상태
+
+- [x] 작업 방향 수립
+- [ ] 코드 / 문서 반영
+- [ ] 검증 완료
+
+---
+
+## 브랜치
+
+- `refactor/ai-blackboard-key-registry`
+
+---
+
+## 커밋
+
+```text
+TBD
+```
+
+---
+
+## 요약
+
+이번 PR은 AI blackboard key 정의 / 검증 / 초기화 / 정리 기준을 registry 중심으로 정리한다.
+
+현재 `CAIKey`는 key name vocabulary 역할을 하지만, required key 검증과 runtime value 초기화 / 정리는 `ACAIController`에서 수동으로 길게 나열되어 있다. 이 구조는 key 추가 또는 삭제 시 누락 위험이 크고, BehaviorTree key 계약을 코드에서 설명하기 어렵다.
+
+핵심 목표는 AI 행동 로직을 바꾸지 않고, blackboard key 계약을 한 곳에서 읽고 검증할 수 있게 만드는 것이다.
+
+---
+
+## 작업 배경
+
+P31에서 `ACAIController` lifecycle cleanup을 정리하면서 blackboard setup / runtime value / behavior tree start 순서가 명확해졌다.
+
+그 과정에서 다음 문제가 남아 있는 것이 확인됐다.
+
+```text
+CAIKey.h
+-> key name만 정의
+
+ACAIController::ValidateBlackboardKeys
+-> required key를 수동 나열
+
+ACAIController::SetInitialBlackboardRuntimeValues
+-> 초기 runtime 값을 수동 나열
+
+ACAIController::ClearBlackboardRuntimeValues
+-> clear 대상을 수동 나열
+```
+
+즉 key를 하나 추가하면 최소 세 곳 이상을 같이 수정해야 한다.
+
+---
+
+## 사전 조회 결과
+
+```text
+핵심 key 정의:
+Source/Portfolio/AI/Blackboard/CAIKey.h
+
+blackboard setup / validate / initialize / clear:
+Source/Portfolio/Controller/CAIController.*
+
+runtime key 사용처:
+Source/Portfolio/AI/BehaviorTree/Service/*
+Source/Portfolio/AI/BehaviorTree/Task/*
+Source/Portfolio/AI/BehaviorTree/Decorator/*
+Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+
+blackboard key 직접 사용 파일:
+23개
+```
+
+---
+
+## 작업 범위
+
+### 1. Blackboard key registry 도입
+
+목표:
+
+```text
+- key name
+- expected blackboard value type
+- required 여부
+- initial value 적용 대상 여부
+- clear 대상 여부
+```
+
+를 한 곳에서 확인할 수 있게 한다.
+
+후보:
+
+```text
+Source/Portfolio/AI/Blackboard/CAIKey.h
+Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+```
+
+registry가 너무 커지면 별도 파일로 분리한다.
+
+### 2. Required key validation 단일화
+
+현재 `ValidateBlackboardKeys()`는 모든 required key를 수동 변수로 선언하고 다시 `bAllValid`에 합산한다.
+
+변경 방향:
+
+```text
+registry의 required key 목록 순회
+-> ValidateBlackboardKey 호출
+-> 누락 key 로그 또는 ensure 정책 적용
+```
+
+### 3. Initial / Clear runtime value 기준 정리
+
+초기값이 필요한 key와 단순 clear만 필요한 key를 구분한다.
+
+```text
+SetInitialBlackboardRuntimeValues
+-> registry 기반 공통 초기값 적용
+-> enemy instance에서 가져와야 하는 tuning 값은 별도 apply helper 유지
+
+ClearBlackboardRuntimeValues
+-> registry 기반 clear 대상 순회
+```
+
+### 4. BT Service / Task / Decorator 사용처 확인
+
+BT 노드의 blackboard read / write 로직은 이번 PR에서 기능 변경하지 않는다.
+
+확인 기준:
+
+```text
+- registry에 없는 key를 직접 사용하지 않는지
+- key type과 GetValueAs / SetValueAs API가 일치하는지
+- controller 초기화 / clear 대상에서 누락된 key가 없는지
+```
+
+---
+
+## 제외 범위
+
+```text
+- BehaviorTree asset 재설계
+- BT Service / Task / Decorator 행동 로직 변경
+- AI update interval 조정
+- perception / target selection 정책 변경
+- engage assignment 알고리즘 변경
+- Enhanced Input migration
+```
+
+---
+
+## 검증 계획
+
+```text
+rg 기반 CAIKey / blackboard 사용처 전수 확인
+registry required key와 ValidateBlackboardKeys 경로 확인
+registry initial / clear 대상과 controller runtime value 경로 확인
+git diff --check
+PortfolioEditor Win64 Development 빌드
+PIE AI basic loop smoke test
+```
+
+---
+
+## 관련 문서
+
+```text
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
+Docs/04_Pull_Request/P31_UE5_Portfolio_Pull_Request.md
+Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
+```
+
+---

--- a/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P32_UE5_Portfolio_Pull_Request.md
@@ -158,8 +158,8 @@ InitializeBlackboardRuntimeValues
 -> 남은 custom key가 있으면 ensure
 
 ClearBlackboardRuntimeValues
--> 이번 커밋에서는 기존 흐름 유지
--> 후속 작업에서 clear 대상 registry 순회 검토
+-> CAIKeyRegistry::GetKeySpecs 순회
+-> bClearOnRuntimeTeardown 대상만 ClearValue
 ```
 
 ### 4. BT Service / Task / Decorator 사용처 확인
@@ -198,6 +198,7 @@ registry required key와 ValidateRequiredKeys 경로 확인
 CAIKey spec과 Blackboard API KeyName 전달 경로 확인
 CAIKeyTypes / CAIKeyFactory / CAIKey / CAIKeyRegistry 책임 분리 확인
 initial blackboard value policy / default value 순회 확인
+blackboard clear 대상 bClearOnRuntimeTeardown 순회 확인
 git diff --check
 PortfolioEditor Win64 Development 빌드
 PIE AI basic loop smoke test
@@ -211,6 +212,7 @@ PortfolioEditor Win64 Development 빌드 통과
 required key 누락 시 ensureMsgf 경로 적용
 initial blackboard value fixed / owner는 registry 순회 적용
 custom value는 명시 helper 유지
+clear runtime value는 bClearOnRuntimeTeardown 기준 registry 순회 적용
 PIE AI basic loop smoke test 대기
 ```
 

--- a/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
+++ b/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
@@ -39,7 +39,7 @@ clear 대상 여부
 runtime owner
 ```
 
-현재 분산 상태:
+기존 분산 상태:
 
 ```text
 CAIKey.h
@@ -64,7 +64,7 @@ BT Service / Task / Decorator
 
 ### 1. key 추가 / 삭제 시 수정 지점이 많다
 
-현재는 key를 하나 추가하면 다음 위치를 모두 맞춰야 한다.
+기존에는 key를 하나 추가하면 다음 위치를 모두 맞춰야 했다.
 
 ```text
 CAIKey.h
@@ -202,8 +202,8 @@ Custom key는 조용히 무시하지 않는다. Registry 순회 중 pending set�
 
 ```text
 ClearBlackboardRuntimeValues
--> GetRuntimeClearBlackboardKeySpecs()
--> ClearValue 반복
+-> CAIKeyRegistry::GetKeySpecs 순회
+-> bClearOnRuntimeTeardown 대상만 ClearValue 반복
 ```
 
 단, `DeadState`처럼 clear보다 Alive reset이 의미적으로 맞는 key는 registry에서 clear 대상이 아닌 reset 대상으로 분류할 수 있다.
@@ -315,10 +315,6 @@ Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 - BT node behavior는 변경되지 않는다.
 - 빌드와 PIE AI smoke test가 통과한다.
 ```
-
-teardown clear registry화는 같은 주제의 후속 후보로 남긴다.
-
----
 
 ## 후속 분리
 

--- a/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
+++ b/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
@@ -1,0 +1,275 @@
+# N15. AI Blackboard Key Registry Policy Note
+
+## 목적
+
+이 문서는 `refactor/ai-blackboard-key-registry` 작업의 설계 기준을 정리한다.
+
+목표는 BehaviorTree 동작을 바꾸는 것이 아니라, blackboard key 계약을 코드에서 한 곳에 모아 검증 / 초기화 / 정리 누락을 줄이는 것이다.
+
+---
+
+## 현재 구조
+
+현재 key name은 `CAIKey.h`에 namespace로 묶여 있다.
+
+```text
+Targeting
+State
+Perception
+Metric
+Navigation
+Patrol
+Investigate
+Chase
+Alert
+Engage
+Reaction
+Dead
+```
+
+이 구조는 key vocabulary로는 읽기 쉽지만, 다음 정보는 별도로 흩어져 있다.
+
+```text
+key type
+required 여부
+initial value 적용 여부
+clear 대상 여부
+runtime owner
+```
+
+현재 분산 상태:
+
+```text
+CAIKey.h
+-> key name 정의
+
+ACAIController::ValidateBlackboardKeys
+-> required key 수동 검증
+
+ACAIController::SetInitialBlackboardRuntimeValues
+-> initial runtime value 수동 설정
+
+ACAIController::ClearBlackboardRuntimeValues
+-> teardown clear 대상 수동 나열
+
+BT Service / Task / Decorator
+-> CAIKey 직접 read / write
+```
+
+---
+
+## 문제
+
+### 1. key 추가 / 삭제 시 수정 지점이 많다
+
+현재는 key를 하나 추가하면 다음 위치를 모두 맞춰야 한다.
+
+```text
+CAIKey.h
+ValidateBlackboardKeys
+SetInitialBlackboardRuntimeValues
+ClearBlackboardRuntimeValues
+BT node usage
+Blackboard asset
+```
+
+누락되면 컴파일은 되지만 runtime blackboard key가 없거나 초기값이 비어 있는 상태가 될 수 있다.
+
+### 2. required key 기준을 코드에서 설명하기 어렵다
+
+`ValidateBlackboardKeys()`는 수동 변수와 `bAllValid` 누적이 길게 나열되어 있다.
+
+이 방식은 key 목록 전체를 검토하기 어렵고, 누락된 key 이름을 추적하기 어렵다.
+
+### 3. 초기값과 clear 정책이 key 정의와 떨어져 있다
+
+어떤 key가 controller possess 시점에 초기값을 받아야 하는지, 어떤 key가 teardown에서 clear되어야 하는지 `CAIKey`만 보고 알 수 없다.
+
+---
+
+## 설계 방향
+
+### 1. CAIKey는 vocabulary로 유지한다
+
+BT Service / Task / Decorator에서 이미 `CAIKey::Category::KeyName` 형태를 넓게 사용하고 있으므로, key name namespace는 유지한다.
+
+이번 작업에서 모든 BT 노드 사용처를 wrapper API로 강제 이전하지 않는다.
+
+### 2. registry는 key contract를 담당한다
+
+registry는 다음 정보를 제공한다.
+
+```text
+FName KeyName
+EBlackboardKeyContractType ValueType
+bool bRequired
+bool bClearOnRuntimeTeardown
+```
+
+초기값까지 registry에 넣을지 여부는 key 성격에 따라 나눈다.
+
+```text
+공통 fixed initial value
+-> registry 또는 helper table에서 처리 가능
+
+enemy instance에서 읽어야 하는 value
+-> controller helper에서 별도 적용 유지
+```
+
+예:
+
+```text
+CAIKey::State::AIIntentState
+-> fixed initial value: Idle
+
+CAIKey::Navigation::HomeLocation
+-> owner pawn location 필요
+
+CAIKey::Patrol::bUsePatrol
+-> ACEnemy instance 설정 필요
+```
+
+### 3. Validation은 registry 순회로 바꾼다
+
+```text
+ValidateBlackboardKeys
+-> GetRequiredBlackboardKeySpecs()
+-> ValidateBlackboardKey 반복
+```
+
+검증 실패 시 key name과 expected type을 로그에 남길 수 있게 한다.
+
+### 4. Runtime value setup은 두 단계로 나눈다
+
+```text
+SetInitialBlackboardRuntimeValues
+-> ApplyFixedInitialBlackboardValues
+-> ApplyOwnerBlackboardValues
+```
+
+고정 초기값과 enemy instance 기반 값을 구분하면 함수가 길어지는 문제를 줄일 수 있다.
+
+### 5. Clear는 registry 기반으로 단순화한다
+
+```text
+ClearBlackboardRuntimeValues
+-> GetRuntimeClearBlackboardKeySpecs()
+-> ClearValue 반복
+```
+
+단, `DeadState`처럼 clear보다 Alive reset이 의미적으로 맞는 key는 registry에서 clear 대상이 아닌 reset 대상으로 분류할 수 있다.
+
+---
+
+## 구현 후보
+
+### Option A. CAIKey.h 안에 registry 추가
+
+장점:
+
+```text
+- key name과 key contract가 한 파일에 있음
+- 작은 변경으로 시작 가능
+```
+
+단점:
+
+```text
+- CAIKey.h가 길어짐
+- type / default value helper가 늘어나면 부담
+```
+
+### Option B. CAIKeyRegistry.h 추가
+
+장점:
+
+```text
+- CAIKey는 name vocabulary로 유지
+- registry / validation / initial / clear 정책을 분리 가능
+```
+
+단점:
+
+```text
+- 파일이 하나 늘어남
+- include 정리가 필요
+```
+
+추천:
+
+```text
+Option B
+```
+
+이유:
+
+```text
+CAIKey.h는 기존 BT 노드가 넓게 include하고 있으므로 가볍게 유지하는 편이 낫다.
+registry는 controller setup / validation 쪽에서 주로 사용하므로 별도 파일이 책임 분리에 맞다.
+```
+
+---
+
+## 예상 수정 대상
+
+```text
+Source/Portfolio/AI/Blackboard/CAIKey.h
+Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+Source/Portfolio/Controller/CAIController.h
+Source/Portfolio/Controller/CAIController.cpp
+```
+
+확인 대상:
+
+```text
+Source/Portfolio/AI/BehaviorTree/Service/*
+Source/Portfolio/AI/BehaviorTree/Task/*
+Source/Portfolio/AI/BehaviorTree/Decorator/*
+Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+```
+
+---
+
+## 작업 순서 제안
+
+```text
+1. CAIKey usage 목록을 key category별로 정리
+2. FAIBlackboardKeySpec / EAIBlackboardKeyValueType 후보 정의
+3. required key registry 구성
+4. ValidateBlackboardKeys를 registry 순회로 변경
+5. clear 대상 registry 구성
+6. ClearBlackboardRuntimeValues를 registry 순회로 변경
+7. fixed initial value helper 분리
+8. owner / enemy 기반 initial value helper 분리
+9. BT Service / Task / Decorator key type 사용처 정적 확인
+10. 빌드 / PIE smoke test
+```
+
+---
+
+## 완료 조건
+
+```text
+- required blackboard key 목록이 registry에서 확인된다.
+- ValidateBlackboardKeys의 수동 bool 나열이 제거된다.
+- ClearBlackboardRuntimeValues의 수동 ClearValue 나열이 줄어든다.
+- initial runtime value 설정이 fixed value와 owner / enemy 기반 value로 구분된다.
+- BT node behavior는 변경되지 않는다.
+- 빌드와 PIE AI smoke test가 통과한다.
+```
+
+---
+
+## 후속 분리
+
+이번 작업에서는 AI update interval을 조정하지 않는다.
+
+후속 작업:
+
+```text
+perf/ai-update-interval-audit
+```
+
+에서 BT Service interval, perception update, engage rebuild interval을 별도로 검토한다.
+
+---

--- a/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
+++ b/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
@@ -6,6 +6,8 @@
 
 목표는 BehaviorTree 동작을 바꾸는 것이 아니라, blackboard key 계약을 코드에서 한 곳에 모아 검증 / 초기화 / 정리 누락을 줄이는 것이다.
 
+`CAIKey`를 data-driven 입력으로 풀지 않고 C++ contract vocabulary로 유지한 결정 배경은 `N16_AI_Blackboard_Key_Contract_Decision_Note.md`에 별도로 정리한다.
+
 ---
 
 ## 현재 구조
@@ -89,19 +91,31 @@ Blackboard asset
 
 ## 설계 방향
 
-### 1. CAIKey는 vocabulary로 유지한다
+### 1. CAIKey는 spec vocabulary로 유지한다
 
-BT Service / Task / Decorator에서 이미 `CAIKey::Category::KeyName` 형태를 넓게 사용하고 있으므로, key name namespace는 유지한다.
+BT Service / Task / Decorator에서 이미 `CAIKey::Category::KeyName` 형태를 넓게 사용하고 있으므로, category namespace는 유지한다.
 
-이번 작업에서 모든 BT 노드 사용처를 wrapper API로 강제 이전하지 않는다.
+다만 `CAIKey`의 값은 단순 `FName`이 아니라 `FAIBlackboardKeySpec`로 정의한다.
 
-### 2. registry는 key contract를 담당한다
+```text
+CAIKey::Targeting::TargetActor
+-> FAIBlackboardKeySpec
 
-registry는 다음 정보를 제공한다.
+CAIKey::Targeting::TargetActor.KeyName
+-> Blackboard API에 전달하는 FName
+```
+
+이렇게 하면 key category 사용감은 유지하면서 key name / expected type / required 여부 같은 계약 정보를 key 정의 근처에 둘 수 있다.
+
+### 2. registry는 key 등록과 검증을 담당한다
+
+`CAIKey.h`는 개별 key의 계약 정보를 정의하고, `CAIKeyRegistry.h`는 전체 key 목록 등록과 검증 흐름을 담당한다.
+
+key spec은 다음 정보를 제공한다.
 
 ```text
 FName KeyName
-EBlackboardKeyContractType ValueType
+EAIBlackboardKeyValueType ValueType
 bool bRequired
 bool bClearOnRuntimeTeardown
 ```
@@ -119,25 +133,38 @@ enemy instance에서 읽어야 하는 value
 예:
 
 ```text
-CAIKey::State::AIIntentState
+CAIKey::State::AIIntentState.KeyName
 -> fixed initial value: Idle
 
-CAIKey::Navigation::HomeLocation
+CAIKey::Navigation::HomeLocation.KeyName
 -> owner pawn location 필요
 
-CAIKey::Patrol::bUsePatrol
+CAIKey::Patrol::bUsePatrol.KeyName
 -> ACEnemy instance 설정 필요
 ```
 
 ### 3. Validation은 registry 순회로 바꾼다
 
 ```text
-ValidateBlackboardKeys
--> GetRequiredBlackboardKeySpecs()
--> ValidateBlackboardKey 반복
+ACAIController::SetupBlackboardComponent
+-> CAIKeyRegistry::ValidateRequiredKeys
+-> CAIKeyRegistry::GetKeySpecs 순회
+-> required key 검증
 ```
 
-검증 실패 시 key name과 expected type을 로그에 남길 수 있게 한다.
+검증 실패 시 누락된 key name과 expected type을 모아 `ensureMsgf` 1회로 남긴다.
+
+```text
+[AIKeyRegistry] Missing required Blackboard keys | Blackboard=... | Missing=TargetActor:Object, ...
+```
+
+개별 key마다 별도 로그를 찍지 않는 이유:
+
+```text
+- required blackboard key 누락은 asset 계약 위반이므로 ensure가 적합하다.
+- 누락 key마다 ensure / log를 남기면 callstack과 로그가 과해진다.
+- 최종 ensure 1회가 Blackboard asset, 누락 key 목록, expected type을 함께 보여준다.
+```
 
 ### 4. Runtime value setup은 두 단계로 나눈다
 
@@ -161,51 +188,49 @@ ClearBlackboardRuntimeValues
 
 ---
 
-## 구현 후보
+## 구현 결정
 
-### Option A. CAIKey.h 안에 registry 추가
-
-장점:
+### 선택한 형태
 
 ```text
-- key name과 key contract가 한 파일에 있음
-- 작은 변경으로 시작 가능
+CAIKey.h
+-> EAIBlackboardKeyValueType
+-> FAIBlackboardKeySpec
+-> CAIKey::Category::KeySpec
+
+CAIKeyRegistry.h
+-> GetKeySpecs()
+-> ValidateRequiredKeys()
+-> missing required key ensure
+
+BT Service / Task / Decorator
+-> CAIKey::Category::KeySpec.KeyName 사용
 ```
 
-단점:
+이 형태는 다음 기준을 만족한다.
 
 ```text
-- CAIKey.h가 길어짐
-- type / default value helper가 늘어나면 부담
+- key category 네임스페이스 사용감 유지
+- key name과 expected type 정의 위치 결합
+- 전체 key 등록 목록은 registry에서 별도 관리
+- Blackboard API에는 명시적으로 KeyName만 전달
 ```
 
-### Option B. CAIKeyRegistry.h 추가
-
-장점:
+### 다른 후보를 사용하지 않은 이유
 
 ```text
-- CAIKey는 name vocabulary로 유지
-- registry / validation / initial / clear 정책을 분리 가능
-```
+- 단순 FName vocabulary 유지
+  -> key type 정의가 registry에만 남아 CAIKey와 중복 관리된다.
 
-단점:
+- CAIKey.h 안에 전체 registry까지 포함
+  -> CAIKey.h가 key 정의 / 전체 등록 / 검증 책임을 모두 가지게 된다.
 
-```text
-- 파일이 하나 늘어남
-- include 정리가 필요
-```
+- 모든 BT 사용처를 wrapper API로 이전
+  -> 이번 PR의 목적보다 변경 범위가 커지고 BT node behavior 검증 부담이 커진다.
 
-추천:
-
-```text
-Option B
-```
-
-이유:
-
-```text
-CAIKey.h는 기존 BT 노드가 넓게 include하고 있으므로 가볍게 유지하는 편이 낫다.
-registry는 controller setup / validation 쪽에서 주로 사용하므로 별도 파일이 책임 분리에 맞다.
+- 자유 FName / DataAsset 기반 key profile
+  -> 현재 규모에서는 유연성보다 추적성 저하와 검증 부담이 더 크다.
+  -> enemy별 key profile이 필요해지는 시점에 별도 확장한다.
 ```
 
 ---
@@ -234,15 +259,12 @@ Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 
 ```text
 1. CAIKey usage 목록을 key category별로 정리
-2. FAIBlackboardKeySpec / EAIBlackboardKeyValueType 후보 정의
+2. FAIBlackboardKeySpec / EAIBlackboardKeyValueType 정의
 3. required key registry 구성
-4. ValidateBlackboardKeys를 registry 순회로 변경
-5. clear 대상 registry 구성
-6. ClearBlackboardRuntimeValues를 registry 순회로 변경
-7. fixed initial value helper 분리
-8. owner / enemy 기반 initial value helper 분리
-9. BT Service / Task / Decorator key type 사용처 정적 확인
-10. 빌드 / PIE smoke test
+4. ValidateBlackboardKeys 수동 검증 제거
+5. CAIKey 사용처를 KeySpec.KeyName 전달 방식으로 변경
+6. BT Service / Task / Decorator key type 사용처 정적 확인
+7. 빌드 / PIE smoke test
 ```
 
 ---
@@ -252,11 +274,13 @@ Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 ```text
 - required blackboard key 목록이 registry에서 확인된다.
 - ValidateBlackboardKeys의 수동 bool 나열이 제거된다.
-- ClearBlackboardRuntimeValues의 수동 ClearValue 나열이 줄어든다.
-- initial runtime value 설정이 fixed value와 owner / enemy 기반 value로 구분된다.
+- 검증 실패 시 누락 key 목록과 expected type이 ensure로 확인된다.
+- Blackboard API 호출부는 KeySpec이 아니라 KeySpec.KeyName을 전달한다.
 - BT node behavior는 변경되지 않는다.
 - 빌드와 PIE AI smoke test가 통과한다.
 ```
+
+초기값 설정과 teardown clear registry화는 같은 주제의 후속 후보로 남긴다. 이번 커밋에서는 required key 계약 검증과 key spec 정의를 먼저 안정화한다.
 
 ---
 

--- a/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
+++ b/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
@@ -48,10 +48,10 @@ CAIKey.h
 ACAIController::ValidateBlackboardKeys
 -> required key 수동 검증
 
-ACAIController::InitializeBlackboardRuntimeValues
+ACAIController::InitializeBlackboardValues
 -> initial runtime value 수동 설정
 
-ACAIController::ClearBlackboardRuntimeValues
+ACAIController::ClearBlackboardValues
 -> teardown clear 대상 수동 나열
 
 BT Service / Task / Decorator
@@ -69,8 +69,8 @@ BT Service / Task / Decorator
 ```text
 CAIKey.h
 ValidateBlackboardKeys
-InitializeBlackboardRuntimeValues
-ClearBlackboardRuntimeValues
+InitializeBlackboardValues
+ClearBlackboardValues
 BT node usage
 Blackboard asset
 ```
@@ -179,29 +179,30 @@ ACAIController::SetupBlackboardComponent
 ### 4. Runtime value setup은 두 단계로 나눈다
 
 ```text
-InitializeBlackboardRuntimeValues
--> ApplyInitialBlackboardValues: registry 1회 순회
+InitializeBlackboardValues
+-> CAIBlackboardValueHelper::InitializeValues: registry 1회 순회
 -> Fixed / FromOwnerLocation / Custom policy 분기
 -> Custom key는 pending set에 등록
--> ApplyCustomBlackboardValues에서 custom value 명시 적용
+-> InitializeCustomBlackboardValues에서 custom value 명시 적용
 -> 처리된 custom key는 pending set에서 제거
--> 남은 custom key가 있으면 ensure
+-> CAIBlackboardValueHelper::ValidateCustomKeysApplied로 누락 검증
 ```
 
 고정 초기값과 owner 위치 기반 값은 key spec의 policy로 자동 적용한다.
 
-Custom value는 key마다 source가 다르므로 controller helper에서 명시 적용한다. 이 부분까지 함수 포인터 / lambda / variant로 자동화하면 key contract가 gameplay object access까지 알게 되므로 이번 범위에서는 제외한다.
+Custom value는 key마다 source가 다르므로 controller에서 명시 적용한다. 이 부분까지 함수 포인터 / lambda / variant로 자동화하면 key contract가 gameplay object access까지 알게 되므로 이번 범위에서는 제외한다.
 
-`Custom` policy는 registry가 자동 적용하지 않는 domain-specific 초기값을 의미한다. 현재 구현에서는 `ACAIController::ApplyCustomBlackboardValues`가 custom value를 명시적으로 적용한다.
+`Custom` policy는 registry가 자동 적용하지 않는 domain-specific 초기값을 의미한다. 현재 구현에서는 `ACAIController::InitializeCustomBlackboardValues`가 custom value를 명시적으로 적용한다.
 
-Custom key는 조용히 무시하지 않는다. Registry 순회 중 pending set에 등록하고, domain-specific 적용이 끝난 뒤에도 남아 있으면 ensure로 누락을 드러낸다.
+Custom key는 조용히 무시하지 않는다. Registry 순회 중 pending set에 등록하고, domain-specific 적용이 끝난 뒤에도 남아 있으면 `CAIBlackboardValueHelper`의 ensure로 누락을 드러낸다.
 
 `RuntimeValue`는 key name / type / required / clear 계약은 필요하지만 possession 초기화 시점에는 의미 있는 값이 없는 key에 사용한다. 예를 들어 `LastSeenTime`, `LastKnownLocation`, `DistanceToTarget`, `DistanceToHome`은 perception / BT service update에서 의미 있는 runtime 값으로 채워진다.
 
 ### 5. Clear는 registry 기반으로 단순화한다
 
 ```text
-ClearBlackboardRuntimeValues
+ClearBlackboardValues
+-> CAIBlackboardValueHelper::ClearValues 호출
 -> CAIKeyRegistry::GetKeySpecs 순회
 -> bClearOnRuntimeTeardown 대상만 ClearValue 반복
 ```
@@ -231,6 +232,14 @@ CAIKeyRegistry.h
 -> ValidateRequiredKeys()
 -> missing required key ensure
 
+CAIBlackboardValueHelper.h
+-> InitializeValues()
+-> ApplyFixedValue()
+-> ApplyOwnerLocationValue()
+-> ApplyCustom*()
+-> ValidateCustomKeysApplied()
+-> ClearValues()
+
 BT Service / Task / Decorator
 -> CAIKey::Category::KeySpec.KeyName 사용
 ```
@@ -242,7 +251,8 @@ BT Service / Task / Decorator
 - key name / expected type / initial policy / fixed default 정의 위치 결합
 - 전체 key 등록 목록은 registry에서 별도 관리
 - Blackboard API에는 명시적으로 KeyName만 전달
-- fixed / owner initial value는 registry 순회로 적용
+- fixed / owner initial value와 clear runtime value는 helper에서 registry 순회로 적용
+- custom value는 controller가 source를 읽고 helper apply API로 적용
 ```
 
 ### 다른 후보를 사용하지 않은 이유
@@ -271,6 +281,7 @@ Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
 Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
 Source/Portfolio/AI/Blackboard/CAIKey.h
 Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
 Source/Portfolio/Controller/CAIController.h
 Source/Portfolio/Controller/CAIController.cpp
 ```
@@ -310,13 +321,14 @@ Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 - 검증 실패 시 누락 key 목록과 expected type이 ensure로 확인된다.
 - Blackboard API 호출부는 KeySpec이 아니라 KeySpec.KeyName을 전달한다.
 - initial blackboard value 설정이 fixed / owner / custom 기반 value로 구분된다.
-- fixed / owner initial value는 registry 순회로 적용된다.
-- custom value는 controller helper에서 명시 적용된다.
+- fixed / owner initial value는 `CAIBlackboardValueHelper`에서 registry 순회로 적용된다.
+- custom value source 적용은 controller에 남고, blackboard write / pending 검증은 `CAIBlackboardValueHelper`가 처리한다.
+- clear runtime value는 `bClearOnRuntimeTeardown` 기준으로 registry 순회 적용된다.
 - BT node behavior는 변경되지 않는다.
 - 빌드와 PIE AI smoke test가 통과한다.
 ```
 
-## 후속 분리
+## 후속 작업
 
 이번 작업에서는 AI update interval을 조정하지 않는다.
 

--- a/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
+++ b/Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
@@ -48,7 +48,7 @@ CAIKey.h
 ACAIController::ValidateBlackboardKeys
 -> required key 수동 검증
 
-ACAIController::SetInitialBlackboardRuntimeValues
+ACAIController::InitializeBlackboardRuntimeValues
 -> initial runtime value 수동 설정
 
 ACAIController::ClearBlackboardRuntimeValues
@@ -69,7 +69,7 @@ BT Service / Task / Decorator
 ```text
 CAIKey.h
 ValidateBlackboardKeys
-SetInitialBlackboardRuntimeValues
+InitializeBlackboardRuntimeValues
 ClearBlackboardRuntimeValues
 BT node usage
 Blackboard asset
@@ -109,25 +109,35 @@ CAIKey::Targeting::TargetActor.KeyName
 
 ### 2. registry는 key 등록과 검증을 담당한다
 
-`CAIKey.h`는 개별 key의 계약 정보를 정의하고, `CAIKeyRegistry.h`는 전체 key 목록 등록과 검증 흐름을 담당한다.
+`CAIKeyTypes.h`는 key spec의 공통 타입을 정의하고, `CAIKeyFactory.h`는 spec 생성 helper를 제공한다.
+
+`CAIKey.h`는 개별 key vocabulary와 key별 계약 정보를 정의하고, `CAIKeyRegistry.h`는 전체 key 목록 등록과 검증 흐름을 담당한다.
 
 key spec은 다음 정보를 제공한다.
 
 ```text
 FName KeyName
 EAIBlackboardKeyValueType ValueType
+EAIBlackboardInitialValuePolicy InitialValuePolicy
+fixed default value fields
 bool bRequired
 bool bClearOnRuntimeTeardown
 ```
 
-초기값까지 registry에 넣을지 여부는 key 성격에 따라 나눈다.
+초기값 적용 방식은 key 성격에 따라 나눈다.
 
 ```text
 공통 fixed initial value
--> registry 또는 helper table에서 처리 가능
+-> FAIBlackboardKeySpec의 InitialValuePolicy / default value 기반으로 registry 순회 처리
 
-enemy instance에서 읽어야 하는 value
--> controller helper에서 별도 적용 유지
+owner 위치 기반 value
+-> FromOwnerLocation policy 기반으로 registry 순회 처리
+
+runtime update value
+-> RuntimeValue factory로 정의하고 possession 초기화에서는 값을 쓰지 않음
+
+custom value
+-> custom helper에서 별도 적용 유지
 ```
 
 예:
@@ -140,7 +150,7 @@ CAIKey::Navigation::HomeLocation.KeyName
 -> owner pawn location 필요
 
 CAIKey::Patrol::bUsePatrol.KeyName
--> ACEnemy instance 설정 필요
+-> custom value 적용 필요
 ```
 
 ### 3. Validation은 registry 순회로 바꾼다
@@ -169,12 +179,24 @@ ACAIController::SetupBlackboardComponent
 ### 4. Runtime value setup은 두 단계로 나눈다
 
 ```text
-SetInitialBlackboardRuntimeValues
--> ApplyFixedInitialBlackboardValues
--> ApplyOwnerBlackboardValues
+InitializeBlackboardRuntimeValues
+-> ApplyInitialBlackboardValues: registry 1회 순회
+-> Fixed / FromOwnerLocation / Custom policy 분기
+-> Custom key는 pending set에 등록
+-> ApplyCustomBlackboardValues에서 custom value 명시 적용
+-> 처리된 custom key는 pending set에서 제거
+-> 남은 custom key가 있으면 ensure
 ```
 
-고정 초기값과 enemy instance 기반 값을 구분하면 함수가 길어지는 문제를 줄일 수 있다.
+고정 초기값과 owner 위치 기반 값은 key spec의 policy로 자동 적용한다.
+
+Custom value는 key마다 source가 다르므로 controller helper에서 명시 적용한다. 이 부분까지 함수 포인터 / lambda / variant로 자동화하면 key contract가 gameplay object access까지 알게 되므로 이번 범위에서는 제외한다.
+
+`Custom` policy는 registry가 자동 적용하지 않는 domain-specific 초기값을 의미한다. 현재 구현에서는 `ACAIController::ApplyCustomBlackboardValues`가 custom value를 명시적으로 적용한다.
+
+Custom key는 조용히 무시하지 않는다. Registry 순회 중 pending set에 등록하고, domain-specific 적용이 끝난 뒤에도 남아 있으면 ensure로 누락을 드러낸다.
+
+`RuntimeValue`는 key name / type / required / clear 계약은 필요하지만 possession 초기화 시점에는 의미 있는 값이 없는 key에 사용한다. 예를 들어 `LastSeenTime`, `LastKnownLocation`, `DistanceToTarget`, `DistanceToHome`은 perception / BT service update에서 의미 있는 runtime 값으로 채워진다.
 
 ### 5. Clear는 registry 기반으로 단순화한다
 
@@ -193,9 +215,15 @@ ClearBlackboardRuntimeValues
 ### 선택한 형태
 
 ```text
-CAIKey.h
+CAIKeyTypes.h
 -> EAIBlackboardKeyValueType
+-> EAIBlackboardInitialValuePolicy
 -> FAIBlackboardKeySpec
+
+CAIKeyFactory.h
+-> fixed / runtime / owner / custom key spec factory helper
+
+CAIKey.h
 -> CAIKey::Category::KeySpec
 
 CAIKeyRegistry.h
@@ -211,9 +239,10 @@ BT Service / Task / Decorator
 
 ```text
 - key category 네임스페이스 사용감 유지
-- key name과 expected type 정의 위치 결합
+- key name / expected type / initial policy / fixed default 정의 위치 결합
 - 전체 key 등록 목록은 registry에서 별도 관리
 - Blackboard API에는 명시적으로 KeyName만 전달
+- fixed / owner initial value는 registry 순회로 적용
 ```
 
 ### 다른 후보를 사용하지 않은 이유
@@ -238,6 +267,8 @@ BT Service / Task / Decorator
 ## 예상 수정 대상
 
 ```text
+Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
+Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
 Source/Portfolio/AI/Blackboard/CAIKey.h
 Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
 Source/Portfolio/Controller/CAIController.h
@@ -264,7 +295,9 @@ Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 4. ValidateBlackboardKeys 수동 검증 제거
 5. CAIKey 사용처를 KeySpec.KeyName 전달 방식으로 변경
 6. BT Service / Task / Decorator key type 사용처 정적 확인
-7. 빌드 / PIE smoke test
+7. initial blackboard value helper 분리
+8. fixed / owner initial value를 registry 순회로 변경
+9. 빌드 / PIE smoke test
 ```
 
 ---
@@ -276,11 +309,14 @@ Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
 - ValidateBlackboardKeys의 수동 bool 나열이 제거된다.
 - 검증 실패 시 누락 key 목록과 expected type이 ensure로 확인된다.
 - Blackboard API 호출부는 KeySpec이 아니라 KeySpec.KeyName을 전달한다.
+- initial blackboard value 설정이 fixed / owner / custom 기반 value로 구분된다.
+- fixed / owner initial value는 registry 순회로 적용된다.
+- custom value는 controller helper에서 명시 적용된다.
 - BT node behavior는 변경되지 않는다.
 - 빌드와 PIE AI smoke test가 통과한다.
 ```
 
-초기값 설정과 teardown clear registry화는 같은 주제의 후속 후보로 남긴다. 이번 커밋에서는 required key 계약 검증과 key spec 정의를 먼저 안정화한다.
+teardown clear registry화는 같은 주제의 후속 후보로 남긴다.
 
 ---
 

--- a/Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
+++ b/Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
@@ -91,11 +91,10 @@ BT 노드나 C++ 설정에 `FName` 필드를 노출하고, asset에서 입력한
 `CAIKey`는 category namespace를 유지하고, 각 key를 `FAIBlackboardKeySpec`로 정의한다.
 
 ```cpp
-static const FAIBlackboardKeySpec TargetActor =
-{
-    TEXT("TargetActor"),
-    EAIBlackboardKeyValueType::Object
-};
+static const FAIBlackboardKeySpec TargetActor = CAIKeyFactory::FixedObjectNull(TEXT("TargetActor"));
+static const FAIBlackboardKeySpec TargetPriority = CAIKeyFactory::FixedInt(TEXT("TargetPriority"), INT_MAX);
+static const FAIBlackboardKeySpec LastSeenTime = CAIKeyFactory::RuntimeFloat(TEXT("LastSeenTime"));
+static const FAIBlackboardKeySpec HomeLocation = CAIKeyFactory::FromOwnerLocation(TEXT("HomeLocation"));
 ```
 
 사용처:
@@ -108,8 +107,10 @@ BlackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName);
 
 ```text
 - BT / Blackboard asset에서 쓰는 key name을 C++ 심볼로 추적할 수 있다.
-- key name과 expected type을 한 곳에 둔다.
+- key name, expected type, initial policy, fixed default value를 한 곳에 둔다.
 - CAIKeyRegistry에서 required key 검증을 구성할 수 있다.
+- fixed / owner-location initial value는 registry 순회로 적용할 수 있다.
+- custom initial value는 domain-specific helper에서 명시 적용할 수 있다.
 - Blackboard API에는 명시적으로 KeyName만 전달하므로 사용 경계가 드러난다.
 ```
 
@@ -160,6 +161,9 @@ CAIKey::Targeting::TargetActor.KeyName
 
 기대 타입:
 EAIBlackboardKeyValueType::Object
+
+초기화 정책:
+EAIBlackboardInitialValuePolicy::Fixed
 ```
 
 따라서 `CAIKey`는 data table이나 runtime registry가 아니라, C++ / BT 경계의 contract vocabulary다.
@@ -202,6 +206,7 @@ BT Task / Service / Decorator
 
 ```text
 - CAIKey를 FAIBlackboardKeySpec 기반 contract vocabulary로 변경
+- CAIKeyTypes / CAIKeyFactory / CAIKey / CAIKeyRegistry 책임 분리
 - CAIKeyRegistry에서 required key 목록 검증
 - Blackboard API 호출부를 KeySpec.KeyName 전달 방식으로 정리
 ```

--- a/Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
+++ b/Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
@@ -1,0 +1,218 @@
+# N16. AI Blackboard Key Contract Decision Note
+
+## 목적
+
+이 문서는 AI Blackboard key를 완전한 data-driven 입력으로 풀지 않고, `CAIKey` / `CAIKeyRegistry` 기반 C++ contract layer로 유지한 이유를 정리한다.
+
+핵심 결론:
+
+```text
+Blackboard asset은 data-driven이다.
+하지만 BT asset과 C++ 코드가 공유하는 key 이름은 추적 가능한 contract layer가 필요하다.
+```
+
+---
+
+## 문제
+
+Blackboard key는 BehaviorTree / Blackboard asset에서 `FName` 기반으로 사용된다.
+
+이를 C++ / BT 노드에서 자유 입력으로 풀면 다음 구조가 된다.
+
+```text
+Blackboard asset
+-> "TargetActor" key 정의
+
+BT Task / Service / Decorator
+-> FName 필드에 "TargetActor" 입력
+
+C++ 코드
+-> GetValueAsObject("TargetActor")
+```
+
+이 방식은 유연하지만, key 오타 / 타입 불일치 / 누락이 생겼을 때 추적 범위가 커진다.
+
+```text
+문제 발생 시 확인해야 하는 위치:
+- Blackboard asset
+- BehaviorTree asset
+- BT Task / Service / Decorator 설정값
+- C++ GetValueAs / SetValueAs 호출부
+```
+
+즉 단순한 key 오타도 asset과 C++ 양쪽을 모두 뒤져야 하는 문제가 된다.
+
+---
+
+## 선택지
+
+### Option A. 자유 FName 입력
+
+BT 노드나 C++ 설정에 `FName` 필드를 노출하고, asset에서 입력한 이름을 그대로 사용한다.
+
+장점:
+
+```text
+- 가장 data-driven에 가깝다.
+- key set을 C++ 재컴파일 없이 바꿀 수 있다.
+- enemy archetype별 key profile을 구성하기 쉽다.
+```
+
+단점:
+
+```text
+- 오타가 컴파일 단계에서 잡히지 않는다.
+- C++ 호출부와 BT asset 설정값의 연결을 검색하기 어렵다.
+- key rename 시 영향 범위 추적이 어렵다.
+- 각 BT 노드가 어떤 key contract를 요구하는지 코드만 보고 파악하기 어렵다.
+```
+
+### Option B. C++ FName 상수
+
+`CAIKey::Targeting::TargetActor` 같은 C++ 상수로 Blackboard key name을 감싼다.
+
+장점:
+
+```text
+- 문자열 직접 입력보다 검색과 rename 추적이 쉽다.
+- C++ 호출부에서 key 사용 의도가 드러난다.
+- BT / C++ 사이의 key vocabulary를 명시할 수 있다.
+```
+
+단점:
+
+```text
+- key type / required 여부는 별도 위치에 남는다.
+- key name과 key contract가 분리된다.
+```
+
+### Option C. C++ key spec contract
+
+`CAIKey`는 category namespace를 유지하고, 각 key를 `FAIBlackboardKeySpec`로 정의한다.
+
+```cpp
+static const FAIBlackboardKeySpec TargetActor =
+{
+    TEXT("TargetActor"),
+    EAIBlackboardKeyValueType::Object
+};
+```
+
+사용처:
+
+```cpp
+BlackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName);
+```
+
+장점:
+
+```text
+- BT / Blackboard asset에서 쓰는 key name을 C++ 심볼로 추적할 수 있다.
+- key name과 expected type을 한 곳에 둔다.
+- CAIKeyRegistry에서 required key 검증을 구성할 수 있다.
+- Blackboard API에는 명시적으로 KeyName만 전달하므로 사용 경계가 드러난다.
+```
+
+단점:
+
+```text
+- 여전히 C++ 코드에 key 목록이 존재한다.
+- 완전한 data-driven key profile은 아니다.
+- enemy별 key policy가 필요해지면 DataAsset 기반 확장이 필요할 수 있다.
+```
+
+---
+
+## 결정
+
+Phase 1에서는 Option C를 선택한다.
+
+```text
+CAIKey
+-> BT / Blackboard asset에서 쓰는 FName을 C++에서 식별 가능한 심볼로 감싼다.
+
+CAIKeyRegistry
+-> 프로젝트가 요구하는 key 목록과 required 검증 흐름을 제공한다.
+
+Blackboard asset
+-> 실제 runtime Blackboard data source로 유지한다.
+```
+
+이 구조는 data-driven을 부정하지 않는다. Blackboard asset 자체는 여전히 data-driven이다.
+
+다만 C++과 BT가 같은 key 이름을 공유하는 부분은 자유 입력으로 풀지 않고, 의도적으로 코드 계약면을 둔다.
+
+---
+
+## 설계 의도
+
+`CAIKey`의 문자열은 runtime 데이터를 구성하기 위한 값이 아니라, asset key name을 코드 심볼로 치환하기 위한 값이다.
+
+```text
+BT / Blackboard asset에 존재해야 하는 이름:
+"TargetActor"
+
+C++에서 추적 가능한 이름:
+CAIKey::Targeting::TargetActor
+
+Blackboard API에 전달하는 값:
+CAIKey::Targeting::TargetActor.KeyName
+
+기대 타입:
+EAIBlackboardKeyValueType::Object
+```
+
+따라서 `CAIKey`는 data table이나 runtime registry가 아니라, C++ / BT 경계의 contract vocabulary다.
+
+---
+
+## Data-driven 확장 기준
+
+다음 요구가 실제로 생기면 DataAsset 기반 key profile을 검토한다.
+
+```text
+- enemy archetype마다 다른 Blackboard key set이 필요하다.
+- designer가 key policy를 C++ 수정 없이 구성해야 한다.
+- project-wide key contract가 아니라 mode / AI type별 contract가 필요하다.
+- initial value / clear policy가 key마다 복잡해져 asset화 이점이 커진다.
+```
+
+예상 확장 형태:
+
+```text
+UAIKeyProfileDataAsset
+-> TArray<FAIBlackboardKeySpec>
+
+ACAIController
+-> key profile asset 로드
+-> TMap<FName, FAIBlackboardKeySpec> 구성
+-> BlackboardData asset과 검증
+
+BT Task / Service / Decorator
+-> 필요 시 FName field 또는 key selector 사용
+```
+
+단, 이 단계에서는 자유도가 늘어나는 만큼 검증 책임도 같이 늘어난다.
+
+---
+
+## 현재 범위
+
+이번 작업에서는 다음만 수행한다.
+
+```text
+- CAIKey를 FAIBlackboardKeySpec 기반 contract vocabulary로 변경
+- CAIKeyRegistry에서 required key 목록 검증
+- Blackboard API 호출부를 KeySpec.KeyName 전달 방식으로 정리
+```
+
+이번 작업에서 하지 않는 것:
+
+```text
+- DataAsset 기반 key profile 도입
+- BT node에 자유 FName field 노출
+- BehaviorTree asset 재설계
+- enemy별 key contract 분기
+```
+
+---

--- a/Source/Portfolio/AI/BehaviorTree/Decorator/CBTDecorator_HasValidTarget.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Decorator/CBTDecorator_HasValidTarget.cpp
@@ -15,12 +15,12 @@ bool UCBTDecorator_HasValidTarget::CalculateRawConditionValue(UBehaviorTreeCompo
 	const UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return false;
 
-	const UObject* target = blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor);
+	const UObject* target = blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName);
 	if (!IsValid(target)) return false;
 
 	if (bRequireLOS)
 	{
-		const bool bHasLOS = blackboardComp->GetValueAsBool(CAIKey::Perception::bHasLOS);
+		const bool bHasLOS = blackboardComp->GetValueAsBool(CAIKey::Perception::bHasLOS.KeyName);
 		if (!bHasLOS) return false;
 	}
 

--- a/Source/Portfolio/AI/BehaviorTree/Decorator/CBTDecorator_HasValidTarget.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Decorator/CBTDecorator_HasValidTarget.cpp
@@ -3,7 +3,7 @@
 
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTDecorator_HasValidTarget::UCBTDecorator_HasValidTarget()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -11,7 +11,7 @@
 #include "Component/CHealthComponent.h"
 #include "System/Combat/CWorldSubsystem_CombatEngage.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 #include "Type/CAIStructure.h"
 #include "Type/CWorldSubSystemStructure.h"
 

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -126,7 +126,7 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeHomeMetricContext(APawn*
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 
 	FVector ownerLocation = InOwnerPawn->GetActorLocation();
-	FVector homeLocation = InBlackboardComp->GetValueAsVector(CAIKey::Navigation::HomeLocation);
+	FVector homeLocation = InBlackboardComp->GetValueAsVector(CAIKey::Navigation::HomeLocation.KeyName);
 
 	float dist_home = FVector::Dist(ownerLocation, homeLocation);
 
@@ -141,11 +141,11 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeAlertRangeContext(APawn*
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 	if (!IsValid(InOutAIContext.TargetActor)) return EContextBuildResult::NoData;
 
-	float chaseOffsetRange = InBlackboardComp->GetValueAsFloat(CAIKey::Chase::ChaseOffsetRange);
-	float chaseEnterBuffer = InBlackboardComp->GetValueAsFloat(CAIKey::Chase::ChaseEnterBuffer);
-	float chaseExitBuffer = InBlackboardComp->GetValueAsFloat(CAIKey::Chase::ChaseExitBuffer);
+	float chaseOffsetRange = InBlackboardComp->GetValueAsFloat(CAIKey::Chase::ChaseOffsetRange.KeyName);
+	float chaseEnterBuffer = InBlackboardComp->GetValueAsFloat(CAIKey::Chase::ChaseEnterBuffer.KeyName);
+	float chaseExitBuffer = InBlackboardComp->GetValueAsFloat(CAIKey::Chase::ChaseExitBuffer.KeyName);
 
-	bool bInAlertRange = InBlackboardComp->GetValueAsBool(CAIKey::Alert::bInAlertRange);
+	bool bInAlertRange = InBlackboardComp->GetValueAsBool(CAIKey::Alert::bInAlertRange.KeyName);
 
 	FVector ownerLocation = InOwnerPawn->GetActorLocation();
 	FVector targetLocation = InOutAIContext.TargetActor->GetActorLocation();
@@ -230,27 +230,27 @@ void UCBTService_UpdateAIContext::UpdatePerceptionContext(UBlackboardComponent* 
 	if (!IsValid(InBlackboardComp)) return;
 	if (!IsValid(InAIContext.TargetActor)) return;
 
-	InBlackboardComp->SetValueAsObject(CAIKey::Targeting::TargetActor, InAIContext.TargetActor);
-	InBlackboardComp->SetValueAsInt(CAIKey::Targeting::TargetPriority, InAIContext.TargetPriority);
-	InBlackboardComp->SetValueAsBool(CAIKey::Perception::bHasLOS, InAIContext.bHasLOS);
-	InBlackboardComp->SetValueAsFloat(CAIKey::Perception::LastSeenTime, InAIContext.LastSeenTime);
-	InBlackboardComp->SetValueAsVector(CAIKey::Perception::LastKnownLocation, InAIContext.LastKnownLocation);
+	InBlackboardComp->SetValueAsObject(CAIKey::Targeting::TargetActor.KeyName, InAIContext.TargetActor);
+	InBlackboardComp->SetValueAsInt(CAIKey::Targeting::TargetPriority.KeyName, InAIContext.TargetPriority);
+	InBlackboardComp->SetValueAsBool(CAIKey::Perception::bHasLOS.KeyName, InAIContext.bHasLOS);
+	InBlackboardComp->SetValueAsFloat(CAIKey::Perception::LastSeenTime.KeyName, InAIContext.LastSeenTime);
+	InBlackboardComp->SetValueAsVector(CAIKey::Perception::LastKnownLocation.KeyName, InAIContext.LastKnownLocation);
 }
 
 void UCBTService_UpdateAIContext::UpdateHomeMetricContext(UBlackboardComponent* InBlackboardComp, FAIContext& InAIContext)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->SetValueAsBool(CAIKey::Navigation::bReturnHome, InAIContext.bReturnHome);
-	InBlackboardComp->SetValueAsFloat(CAIKey::Metric::DistanceToHome, InAIContext.DistanceToHome);
+	InBlackboardComp->SetValueAsBool(CAIKey::Navigation::bReturnHome.KeyName, InAIContext.bReturnHome);
+	InBlackboardComp->SetValueAsFloat(CAIKey::Metric::DistanceToHome.KeyName, InAIContext.DistanceToHome);
 }
 
 void UCBTService_UpdateAIContext::UpdateAlertRangeContext(UBlackboardComponent* InBlackboardComp, FAIContext& InAIContext)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->SetValueAsFloat(CAIKey::Metric::DistanceToTarget, InAIContext.DistanceToTarget);
-	InBlackboardComp->SetValueAsBool(CAIKey::Alert::bInAlertRange, InAIContext.bInAlertRange);
+	InBlackboardComp->SetValueAsFloat(CAIKey::Metric::DistanceToTarget.KeyName, InAIContext.DistanceToTarget);
+	InBlackboardComp->SetValueAsBool(CAIKey::Alert::bInAlertRange.KeyName, InAIContext.bInAlertRange);
 
 }
 
@@ -258,63 +258,63 @@ void UCBTService_UpdateAIContext::UpdateEngageAssignmentContext(UBlackboardCompo
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->SetValueAsBool(CAIKey::Engage::bShouldEngage, InAIContext.bShouldEngage);
+	InBlackboardComp->SetValueAsBool(CAIKey::Engage::bShouldEngage.KeyName, InAIContext.bShouldEngage);
 }
 
 void UCBTService_UpdateAIContext::UpdateReactionContext(UBlackboardComponent* InBlackboardComp, FAIContext& InAIContext)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->SetValueAsBool(CAIKey::Reaction::bIsActiveReaction, InAIContext.bIsActiveReaction);
+	InBlackboardComp->SetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName, InAIContext.bIsActiveReaction);
 }
 
 void UCBTService_UpdateAIContext::UpdateDeadContext(UBlackboardComponent* InBlackboardComp, FAIContext& InAIContext)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->SetValueAsEnum(CAIKey::Dead::DeadState, static_cast<uint8>(InAIContext.DeadState));
+	InBlackboardComp->SetValueAsEnum(CAIKey::Dead::DeadState.KeyName, static_cast<uint8>(InAIContext.DeadState));
 }
 
 void UCBTService_UpdateAIContext::ClearPerceptionContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->ClearValue(CAIKey::Targeting::TargetActor);
-	InBlackboardComp->ClearValue(CAIKey::Targeting::TargetPriority);
-	InBlackboardComp->ClearValue(CAIKey::Perception::bHasLOS);
+	InBlackboardComp->ClearValue(CAIKey::Targeting::TargetActor.KeyName);
+	InBlackboardComp->ClearValue(CAIKey::Targeting::TargetPriority.KeyName);
+	InBlackboardComp->ClearValue(CAIKey::Perception::bHasLOS.KeyName);
 }
 
 void UCBTService_UpdateAIContext::ClearHomeMetricContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->ClearValue(CAIKey::Metric::DistanceToHome);
-	InBlackboardComp->ClearValue(CAIKey::Navigation::bReturnHome);
+	InBlackboardComp->ClearValue(CAIKey::Metric::DistanceToHome.KeyName);
+	InBlackboardComp->ClearValue(CAIKey::Navigation::bReturnHome.KeyName);
 }
 
 void UCBTService_UpdateAIContext::ClearAlertRangeContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->ClearValue(CAIKey::Metric::DistanceToTarget);
-	InBlackboardComp->ClearValue(CAIKey::Alert::bInAlertRange);
+	InBlackboardComp->ClearValue(CAIKey::Metric::DistanceToTarget.KeyName);
+	InBlackboardComp->ClearValue(CAIKey::Alert::bInAlertRange.KeyName);
 }
 
 void UCBTService_UpdateAIContext::ClearEngageAssignmentContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->ClearValue(CAIKey::Engage::bShouldEngage);
+	InBlackboardComp->ClearValue(CAIKey::Engage::bShouldEngage.KeyName);
 }
 
 void UCBTService_UpdateAIContext::ClearReactionContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->ClearValue(CAIKey::Reaction::bIsActiveReaction);
+	InBlackboardComp->ClearValue(CAIKey::Reaction::bIsActiveReaction.KeyName);
 }
 
 void UCBTService_UpdateAIContext::ClearDeadContext(UBlackboardComponent* InBlackboardComp)
 {
-	InBlackboardComp->SetValueAsEnum(CAIKey::Dead::DeadState, static_cast<uint8>(EDeadState::Alive));
+	InBlackboardComp->SetValueAsEnum(CAIKey::Dead::DeadState.KeyName, static_cast<uint8>(EDeadState::Alive));
 }

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
@@ -43,9 +43,9 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 	// -----------------------------------------------------------------------------
 	// 1. Absolute States
 	// -----------------------------------------------------------------------------
-	const EDeadState deadState = static_cast<EDeadState>(InBlackboard->GetValueAsEnum(CAIKey::Dead::DeadState));
-	const bool bIsActiveReaction = InBlackboard->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction);
-	const bool bIsCombatAction = InBlackboard->GetValueAsBool(CAIKey::Engage::bIsCombatAction);
+	const EDeadState deadState = static_cast<EDeadState>(InBlackboard->GetValueAsEnum(CAIKey::Dead::DeadState.KeyName));
+	const bool bIsActiveReaction = InBlackboard->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName);
+	const bool bIsCombatAction = InBlackboard->GetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName);
 
 	if (deadState != EDeadState::Alive)
 		return EAIIntentState::Dead;
@@ -60,14 +60,14 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 	// -----------------------------------------------------------------------------
 	// 2.  Context
 	// -----------------------------------------------------------------------------
-	AActor* target = Cast<AActor>(InBlackboard->GetValueAsObject(CAIKey::Targeting::TargetActor));
+	AActor* target = Cast<AActor>(InBlackboard->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName));
 
 	const bool bHasTarget = IsValid(target);
-	const bool bHasLOS = InBlackboard->GetValueAsBool(CAIKey::Perception::bHasLOS);
-	const bool bIsInvestigating = InBlackboard->GetValueAsBool(CAIKey::Investigate::bIsInvestigating);
+	const bool bHasLOS = InBlackboard->GetValueAsBool(CAIKey::Perception::bHasLOS.KeyName);
+	const bool bIsInvestigating = InBlackboard->GetValueAsBool(CAIKey::Investigate::bIsInvestigating.KeyName);
 
-	const bool bInAlertRange = InBlackboard->GetValueAsBool(CAIKey::Alert::bInAlertRange);
-	const bool bShouldEngage = InBlackboard->GetValueAsBool(CAIKey::Engage::bShouldEngage);
+	const bool bInAlertRange = InBlackboard->GetValueAsBool(CAIKey::Alert::bInAlertRange.KeyName);
+	const bool bShouldEngage = InBlackboard->GetValueAsBool(CAIKey::Engage::bShouldEngage.KeyName);
 
 	// -----------------------------------------------------------------------------
 	// 3) Decide Next AIIntentState
@@ -90,12 +90,12 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 
 bool UCBTService_UpdateAIIntentState::ChangeAIIntentState(UBlackboardComponent* InBlackboardComp, EAIIntentState InNextAIIntentState)
 {
-	const uint8 currentAIIntentState = static_cast<uint8>(InBlackboardComp->GetValueAsEnum(CAIKey::State::AIIntentState));
+	const uint8 currentAIIntentState = static_cast<uint8>(InBlackboardComp->GetValueAsEnum(CAIKey::State::AIIntentState.KeyName));
 	const uint8 nextAIIntentState = static_cast<uint8>(InNextAIIntentState);
 
 	if (currentAIIntentState == nextAIIntentState) return false;
 
-	InBlackboardComp->SetValueAsEnum(CAIKey::State::AIIntentState, nextAIIntentState);
+	InBlackboardComp->SetValueAsEnum(CAIKey::State::AIIntentState.KeyName, nextAIIntentState);
 
 	UpdateAIIntentStateTransition(InBlackboardComp, static_cast<EAIIntentState>(currentAIIntentState), static_cast<EAIIntentState>(nextAIIntentState));
 	return true;
@@ -109,12 +109,12 @@ void UCBTService_UpdateAIIntentState::UpdateAIIntentStateTransition(UBlackboardC
 	// Engage -> Non-Engage
 	if (InCurrentAIIntentState == EAIIntentState::Engage && InNextAIIntentState != EAIIntentState::Engage)
 	{
-		InBlackboardComp->SetValueAsBool(CAIKey::Engage::bInEngageRange, false);
-		InBlackboardComp->SetValueAsBool(CAIKey::Engage::bCanCombatAction, false);
+		InBlackboardComp->SetValueAsBool(CAIKey::Engage::bInEngageRange.KeyName, false);
+		InBlackboardComp->SetValueAsBool(CAIKey::Engage::bCanCombatAction.KeyName, false);
 
 		if (InNextAIIntentState == EAIIntentState::Dead || InNextAIIntentState == EAIIntentState::Idle)
 		{
-			InBlackboardComp->ClearValue(CAIKey::Engage::NextCombatActionTime);
+			InBlackboardComp->ClearValue(CAIKey::Engage::NextCombatActionTime.KeyName);
 		}
 	} 
 }

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
@@ -12,7 +12,7 @@
 #include "Type/CStateStructure.h"
 #include "Type/CWeaponStructure.h"
 #include "Type/CHealthStructure.h"
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTService_UpdateAIIntentState::UCBTService_UpdateAIIntentState()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -60,15 +60,15 @@ EContextBuildResult UCBTService_UpdateEngageContext::BuildEngageContext(APawn* I
 	ACEnemy* enemy = Cast<ACEnemy>(InOwnerPawn);
 	if (!IsValid(enemy)) return EContextBuildResult::Error;
 
-	OutEngageContext.TargetActor = Cast<AActor>(InBlackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor));
+	OutEngageContext.TargetActor = Cast<AActor>(InBlackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName));
 	if (!IsValid(OutEngageContext.TargetActor)) return EContextBuildResult::NoData;
 
 	OutEngageContext.EngageOffsetRange = enemy->GetEngageOffsetRange();
 	OutEngageContext.EngageEnterBuffer = enemy->GetEngageEnterBuffer();
 	OutEngageContext.EngageExitBuffer = enemy->GetEngageExitBuffer();
 
-	OutEngageContext.bPrevInEngageRange = InBlackboardComp->GetValueAsBool(CAIKey::Engage::bInEngageRange);
-	OutEngageContext.NextCombatActionTime = InBlackboardComp->GetValueAsFloat(CAIKey::Engage::NextCombatActionTime);
+	OutEngageContext.bPrevInEngageRange = InBlackboardComp->GetValueAsBool(CAIKey::Engage::bInEngageRange.KeyName);
+	OutEngageContext.NextCombatActionTime = InBlackboardComp->GetValueAsFloat(CAIKey::Engage::NextCombatActionTime.KeyName);
 
 	return EContextBuildResult::Success;
 }
@@ -100,8 +100,8 @@ EContextBuildResult UCBTService_UpdateEngageContext::ComputeEngageContext(APawn*
 	float currentTime = InOwnerPawn->GetWorld()->GetTimeSeconds();
 	const bool bCooldownElapsed = currentTime >= InOutEngageContext.NextCombatActionTime;
 
-	const bool bIsCombatAction = InBlackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction);
-	const bool bIsActiveReaction = InBlackboardComp->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction);
+	const bool bIsCombatAction = InBlackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName);
+	const bool bIsActiveReaction = InBlackboardComp->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName);
 
 	InOutEngageContext.EngageOuterRange = engageOuterRange;
 	InOutEngageContext.EngageInnerRange = engageInnerRange;
@@ -124,16 +124,16 @@ void UCBTService_UpdateEngageContext::UpdateEngageContext(UBlackboardComponent* 
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->SetValueAsBool(CAIKey::Engage::bInEngageRange, InEngageContext.bInEngageRange);
-	InBlackboardComp->SetValueAsBool(CAIKey::Engage::bCanCombatAction, InEngageContext.bCanCombatAction);
+	InBlackboardComp->SetValueAsBool(CAIKey::Engage::bInEngageRange.KeyName, InEngageContext.bInEngageRange);
+	InBlackboardComp->SetValueAsBool(CAIKey::Engage::bCanCombatAction.KeyName, InEngageContext.bCanCombatAction);
 }
 
 void UCBTService_UpdateEngageContext::ClearEngageContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->ClearValue(CAIKey::Engage::bInEngageRange);
-	InBlackboardComp->ClearValue(CAIKey::Engage::bCanCombatAction);
+	InBlackboardComp->ClearValue(CAIKey::Engage::bInEngageRange.KeyName);
+	InBlackboardComp->ClearValue(CAIKey::Engage::bCanCombatAction.KeyName);
 }
 
 void UCBTService_UpdateEngageContext::PrintEngageContext(const APawn* InOwnerPawn, const FEngageContext& InEngageContext, const float InCurrentTime)

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -7,7 +7,7 @@
 #include "BehaviorTree/BehaviorTreeComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 #include "Type/CAIStructure.h"
 
 UCBTService_UpdateEngageContext::UCBTService_UpdateEngageContext()

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateInvestigateContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateInvestigateContext.cpp
@@ -22,18 +22,18 @@ void UCBTService_UpdateInvestigateContext::TickNode(UBehaviorTreeComponent& Owne
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return;
 
-	if (!blackboardComp->GetValueAsBool(CAIKey::Investigate::bUseInvestigate)) return;
-	if (!blackboardComp->GetValueAsBool(CAIKey::Investigate::bCanInvestigate)) return;
-	if (!blackboardComp->GetValueAsBool(CAIKey::Investigate::bIsInvestigating)) return;
+	if (!blackboardComp->GetValueAsBool(CAIKey::Investigate::bUseInvestigate.KeyName)) return;
+	if (!blackboardComp->GetValueAsBool(CAIKey::Investigate::bCanInvestigate.KeyName)) return;
+	if (!blackboardComp->GetValueAsBool(CAIKey::Investigate::bIsInvestigating.KeyName)) return;
 
-	const float lastSeenTime = blackboardComp->GetValueAsFloat(CAIKey::Perception::LastSeenTime);
-	const float investigateDuration = blackboardComp->GetValueAsFloat(CAIKey::Investigate::InvestigateDuration);
+	const float lastSeenTime = blackboardComp->GetValueAsFloat(CAIKey::Perception::LastSeenTime.KeyName);
+	const float investigateDuration = blackboardComp->GetValueAsFloat(CAIKey::Investigate::InvestigateDuration.KeyName);
 
 	const bool bTimeout = (investigateDuration > 0.f) && ((world->GetTimeSeconds() - lastSeenTime) >= investigateDuration);
 
 	if (bTimeout)
 	{
-		blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate, false);
+		blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate.KeyName, false);
 		FLog::Log(TEXT("[Investigate Time out]"));
 	}
 }

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateInvestigateContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateInvestigateContext.cpp
@@ -3,7 +3,7 @@
 
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTService_UpdateInvestigateContext::UCBTService_UpdateInvestigateContext()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdatePatrolContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdatePatrolContext.cpp
@@ -57,19 +57,19 @@ EContextBuildResult UCBTService_UpdatePatrolContext::BuildPatrolContext(APawn* I
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 
-	const bool bUsePatrol = InBlackboardComp->GetValueAsBool(CAIKey::Patrol::bUsePatrol);
+	const bool bUsePatrol = InBlackboardComp->GetValueAsBool(CAIKey::Patrol::bUsePatrol.KeyName);
 	if (!bUsePatrol) return EContextBuildResult::NoData;
 
-	OutPatrolContext.bUsePatrol = InBlackboardComp->GetValueAsBool(CAIKey::Patrol::bUsePatrol);
-	OutPatrolContext.PatrolPath = Cast<ACPatrolPath>(InBlackboardComp->GetValueAsObject(CAIKey::Patrol::PatrolPath));
-	OutPatrolContext.PatrolMode = static_cast<EPatrolMode>(InBlackboardComp->GetValueAsEnum(CAIKey::Patrol::PatrolMode));
+	OutPatrolContext.bUsePatrol = InBlackboardComp->GetValueAsBool(CAIKey::Patrol::bUsePatrol.KeyName);
+	OutPatrolContext.PatrolPath = Cast<ACPatrolPath>(InBlackboardComp->GetValueAsObject(CAIKey::Patrol::PatrolPath.KeyName));
+	OutPatrolContext.PatrolMode = static_cast<EPatrolMode>(InBlackboardComp->GetValueAsEnum(CAIKey::Patrol::PatrolMode.KeyName));
 
 	if (!OutPatrolContext.bUsePatrol || !IsValid(OutPatrolContext.PatrolPath) || OutPatrolContext.PatrolPath->Num() <= 0 || OutPatrolContext.PatrolMode == EPatrolMode::None)
 		return EContextBuildResult::NoData;
 
-	OutPatrolContext.CurrentIndex = InBlackboardComp->GetValueAsInt(CAIKey::Patrol::PatrolIndex);
-	OutPatrolContext.bPatrolReverse = InBlackboardComp->GetValueAsBool(CAIKey::Patrol::bPatrolReverse);
-	OutPatrolContext.CurrentPatrolLocation = InBlackboardComp->GetValueAsVector(CAIKey::Patrol::PatrolLocation);
+	OutPatrolContext.CurrentIndex = InBlackboardComp->GetValueAsInt(CAIKey::Patrol::PatrolIndex.KeyName);
+	OutPatrolContext.bPatrolReverse = InBlackboardComp->GetValueAsBool(CAIKey::Patrol::bPatrolReverse.KeyName);
+	OutPatrolContext.CurrentPatrolLocation = InBlackboardComp->GetValueAsVector(CAIKey::Patrol::PatrolLocation.KeyName);
 
 	return EContextBuildResult::Success;
 }
@@ -168,16 +168,16 @@ void UCBTService_UpdatePatrolContext::UpdatePatrolContext(UBlackboardComponent* 
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->SetValueAsBool(CAIKey::Patrol::bPatrolReverse, InPatrolContext.bPatrolReverse);
-	InBlackboardComp->SetValueAsInt(CAIKey::Patrol::PatrolIndex, InPatrolContext.NextIndex);
-	InBlackboardComp->SetValueAsVector(CAIKey::Patrol::PatrolLocation, InPatrolContext.NextPatrolLocation);
+	InBlackboardComp->SetValueAsBool(CAIKey::Patrol::bPatrolReverse.KeyName, InPatrolContext.bPatrolReverse);
+	InBlackboardComp->SetValueAsInt(CAIKey::Patrol::PatrolIndex.KeyName, InPatrolContext.NextIndex);
+	InBlackboardComp->SetValueAsVector(CAIKey::Patrol::PatrolLocation.KeyName, InPatrolContext.NextPatrolLocation);
 }
 
 void UCBTService_UpdatePatrolContext::ClearPatrolContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	InBlackboardComp->ClearValue(CAIKey::Patrol::bPatrolReverse);
+	InBlackboardComp->ClearValue(CAIKey::Patrol::bPatrolReverse.KeyName);
 }
 
 bool UCBTService_UpdatePatrolContext::IsReached(const FVector& InOwnerLocation, const FVector& InPatrolLocation) const
@@ -197,7 +197,7 @@ void UCBTService_UpdatePatrolContext::PrintPatrolContextData(const APawn* InOwne
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return;
 
 	FVector ownerLocation = InOwnerPawn->GetActorLocation();
-	FVector patrolLocation = InBlackboardComp->GetValueAsVector(CAIKey::Patrol::PatrolLocation);
+	FVector patrolLocation = InBlackboardComp->GetValueAsVector(CAIKey::Patrol::PatrolLocation.KeyName);
 
 	float dist2D = FVector::Dist2D(ownerLocation, patrolLocation);
 	float diff_Z = FMath::Abs(ownerLocation.Z - patrolLocation.Z);

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdatePatrolContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdatePatrolContext.cpp
@@ -8,7 +8,7 @@
 
 #include "AI/Patrol/CPatrolPath.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 #include "Type/CAIStructure.h"
 
 UCBTService_UpdatePatrolContext::UCBTService_UpdatePatrolContext()

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_AdvanceInvestigateIndex.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_AdvanceInvestigateIndex.cpp
@@ -15,19 +15,19 @@ EBTNodeResult::Type UCBTTask_AdvanceInvestigateIndex::ExecuteTask(UBehaviorTreeC
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return EBTNodeResult::Failed;
 
-	const int32 maxIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateMaxIndex);
-	const int32 currentIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateIndex);
+	const int32 maxIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateMaxIndex.KeyName);
+	const int32 currentIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName);
 	const int32 nextIndex = currentIndex + 1;
 
 	if (nextIndex > maxIndex)
 	{
-		blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate, false);
-		blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex, currentIndex);
+		blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate.KeyName, false);
+		blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName, currentIndex);
 		FLog::Log(TEXT("[Index Done]"));
 	}
 	else
 	{
-		blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex, nextIndex);
+		blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName, nextIndex);
 	}
 
 	return EBTNodeResult::Succeeded;

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_AdvanceInvestigateIndex.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_AdvanceInvestigateIndex.cpp
@@ -3,7 +3,7 @@
 
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_AdvanceInvestigateIndex::UCBTTask_AdvanceInvestigateIndex()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_ClearFocus.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_ClearFocus.cpp
@@ -5,7 +5,7 @@
 #include "GameFramework/Pawn.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_ClearFocus::UCBTTask_ClearFocus()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_EndInvestigate.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_EndInvestigate.cpp
@@ -15,14 +15,14 @@ EBTNodeResult::Type UCBTTask_EndInvestigate::ExecuteTask(UBehaviorTreeComponent&
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return EBTNodeResult::Failed;
 
-	blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate, false);
-	blackboardComp->SetValueAsBool(CAIKey::Investigate::bIsInvestigating, false);
+	blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate.KeyName, false);
+	blackboardComp->SetValueAsBool(CAIKey::Investigate::bIsInvestigating.KeyName, false);
 
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateLocation);
-	blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex, -1);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateLocation.KeyName);
+	blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName, -1);
 
-	blackboardComp->ClearValue(CAIKey::Perception::LastSeenTime);
-	blackboardComp->ClearValue(CAIKey::Perception::LastKnownLocation);
+	blackboardComp->ClearValue(CAIKey::Perception::LastSeenTime.KeyName);
+	blackboardComp->ClearValue(CAIKey::Perception::LastKnownLocation.KeyName);
 
 	return EBTNodeResult::Succeeded;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_EndInvestigate.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_EndInvestigate.cpp
@@ -3,7 +3,7 @@
 
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_EndInvestigate::UCBTTask_EndInvestigate()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectAlertPoint.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectAlertPoint.cpp
@@ -5,7 +5,7 @@
 #include "GameFramework/Pawn.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_SelectAlertPoint::UCBTTask_SelectAlertPoint()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectAlertPoint.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectAlertPoint.cpp
@@ -23,12 +23,12 @@ EBTNodeResult::Type UCBTTask_SelectAlertPoint::ExecuteTask(UBehaviorTreeComponen
 	APawn* pawn = aiController->GetPawn();
 	if (!IsValid(pawn)) return EBTNodeResult::Failed;
 
-	AActor* target = Cast<AActor>(blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor));
+	AActor* target = Cast<AActor>(blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName));
 	if (!IsValid(target)) return EBTNodeResult::Failed;
 
-	bool bUseAlertStep = blackboardComp->GetValueAsBool(CAIKey::Alert::bUseAlertStep);
-	float stepForwardDistance = blackboardComp->GetValueAsFloat(CAIKey::Alert::StepForwardDistance);
-	float stepSideDistance = blackboardComp->GetValueAsFloat(CAIKey::Alert::StepSideDistance);
+	bool bUseAlertStep = blackboardComp->GetValueAsBool(CAIKey::Alert::bUseAlertStep.KeyName);
+	float stepForwardDistance = blackboardComp->GetValueAsFloat(CAIKey::Alert::StepForwardDistance.KeyName);
+	float stepSideDistance = blackboardComp->GetValueAsFloat(CAIKey::Alert::StepSideDistance.KeyName);
 
 	FVector unitVec_ToTarget = (target->GetActorLocation() - pawn->GetActorLocation()).GetSafeNormal2D();
 	FVector unitVec_Right = FVector::CrossProduct(FVector::UpVector, unitVec_ToTarget);
@@ -36,6 +36,6 @@ EBTNodeResult::Type UCBTTask_SelectAlertPoint::ExecuteTask(UBehaviorTreeComponen
 
 	const FVector alertLocation = pawn->GetActorLocation() + (unitVec_ToTarget * stepForwardDistance) + (unitVec_Right * side * stepSideDistance);
 
-	blackboardComp->SetValueAsVector(CAIKey::Alert::AlertStepLocation, alertLocation);
+	blackboardComp->SetValueAsVector(CAIKey::Alert::AlertStepLocation.KeyName, alertLocation);
 	return EBTNodeResult::Succeeded;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
@@ -8,7 +8,7 @@
 #include "AI/Patrol/CPatrolPath.h"
 
 #include "Type/CAIStructure.h"
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_SelectPatrolPoint::UCBTTask_SelectPatrolPoint()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
@@ -24,14 +24,14 @@ EBTNodeResult::Type UCBTTask_SelectPatrolPoint::ExecuteTask(UBehaviorTreeCompone
 	APawn* ownerPawn = IsValid(aiOwner) ? aiOwner->GetPawn() : nullptr;
 	if (!IsValid(ownerPawn)) return EBTNodeResult::Failed;
 
-	bool bUsePatrol = blackboardComp->GetValueAsBool(CAIKey::Patrol::bUsePatrol);
-	ACPatrolPath* patrolPath = Cast<ACPatrolPath>(blackboardComp->GetValueAsObject(CAIKey::Patrol::PatrolPath));
-	EPatrolMode patrolMode = static_cast<EPatrolMode>(blackboardComp->GetValueAsEnum(CAIKey::Patrol::PatrolMode));
+	bool bUsePatrol = blackboardComp->GetValueAsBool(CAIKey::Patrol::bUsePatrol.KeyName);
+	ACPatrolPath* patrolPath = Cast<ACPatrolPath>(blackboardComp->GetValueAsObject(CAIKey::Patrol::PatrolPath.KeyName));
+	EPatrolMode patrolMode = static_cast<EPatrolMode>(blackboardComp->GetValueAsEnum(CAIKey::Patrol::PatrolMode.KeyName));
 
 	if (!bUsePatrol || !IsValid(patrolPath) || patrolPath->Num() <= 0 || patrolMode == EPatrolMode::None) return EBTNodeResult::Failed;
 	
-	int32 currentIndex = blackboardComp->GetValueAsInt(CAIKey::Patrol::PatrolIndex);
-	bool bPatrolReverse = blackboardComp->GetValueAsBool(CAIKey::Patrol::bPatrolReverse);
+	int32 currentIndex = blackboardComp->GetValueAsInt(CAIKey::Patrol::PatrolIndex.KeyName);
+	bool bPatrolReverse = blackboardComp->GetValueAsBool(CAIKey::Patrol::bPatrolReverse.KeyName);
 	
 	const int32 count = patrolPath->Num();
 	int32 nextIndex = INDEX_NONE;
@@ -93,9 +93,9 @@ EBTNodeResult::Type UCBTTask_SelectPatrolPoint::ExecuteTask(UBehaviorTreeCompone
 	FPatrolPointData nextPatrolPointData;
 	if (!patrolPath->GetPointData(nextIndex, nextPatrolPointData)) return EBTNodeResult::Failed;
 
-	blackboardComp->SetValueAsBool(CAIKey::Patrol::bPatrolReverse, bPatrolReverse);
-	blackboardComp->SetValueAsInt(CAIKey::Patrol::PatrolIndex, nextIndex);
-	blackboardComp->SetValueAsVector(CAIKey::Patrol::PatrolLocation, nextPatrolPointData.Location);
+	blackboardComp->SetValueAsBool(CAIKey::Patrol::bPatrolReverse.KeyName, bPatrolReverse);
+	blackboardComp->SetValueAsInt(CAIKey::Patrol::PatrolIndex.KeyName, nextIndex);
+	blackboardComp->SetValueAsVector(CAIKey::Patrol::PatrolLocation.KeyName, nextPatrolPointData.Location);
 
 	return EBTNodeResult::Succeeded;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SetFocus.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SetFocus.cpp
@@ -5,7 +5,7 @@
 #include "GameFramework/Pawn.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_SetFocus::UCBTTask_SetFocus()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SetFocus.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SetFocus.cpp
@@ -20,7 +20,7 @@ EBTNodeResult::Type UCBTTask_SetFocus::ExecuteTask(UBehaviorTreeComponent& Owner
 	AAIController* aiController = OwnerComp.GetAIOwner();
 	if (!IsValid(aiController)) return EBTNodeResult::Failed;
 
-	AActor* target = Cast<AActor>(blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor));
+	AActor* target = Cast<AActor>(blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName));
 	if (!IsValid(target)) return EBTNodeResult::Failed;
 
 	aiController->SetFocus(target, EAIFocusPriority::Gameplay);

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartCombatAction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartCombatAction.cpp
@@ -26,10 +26,10 @@ EBTNodeResult::Type UCBTTask_StartCombatAction::ExecuteTask(UBehaviorTreeCompone
 	ACEnemy* enemy = Cast<ACEnemy>(aiController->GetPawn());
 	if (!IsValid(enemy)) return EBTNodeResult::Failed;
 
-	const bool bCanCombatAction = blackboardComp->GetValueAsBool(CAIKey::Engage::bCanCombatAction);
+	const bool bCanCombatAction = blackboardComp->GetValueAsBool(CAIKey::Engage::bCanCombatAction.KeyName);
 	if (!bCanCombatAction) return EBTNodeResult::Failed;
 
-	const bool bIsCombatAction = blackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction);
+	const bool bIsCombatAction = blackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName);
 	if (bIsCombatAction) return EBTNodeResult::Failed;
 
 	if (bStopMovementOnStart)
@@ -44,7 +44,7 @@ EBTNodeResult::Type UCBTTask_StartCombatAction::ExecuteTask(UBehaviorTreeCompone
 	const float nextCombatActionTime = currentTime + enemy->GetCombatActionCooldown();
 	
 	// Set Cooldown
-	blackboardComp->SetValueAsFloat(CAIKey::Engage::NextCombatActionTime, nextCombatActionTime);
+	blackboardComp->SetValueAsFloat(CAIKey::Engage::NextCombatActionTime.KeyName, nextCombatActionTime);
 
 	return EBTNodeResult::Succeeded;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartCombatAction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartCombatAction.cpp
@@ -6,7 +6,7 @@
 
 #include "Character/Enemy/CEnemy.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 #include "Type/CActionOrchestrationStructure.h"
 

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartInvestigate.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartInvestigate.cpp
@@ -3,7 +3,7 @@
 
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_StartInvestigate::UCBTTask_StartInvestigate()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartInvestigate.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartInvestigate.cpp
@@ -18,13 +18,13 @@ EBTNodeResult::Type UCBTTask_StartInvestigate::ExecuteTask(UBehaviorTreeComponen
 	UWorld* world = OwnerComp.GetWorld();
 	if (!IsValid(world)) return EBTNodeResult::Failed;
 
-	const FVector lastKnownLocation = blackboardComp->GetValueAsVector(CAIKey::Perception::LastKnownLocation);
+	const FVector lastKnownLocation = blackboardComp->GetValueAsVector(CAIKey::Perception::LastKnownLocation.KeyName);
 
-	blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate, true);
-	blackboardComp->SetValueAsBool(CAIKey::Investigate::bIsInvestigating, true);
+	blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate.KeyName, true);
+	blackboardComp->SetValueAsBool(CAIKey::Investigate::bIsInvestigating.KeyName, true);
 
-	blackboardComp->SetValueAsVector(CAIKey::Investigate::InvestigateLocation, lastKnownLocation);
-	blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex, 0);
+	blackboardComp->SetValueAsVector(CAIKey::Investigate::InvestigateLocation.KeyName, lastKnownLocation);
+	blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName, 0);
 
 	return EBTNodeResult::Succeeded;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartReaction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartReaction.cpp
@@ -4,7 +4,7 @@
 #include "AIController.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_StartReaction::UCBTTask_StartReaction()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartReaction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartReaction.cpp
@@ -16,7 +16,7 @@ EBTNodeResult::Type UCBTTask_StartReaction::ExecuteTask(UBehaviorTreeComponent& 
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return EBTNodeResult::Failed;
 
-	const bool bIsActiveReaction = blackboardComp->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction);
+	const bool bIsActiveReaction = blackboardComp->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName);
 
 	return bIsActiveReaction ? EBTNodeResult::Succeeded : EBTNodeResult::Failed;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndCombatAction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndCombatAction.cpp
@@ -3,7 +3,7 @@
 
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_WaitEndCombatAction::UCBTTask_WaitEndCombatAction()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndCombatAction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndCombatAction.cpp
@@ -19,7 +19,7 @@ EBTNodeResult::Type UCBTTask_WaitEndCombatAction::ExecuteTask(UBehaviorTreeCompo
 		return EBTNodeResult::Failed;
 	}
 
-	if (!blackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction))
+	if (!blackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName))
 	{
 		return EBTNodeResult::Succeeded;
 	}
@@ -36,7 +36,7 @@ void UCBTTask_WaitEndCombatAction::TickTask(UBehaviorTreeComponent& OwnerComp, u
 		return;
 	}
 
-	if (!blackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction))
+	if (!blackboardComp->GetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName))
 	{
 		FinishLatentTask(OwnerComp, EBTNodeResult::Succeeded);
 		return;

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndReaction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndReaction.cpp
@@ -4,7 +4,7 @@
 #include "AIController.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 UCBTTask_WaitEndReaction::UCBTTask_WaitEndReaction()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndReaction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_WaitEndReaction.cpp
@@ -26,7 +26,7 @@ void UCBTTask_WaitEndReaction::TickTask(UBehaviorTreeComponent& OwnerComp, uint8
 		return;
 	}
 
-	const bool bIsActiveReaction = blackboardComp->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction);
+	const bool bIsActiveReaction = blackboardComp->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName);
 
 	if (!bIsActiveReaction)
 	{

--- a/Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
+++ b/Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "BehaviorTree/BlackboardComponent.h"
+#include "GameFramework/Pawn.h"
+
+#include "AI/Blackboard/CAIKeyRegistry.h"
+
+namespace CAIBlackboardValueHelper
+{
+	static void ApplyFixedValue(UBlackboardComponent* InBlackboardComp, const FAIBlackboardKeySpec& InKeySpec)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		switch (InKeySpec.ValueType)
+		{
+		case EAIBlackboardKeyValueType::Bool:
+			InBlackboardComp->SetValueAsBool(InKeySpec.KeyName, InKeySpec.BoolDefault);
+			break;
+
+		case EAIBlackboardKeyValueType::Int:
+			InBlackboardComp->SetValueAsInt(InKeySpec.KeyName, InKeySpec.IntDefault);
+			break;
+
+		case EAIBlackboardKeyValueType::Float:
+			InBlackboardComp->SetValueAsFloat(InKeySpec.KeyName, InKeySpec.FloatDefault);
+			break;
+
+		case EAIBlackboardKeyValueType::Vector:
+			InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InKeySpec.VectorDefault);
+			break;
+
+		case EAIBlackboardKeyValueType::Enum:
+			InBlackboardComp->SetValueAsEnum(InKeySpec.KeyName, InKeySpec.EnumDefault);
+			break;
+
+		case EAIBlackboardKeyValueType::Object:
+			InBlackboardComp->ClearValue(InKeySpec.KeyName);
+			break;
+		}
+	}
+
+	static void ApplyOwnerLocationValue(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, const FAIBlackboardKeySpec& InKeySpec)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+		if (!IsValid(InOwnerPawn)) return;
+
+		InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InOwnerPawn->GetActorLocation());
+	}
+
+	static void InitializeValues(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, TSet<FName>& OutPendingKeys)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
+		{
+			switch (keySpec.InitialValuePolicy)
+			{
+			case EAIBlackboardInitialValuePolicy::Fixed:
+				ApplyFixedValue(InBlackboardComp, keySpec);
+				break;
+
+			case EAIBlackboardInitialValuePolicy::FromOwnerLocation:
+				ApplyOwnerLocationValue(InBlackboardComp, InOwnerPawn, keySpec);
+				break;
+
+			case EAIBlackboardInitialValuePolicy::Custom:
+				OutPendingKeys.Add(keySpec.KeyName);
+				break;
+
+			case EAIBlackboardInitialValuePolicy::None:
+			default:
+				break;
+			}
+		}
+	}
+
+	static void MarkCustomKeyApplied(TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, const UObject* InOwnerContext)
+	{
+		ensureMsgf(
+			InOutPendingKeys.Remove(InKeySpec.KeyName) > 0,
+			TEXT("[AIBlackboardValueHelper] Custom Blackboard key was not registered | Owner=%s | Key=%s"),
+			*GetNameSafe(InOwnerContext),
+			*InKeySpec.KeyName.ToString());
+	}
+
+	static void ApplyCustomBool(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, bool InValue, const UObject* InOwnerContext)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		InBlackboardComp->SetValueAsBool(InKeySpec.KeyName, InValue);
+		MarkCustomKeyApplied(InOutPendingKeys, InKeySpec, InOwnerContext);
+	}
+
+	static void ApplyCustomInt(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, int32 InValue, const UObject* InOwnerContext)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		InBlackboardComp->SetValueAsInt(InKeySpec.KeyName, InValue);
+		MarkCustomKeyApplied(InOutPendingKeys, InKeySpec, InOwnerContext);
+	}
+
+	static void ApplyCustomFloat(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, float InValue, const UObject* InOwnerContext)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		InBlackboardComp->SetValueAsFloat(InKeySpec.KeyName, InValue);
+		MarkCustomKeyApplied(InOutPendingKeys, InKeySpec, InOwnerContext);
+	}
+
+	static void ApplyCustomVector(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, const FVector& InValue, const UObject* InOwnerContext)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InValue);
+		MarkCustomKeyApplied(InOutPendingKeys, InKeySpec, InOwnerContext);
+	}
+
+	static void ApplyCustomEnum(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, uint8 InValue, const UObject* InOwnerContext)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		InBlackboardComp->SetValueAsEnum(InKeySpec.KeyName, InValue);
+		MarkCustomKeyApplied(InOutPendingKeys, InKeySpec, InOwnerContext);
+	}
+
+	static void ApplyCustomObject(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, UObject* InValue, const UObject* InOwnerContext)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		InBlackboardComp->SetValueAsObject(InKeySpec.KeyName, InValue);
+		MarkCustomKeyApplied(InOutPendingKeys, InKeySpec, InOwnerContext);
+	}
+
+	static bool ValidateCustomKeysApplied(const TSet<FName>& InPendingKeys, const UObject* InOwnerContext)
+	{
+		if (InPendingKeys.IsEmpty()) return true;
+
+		TArray<FString> pendingKeyNames;
+		for (const FName& keyName : InPendingKeys)
+		{
+			pendingKeyNames.Add(keyName.ToString());
+		}
+
+		const FString pendingCustomKeys = FString::Join(pendingKeyNames, TEXT(", "));
+
+		ensureMsgf(false,
+			TEXT("[AIBlackboardValueHelper] Missing custom Blackboard initial values | Owner=%s | Pending=%s"),
+			*GetNameSafe(InOwnerContext),
+			*pendingCustomKeys);
+
+		return false;
+	}
+
+	static void ClearValues(UBlackboardComponent* InBlackboardComp)
+	{
+		if (!IsValid(InBlackboardComp)) return;
+
+		for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
+		{
+			if (!keySpec.bClearOnRuntimeTeardown) continue;
+
+			InBlackboardComp->ClearValue(keySpec.KeyName);
+		}
+	}
+}

--- a/Source/Portfolio/AI/Blackboard/CAIKey.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKey.h
@@ -1,114 +1,99 @@
 #pragma once
 
 #include "CoreMinimal.h"
-
-enum class EAIBlackboardKeyValueType : uint8
-{
-	Bool,
-	Int,
-	Float,
-	Enum,
-	Object,
-	Vector,
-};
-
-struct FAIBlackboardKeySpec
-{
-	FName KeyName = NAME_None;
-	EAIBlackboardKeyValueType ValueType = EAIBlackboardKeyValueType::Bool;
-	bool bRequired = true;
-	bool bClearOnRuntimeTeardown = true;
-};
+#include "AI/BlackBoard/CAIKeyFactory.h"
+#include "Type/CHealthStructure.h"
+#include "Type/CStateStructure.h"
 
 namespace CAIKey
 {
 	namespace Targeting
 	{
-		static const FAIBlackboardKeySpec TargetActor = { TEXT("TargetActor"), EAIBlackboardKeyValueType::Object };
-		static const FAIBlackboardKeySpec TargetPriority = { TEXT("TargetPriority"), EAIBlackboardKeyValueType::Int };
+		static const FAIBlackboardKeySpec TargetActor = CAIKeyFactory::FixedObjectNull(TEXT("TargetActor"));
+		static const FAIBlackboardKeySpec TargetPriority = CAIKeyFactory::FixedInt(TEXT("TargetPriority"), INT_MAX);
 	}
 
 	namespace State
 	{
-		static const FAIBlackboardKeySpec AIIntentState = { TEXT("AIIntentState"), EAIBlackboardKeyValueType::Enum };
+		static const FAIBlackboardKeySpec AIIntentState = CAIKeyFactory::FixedEnum(TEXT("AIIntentState"), static_cast<uint8>(EAIIntentState::Idle));
 	}
 
 	namespace Perception
 	{
-		static const FAIBlackboardKeySpec bHasLOS = { TEXT("bHasLOS"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec LastSeenTime = { TEXT("LastSeenTime"), EAIBlackboardKeyValueType::Float };
-		static const FAIBlackboardKeySpec LastKnownLocation = { TEXT("LastKnownLocation"), EAIBlackboardKeyValueType::Vector };
+		static const FAIBlackboardKeySpec bHasLOS = CAIKeyFactory::FixedBool(TEXT("bHasLOS"), false);
+		static const FAIBlackboardKeySpec LastSeenTime = CAIKeyFactory::RuntimeFloat(TEXT("LastSeenTime"));
+		static const FAIBlackboardKeySpec LastKnownLocation = CAIKeyFactory::RuntimeVector(TEXT("LastKnownLocation"));
 	}
 
 	namespace Metric
 	{
-		static const FAIBlackboardKeySpec DistanceToTarget = { TEXT("DistanceToTarget"), EAIBlackboardKeyValueType::Float };
-		static const FAIBlackboardKeySpec DistanceToHome = { TEXT("DistanceToHome"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec DistanceToTarget = CAIKeyFactory::RuntimeFloat(TEXT("DistanceToTarget"));
+		static const FAIBlackboardKeySpec DistanceToHome = CAIKeyFactory::RuntimeFloat(TEXT("DistanceToHome"));
 	}
 
 	namespace Navigation
 	{
-		static const FAIBlackboardKeySpec bReturnHome = { TEXT("bReturnHome"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec HomeLocation = { TEXT("HomeLocation"), EAIBlackboardKeyValueType::Vector };
+		static const FAIBlackboardKeySpec bReturnHome = CAIKeyFactory::FixedBool(TEXT("bReturnHome"), false);
+		static const FAIBlackboardKeySpec HomeLocation = CAIKeyFactory::FromOwnerLocation(TEXT("HomeLocation"));
 	}
 
 	namespace Patrol
 	{
-		static const FAIBlackboardKeySpec bUsePatrol = { TEXT("bUsePatrol"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec PatrolPath = { TEXT("PatrolPath"), EAIBlackboardKeyValueType::Object };
-		static const FAIBlackboardKeySpec PatrolMode = { TEXT("PatrolMode"), EAIBlackboardKeyValueType::Enum };
+		static const FAIBlackboardKeySpec bUsePatrol = CAIKeyFactory::CustomBool(TEXT("bUsePatrol"));
+		static const FAIBlackboardKeySpec PatrolPath = CAIKeyFactory::CustomObject(TEXT("PatrolPath"));
+		static const FAIBlackboardKeySpec PatrolMode = CAIKeyFactory::CustomEnum(TEXT("PatrolMode"));
 
-		static const FAIBlackboardKeySpec bPatrolReverse = { TEXT("bPatrolReverse"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec PatrolLocation = { TEXT("PatrolLocation"), EAIBlackboardKeyValueType::Vector };
-		static const FAIBlackboardKeySpec PatrolIndex = { TEXT("PatrolIndex"), EAIBlackboardKeyValueType::Int };
+		static const FAIBlackboardKeySpec bPatrolReverse = CAIKeyFactory::FixedBool(TEXT("bPatrolReverse"), false);
+		static const FAIBlackboardKeySpec PatrolLocation = CAIKeyFactory::FromOwnerLocation(TEXT("PatrolLocation"));
+		static const FAIBlackboardKeySpec PatrolIndex = CAIKeyFactory::FixedInt(TEXT("PatrolIndex"), -1);
 	}
 
 	namespace Investigate
 	{
-		static const FAIBlackboardKeySpec bUseInvestigate = { TEXT("bUseInvestigate"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec InvestigateDuration = { TEXT("InvestigateDuration"), EAIBlackboardKeyValueType::Float };
-		static const FAIBlackboardKeySpec InvestigateMaxIndex = { TEXT("InvestigateMaxIndex"), EAIBlackboardKeyValueType::Int };
+		static const FAIBlackboardKeySpec bUseInvestigate = CAIKeyFactory::CustomBool(TEXT("bUseInvestigate"));
+		static const FAIBlackboardKeySpec InvestigateDuration = CAIKeyFactory::CustomFloat(TEXT("InvestigateDuration"));
+		static const FAIBlackboardKeySpec InvestigateMaxIndex = CAIKeyFactory::CustomInt(TEXT("InvestigateMaxIndex"));
 
-		static const FAIBlackboardKeySpec bCanInvestigate = { TEXT("bCanInvestigate"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec bIsInvestigating = { TEXT("bIsInvestigating"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec InvestigateLocation = { TEXT("InvestigateLocation"), EAIBlackboardKeyValueType::Vector };
-		static const FAIBlackboardKeySpec InvestigateIndex = { TEXT("InvestigateIndex"), EAIBlackboardKeyValueType::Int };
+		static const FAIBlackboardKeySpec bCanInvestigate = CAIKeyFactory::FixedBool(TEXT("bCanInvestigate"), false);
+		static const FAIBlackboardKeySpec bIsInvestigating = CAIKeyFactory::FixedBool(TEXT("bIsInvestigating"), false);
+		static const FAIBlackboardKeySpec InvestigateLocation = CAIKeyFactory::FromOwnerLocation(TEXT("InvestigateLocation"));
+		static const FAIBlackboardKeySpec InvestigateIndex = CAIKeyFactory::FixedInt(TEXT("InvestigateIndex"), INDEX_NONE);
 	}
 
 	namespace Chase
 	{
-		static const FAIBlackboardKeySpec ChaseOffsetRange = { TEXT("ChaseOffsetRange"), EAIBlackboardKeyValueType::Float };
-		static const FAIBlackboardKeySpec ChaseEnterBuffer = { TEXT("ChaseEnterBuffer"), EAIBlackboardKeyValueType::Float };
-		static const FAIBlackboardKeySpec ChaseExitBuffer = { TEXT("ChaseExitBuffer"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec ChaseOffsetRange = CAIKeyFactory::CustomFloat(TEXT("ChaseOffsetRange"));
+		static const FAIBlackboardKeySpec ChaseEnterBuffer = CAIKeyFactory::CustomFloat(TEXT("ChaseEnterBuffer"));
+		static const FAIBlackboardKeySpec ChaseExitBuffer = CAIKeyFactory::CustomFloat(TEXT("ChaseExitBuffer"));
 	}
 
 	namespace Alert
 	{
-		static const FAIBlackboardKeySpec bUseAlertStep = { TEXT("bUseAlertStep"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec StepForwardDistance = { TEXT("StepForwardDistance"), EAIBlackboardKeyValueType::Float };
-		static const FAIBlackboardKeySpec StepSideDistance = { TEXT("StepSideDistance"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec bUseAlertStep = CAIKeyFactory::CustomBool(TEXT("bUseAlertStep"));
+		static const FAIBlackboardKeySpec StepForwardDistance = CAIKeyFactory::CustomFloat(TEXT("StepForwardDistance"));
+		static const FAIBlackboardKeySpec StepSideDistance = CAIKeyFactory::CustomFloat(TEXT("StepSideDistance"));
 
-		static const FAIBlackboardKeySpec bInAlertRange = { TEXT("bInAlertRange"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec AlertStepLocation = { TEXT("AlertStepLocation"), EAIBlackboardKeyValueType::Vector };
+		static const FAIBlackboardKeySpec bInAlertRange = CAIKeyFactory::FixedBool(TEXT("bInAlertRange"), false);
+		static const FAIBlackboardKeySpec AlertStepLocation = CAIKeyFactory::FromOwnerLocation(TEXT("AlertStepLocation"));
 	}
 
 	namespace Engage
 	{
-		static const FAIBlackboardKeySpec bShouldEngage = { TEXT("bShouldEngage"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec bCanCombatAction = { TEXT("bCanCombatAction"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec bShouldEngage = CAIKeyFactory::FixedBool(TEXT("bShouldEngage"), false);
+		static const FAIBlackboardKeySpec bCanCombatAction = CAIKeyFactory::FixedBool(TEXT("bCanCombatAction"), false);
 		
-		static const FAIBlackboardKeySpec bIsCombatAction = { TEXT("bIsCombatAction"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec bInEngageRange = { TEXT("bInEngageRange"), EAIBlackboardKeyValueType::Bool };
-		static const FAIBlackboardKeySpec NextCombatActionTime = { TEXT("NextCombatActionTime"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec bIsCombatAction = CAIKeyFactory::FixedBool(TEXT("bIsCombatAction"), false);
+		static const FAIBlackboardKeySpec bInEngageRange = CAIKeyFactory::FixedBool(TEXT("bInEngageRange"), false);
+		static const FAIBlackboardKeySpec NextCombatActionTime = CAIKeyFactory::FixedFloat(TEXT("NextCombatActionTime"), -1.f);
 	}
 	
 	namespace Reaction
 	{
-		static const FAIBlackboardKeySpec bIsActiveReaction = { TEXT("bIsActiveReaction"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec bIsActiveReaction = CAIKeyFactory::FixedBool(TEXT("bIsActiveReaction"), false);
 	}
 
 	namespace Dead
 	{
-		static const FAIBlackboardKeySpec DeadState = { TEXT("DeadState"), EAIBlackboardKeyValueType::Enum };
+		static const FAIBlackboardKeySpec DeadState = CAIKeyFactory::FixedEnum(TEXT("DeadState"), static_cast<uint8>(EDeadState::Alive));
 	}
 }

--- a/Source/Portfolio/AI/Blackboard/CAIKey.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKey.h
@@ -2,95 +2,113 @@
 
 #include "CoreMinimal.h"
 
+enum class EAIBlackboardKeyValueType : uint8
+{
+	Bool,
+	Int,
+	Float,
+	Enum,
+	Object,
+	Vector,
+};
+
+struct FAIBlackboardKeySpec
+{
+	FName KeyName = NAME_None;
+	EAIBlackboardKeyValueType ValueType = EAIBlackboardKeyValueType::Bool;
+	bool bRequired = true;
+	bool bClearOnRuntimeTeardown = true;
+};
+
 namespace CAIKey
 {
 	namespace Targeting
 	{
-		static const FName TargetActor = "TargetActor";							// Object(Actor)
-		static const FName TargetPriority = "TargetPriority";					// Int
+		static const FAIBlackboardKeySpec TargetActor = { TEXT("TargetActor"), EAIBlackboardKeyValueType::Object };
+		static const FAIBlackboardKeySpec TargetPriority = { TEXT("TargetPriority"), EAIBlackboardKeyValueType::Int };
 	}
 
 	namespace State
 	{
-		static const FName AIIntentState = "AIIntentState";						// Enum(EAIIntentState)
+		static const FAIBlackboardKeySpec AIIntentState = { TEXT("AIIntentState"), EAIBlackboardKeyValueType::Enum };
 	}
 
 	namespace Perception
 	{
-		static const FName bHasLOS = "bHasLOS";									// Bool
-		static const FName LastSeenTime = "LastSeenTime";						// Float
-		static const FName LastKnownLocation = "LastKnownLocation";				// Vector
+		static const FAIBlackboardKeySpec bHasLOS = { TEXT("bHasLOS"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec LastSeenTime = { TEXT("LastSeenTime"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec LastKnownLocation = { TEXT("LastKnownLocation"), EAIBlackboardKeyValueType::Vector };
 	}
 
 	namespace Metric
 	{
-		static const FName DistanceToTarget = "DistanceToTarget";				// Float
-		static const FName DistanceToHome = "DistanceToHome";					// Float
+		static const FAIBlackboardKeySpec DistanceToTarget = { TEXT("DistanceToTarget"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec DistanceToHome = { TEXT("DistanceToHome"), EAIBlackboardKeyValueType::Float };
 	}
 
 	namespace Navigation
 	{
-		static const FName bReturnHome = "bReturnHome";							// Bool
-		static const FName HomeLocation = "HomeLocation";						// Vector
+		static const FAIBlackboardKeySpec bReturnHome = { TEXT("bReturnHome"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec HomeLocation = { TEXT("HomeLocation"), EAIBlackboardKeyValueType::Vector };
 	}
 
 	namespace Patrol
 	{
-		static const FName bUsePatrol = "bUsePatrol";							// Bool
-		static const FName PatrolPath = "PatrolPath";							// Object(ACPatrolPath)
-		static const FName PatrolMode = "PatrolMode";							// Enum(EPatrolMode)
+		static const FAIBlackboardKeySpec bUsePatrol = { TEXT("bUsePatrol"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec PatrolPath = { TEXT("PatrolPath"), EAIBlackboardKeyValueType::Object };
+		static const FAIBlackboardKeySpec PatrolMode = { TEXT("PatrolMode"), EAIBlackboardKeyValueType::Enum };
 
-		static const FName bPatrolReverse = "bPatrolReverse";					// Bool
-		static const FName PatrolLocation = "PatrolLocation";					// Vector
-		static const FName PatrolIndex = "PatrolIndex";							// Int
+		static const FAIBlackboardKeySpec bPatrolReverse = { TEXT("bPatrolReverse"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec PatrolLocation = { TEXT("PatrolLocation"), EAIBlackboardKeyValueType::Vector };
+		static const FAIBlackboardKeySpec PatrolIndex = { TEXT("PatrolIndex"), EAIBlackboardKeyValueType::Int };
 	}
 
 	namespace Investigate
 	{
-		static const FName bUseInvestigate = "bUseInvestigate";					// Bool
-		static const FName InvestigateDuration = "InvestigateDuration";			// Float
-		static const FName InvestigateMaxIndex = "InvestigateMaxIndex";			// Int
+		static const FAIBlackboardKeySpec bUseInvestigate = { TEXT("bUseInvestigate"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec InvestigateDuration = { TEXT("InvestigateDuration"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec InvestigateMaxIndex = { TEXT("InvestigateMaxIndex"), EAIBlackboardKeyValueType::Int };
 
-		static const FName bCanInvestigate = "bCanInvestigate";					// Bool
-		static const FName bIsInvestigating = "bIsInvestigating";				// Bool
-		static const FName InvestigateLocation = "InvestigateLocation";			// Vector
-		static const FName InvestigateIndex = "InvestigateIndex";				// Int
+		static const FAIBlackboardKeySpec bCanInvestigate = { TEXT("bCanInvestigate"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec bIsInvestigating = { TEXT("bIsInvestigating"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec InvestigateLocation = { TEXT("InvestigateLocation"), EAIBlackboardKeyValueType::Vector };
+		static const FAIBlackboardKeySpec InvestigateIndex = { TEXT("InvestigateIndex"), EAIBlackboardKeyValueType::Int };
 	}
 
 	namespace Chase
 	{
-		static const FName ChaseOffsetRange = "ChaseOffsetRange";				// Float
-		static const FName ChaseEnterBuffer = "ChaseEnterBuffer";				// Float
-		static const FName ChaseExitBuffer = "ChaseExitBuffer";					// Float
+		static const FAIBlackboardKeySpec ChaseOffsetRange = { TEXT("ChaseOffsetRange"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec ChaseEnterBuffer = { TEXT("ChaseEnterBuffer"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec ChaseExitBuffer = { TEXT("ChaseExitBuffer"), EAIBlackboardKeyValueType::Float };
 	}
 
 	namespace Alert
 	{
-		static const FName bUseAlertStep = "bUseAlertStep";						// Bool
-		static const FName StepForwardDistance = "StepForwardDistance";			// Float
-		static const FName StepSideDistance = "StepSideDistance";				// Float
+		static const FAIBlackboardKeySpec bUseAlertStep = { TEXT("bUseAlertStep"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec StepForwardDistance = { TEXT("StepForwardDistance"), EAIBlackboardKeyValueType::Float };
+		static const FAIBlackboardKeySpec StepSideDistance = { TEXT("StepSideDistance"), EAIBlackboardKeyValueType::Float };
 
-		static const FName bInAlertRange = "bInAlertRange";						// Bool
-		static const FName AlertStepLocation = "AlertStepLocation";				// Vector
+		static const FAIBlackboardKeySpec bInAlertRange = { TEXT("bInAlertRange"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec AlertStepLocation = { TEXT("AlertStepLocation"), EAIBlackboardKeyValueType::Vector };
 	}
 
 	namespace Engage
 	{
-		static const FName bShouldEngage = "bShouldEngage";						// Bool	 (UpdateAIContext)
-		static const FName bCanCombatAction = "bCanCombatAction";				// Bool	 (UpdateEngageContext)
+		static const FAIBlackboardKeySpec bShouldEngage = { TEXT("bShouldEngage"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec bCanCombatAction = { TEXT("bCanCombatAction"), EAIBlackboardKeyValueType::Bool };
 		
-		static const FName bIsCombatAction = "bIsCombatAction";					// Bool	 (OnActionTypeChanged)
-		static const FName bInEngageRange = "bInEngageRange";					// Bool	 (UpdateAIContext)
-		static const FName NextCombatActionTime = "NextCombatActionTime";		// Float (StartCombatAction)
+		static const FAIBlackboardKeySpec bIsCombatAction = { TEXT("bIsCombatAction"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec bInEngageRange = { TEXT("bInEngageRange"), EAIBlackboardKeyValueType::Bool };
+		static const FAIBlackboardKeySpec NextCombatActionTime = { TEXT("NextCombatActionTime"), EAIBlackboardKeyValueType::Float };
 	}
 	
 	namespace Reaction
 	{
-		static const FName bIsActiveReaction = "bIsActiveReaction";				// Bool
+		static const FAIBlackboardKeySpec bIsActiveReaction = { TEXT("bIsActiveReaction"), EAIBlackboardKeyValueType::Bool };
 	}
 
 	namespace Dead
 	{
-		static const FName DeadState = "DeadState";								// Enum(EDeadState)
+		static const FAIBlackboardKeySpec DeadState = { TEXT("DeadState"), EAIBlackboardKeyValueType::Enum };
 	}
 }

--- a/Source/Portfolio/AI/Blackboard/CAIKey.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKey.h
@@ -7,7 +7,7 @@ namespace CAIKey
 	namespace Targeting
 	{
 		static const FName TargetActor = "TargetActor";							// Object(Actor)
-		static const FName TargetPriority = "TargetPriority";					// Float
+		static const FName TargetPriority = "TargetPriority";					// Int
 	}
 
 	namespace State

--- a/Source/Portfolio/AI/Blackboard/CAIKey.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKey.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "AI/BlackBoard/CAIKeyFactory.h"
+#include "AI/Blackboard/CAIKeyFactory.h"
 #include "Type/CHealthStructure.h"
 #include "Type/CStateStructure.h"
 

--- a/Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 
-#include "AI/BlackBoard/CAIKeyTypes.h"
+#include "AI/Blackboard/CAIKeyTypes.h"
 
 namespace CAIKeyFactory
 {

--- a/Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "AI/BlackBoard/CAIKeyTypes.h"
+
+namespace CAIKeyFactory
+{
+	static FAIBlackboardKeySpec MakeKey(const TCHAR* InKeyName, EAIBlackboardKeyValueType InValueType)
+	{
+		FAIBlackboardKeySpec keySpec;
+		keySpec.KeyName = InKeyName;
+		keySpec.ValueType = InValueType;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec FixedBool(const TCHAR* InKeyName, bool InValue)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, EAIBlackboardKeyValueType::Bool);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::Fixed;
+		keySpec.BoolDefault = InValue;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec FixedInt(const TCHAR* InKeyName, int32 InValue)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, EAIBlackboardKeyValueType::Int);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::Fixed;
+		keySpec.IntDefault = InValue;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec FixedFloat(const TCHAR* InKeyName, float InValue)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, EAIBlackboardKeyValueType::Float);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::Fixed;
+		keySpec.FloatDefault = InValue;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec FixedVector(const TCHAR* InKeyName, const FVector& InValue)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, EAIBlackboardKeyValueType::Vector);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::Fixed;
+		keySpec.VectorDefault = InValue;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec FixedEnum(const TCHAR* InKeyName, uint8 InValue)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, EAIBlackboardKeyValueType::Enum);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::Fixed;
+		keySpec.EnumDefault = InValue;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec FixedObjectNull(const TCHAR* InKeyName)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, EAIBlackboardKeyValueType::Object);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::Fixed;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec RuntimeValue(const TCHAR* InKeyName, EAIBlackboardKeyValueType InValueType)
+	{
+		return MakeKey(InKeyName, InValueType);
+	}
+
+	static FAIBlackboardKeySpec RuntimeBool(const TCHAR* InKeyName)
+	{
+		return RuntimeValue(InKeyName, EAIBlackboardKeyValueType::Bool);
+	}
+
+	static FAIBlackboardKeySpec RuntimeInt(const TCHAR* InKeyName)
+	{
+		return RuntimeValue(InKeyName, EAIBlackboardKeyValueType::Int);
+	}
+
+	static FAIBlackboardKeySpec RuntimeFloat(const TCHAR* InKeyName)
+	{
+		return RuntimeValue(InKeyName, EAIBlackboardKeyValueType::Float);
+	}
+
+	static FAIBlackboardKeySpec RuntimeVector(const TCHAR* InKeyName)
+	{
+		return RuntimeValue(InKeyName, EAIBlackboardKeyValueType::Vector);
+	}
+
+	static FAIBlackboardKeySpec RuntimeEnum(const TCHAR* InKeyName)
+	{
+		return RuntimeValue(InKeyName, EAIBlackboardKeyValueType::Enum);
+	}
+
+	static FAIBlackboardKeySpec RuntimeObject(const TCHAR* InKeyName)
+	{
+		return RuntimeValue(InKeyName, EAIBlackboardKeyValueType::Object);
+	}
+
+	static FAIBlackboardKeySpec FromOwnerLocation(const TCHAR* InKeyName)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, EAIBlackboardKeyValueType::Vector);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::FromOwnerLocation;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec Custom(const TCHAR* InKeyName, EAIBlackboardKeyValueType InValueType)
+	{
+		FAIBlackboardKeySpec keySpec = MakeKey(InKeyName, InValueType);
+		keySpec.InitialValuePolicy = EAIBlackboardInitialValuePolicy::Custom;
+		return keySpec;
+	}
+
+	static FAIBlackboardKeySpec CustomBool(const TCHAR* InKeyName)
+	{
+		return Custom(InKeyName, EAIBlackboardKeyValueType::Bool);
+	}
+
+	static FAIBlackboardKeySpec CustomInt(const TCHAR* InKeyName)
+	{
+		return Custom(InKeyName, EAIBlackboardKeyValueType::Int);
+	}
+
+	static FAIBlackboardKeySpec CustomFloat(const TCHAR* InKeyName)
+	{
+		return Custom(InKeyName, EAIBlackboardKeyValueType::Float);
+	}
+
+	static FAIBlackboardKeySpec CustomVector(const TCHAR* InKeyName)
+	{
+		return Custom(InKeyName, EAIBlackboardKeyValueType::Vector);
+	}
+
+	static FAIBlackboardKeySpec CustomEnum(const TCHAR* InKeyName)
+	{
+		return Custom(InKeyName, EAIBlackboardKeyValueType::Enum);
+	}
+
+	static FAIBlackboardKeySpec CustomObject(const TCHAR* InKeyName)
+	{
+		return Custom(InKeyName, EAIBlackboardKeyValueType::Object);
+	}
+}

--- a/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "AI/BlackBoard/CAIKey.h"
+
+enum class EAIBlackboardKeyValueType : uint8
+{
+	Bool,
+	Int,
+	Float,
+	Enum,
+	Object,
+	Vector,
+};
+
+struct FAIBlackboardKeySpec
+{
+	FName KeyName = NAME_None;
+	EAIBlackboardKeyValueType ValueType = EAIBlackboardKeyValueType::Bool;
+	bool bRequired = true;
+	bool bClearOnRuntimeTeardown = true;
+};
+
+namespace CAIKeyRegistry
+{
+	static const TArray<FAIBlackboardKeySpec>& GetKeySpecs()
+	{
+		static const TArray<FAIBlackboardKeySpec> keySpecs =
+		{
+			// Targeting
+			{ CAIKey::Targeting::TargetActor, EAIBlackboardKeyValueType::Object },
+			{ CAIKey::Targeting::TargetPriority, EAIBlackboardKeyValueType::Int },
+
+			// State
+			{ CAIKey::State::AIIntentState, EAIBlackboardKeyValueType::Enum },
+
+			// Perception
+			{ CAIKey::Perception::bHasLOS, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Perception::LastSeenTime, EAIBlackboardKeyValueType::Float },
+			{ CAIKey::Perception::LastKnownLocation, EAIBlackboardKeyValueType::Vector },
+
+			// Metric
+			{ CAIKey::Metric::DistanceToTarget, EAIBlackboardKeyValueType::Float },
+			{ CAIKey::Metric::DistanceToHome, EAIBlackboardKeyValueType::Float },
+
+			// Navigation
+			{ CAIKey::Navigation::bReturnHome, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Navigation::HomeLocation, EAIBlackboardKeyValueType::Vector },
+
+			// Patrol
+			{ CAIKey::Patrol::bUsePatrol, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Patrol::PatrolPath, EAIBlackboardKeyValueType::Object },
+			{ CAIKey::Patrol::PatrolMode, EAIBlackboardKeyValueType::Enum },
+			{ CAIKey::Patrol::bPatrolReverse, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Patrol::PatrolLocation, EAIBlackboardKeyValueType::Vector },
+			{ CAIKey::Patrol::PatrolIndex, EAIBlackboardKeyValueType::Int },
+
+			// Investigate
+			{ CAIKey::Investigate::bUseInvestigate, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Investigate::InvestigateDuration, EAIBlackboardKeyValueType::Float },
+			{ CAIKey::Investigate::InvestigateMaxIndex, EAIBlackboardKeyValueType::Int },
+			{ CAIKey::Investigate::bCanInvestigate, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Investigate::bIsInvestigating, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Investigate::InvestigateLocation, EAIBlackboardKeyValueType::Vector },
+			{ CAIKey::Investigate::InvestigateIndex, EAIBlackboardKeyValueType::Int },
+
+			// Chase
+			{ CAIKey::Chase::ChaseOffsetRange, EAIBlackboardKeyValueType::Float },
+			{ CAIKey::Chase::ChaseEnterBuffer, EAIBlackboardKeyValueType::Float },
+			{ CAIKey::Chase::ChaseExitBuffer, EAIBlackboardKeyValueType::Float },
+
+			// Alert
+			{ CAIKey::Alert::bUseAlertStep, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Alert::StepForwardDistance, EAIBlackboardKeyValueType::Float },
+			{ CAIKey::Alert::StepSideDistance, EAIBlackboardKeyValueType::Float },
+			{ CAIKey::Alert::bInAlertRange, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Alert::AlertStepLocation, EAIBlackboardKeyValueType::Vector },
+
+			// Engage
+			{ CAIKey::Engage::bShouldEngage, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Engage::bCanCombatAction, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Engage::bIsCombatAction, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Engage::bInEngageRange, EAIBlackboardKeyValueType::Bool },
+			{ CAIKey::Engage::NextCombatActionTime, EAIBlackboardKeyValueType::Float },
+
+			// Reaction
+			{ CAIKey::Reaction::bIsActiveReaction, EAIBlackboardKeyValueType::Bool },
+
+			// Dead
+			{ CAIKey::Dead::DeadState, EAIBlackboardKeyValueType::Enum },
+		};
+
+		return keySpecs;
+	}
+}

--- a/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
@@ -4,7 +4,7 @@
 
 #include "BehaviorTree/BlackboardData.h"
 
-#include "AI/BlackBoard/CAIKey.h"
+#include "AI/Blackboard/CAIKey.h"
 
 namespace CAIKeyRegistry
 {

--- a/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
@@ -24,6 +24,33 @@ struct FAIBlackboardKeySpec
 
 namespace CAIKeyRegistry
 {
+	static const TCHAR* GetValueTypeName(EAIBlackboardKeyValueType InValueType)
+	{
+		switch (InValueType)
+		{
+		case EAIBlackboardKeyValueType::Bool:
+			return TEXT("Bool");
+
+		case EAIBlackboardKeyValueType::Int:
+			return TEXT("Int");
+
+		case EAIBlackboardKeyValueType::Float:
+			return TEXT("Float");
+
+		case EAIBlackboardKeyValueType::Enum:
+			return TEXT("Enum");
+
+		case EAIBlackboardKeyValueType::Object:
+			return TEXT("Object");
+
+		case EAIBlackboardKeyValueType::Vector:
+			return TEXT("Vector");
+
+		default:
+			return TEXT("Unknown");
+		}
+	}
+
 	static const TArray<FAIBlackboardKeySpec>& GetKeySpecs()
 	{
 		static const TArray<FAIBlackboardKeySpec> keySpecs =

--- a/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
@@ -2,25 +2,9 @@
 
 #include "CoreMinimal.h"
 
+#include "BehaviorTree/BlackboardData.h"
+
 #include "AI/BlackBoard/CAIKey.h"
-
-enum class EAIBlackboardKeyValueType : uint8
-{
-	Bool,
-	Int,
-	Float,
-	Enum,
-	Object,
-	Vector,
-};
-
-struct FAIBlackboardKeySpec
-{
-	FName KeyName = NAME_None;
-	EAIBlackboardKeyValueType ValueType = EAIBlackboardKeyValueType::Bool;
-	bool bRequired = true;
-	bool bClearOnRuntimeTeardown = true;
-};
 
 namespace CAIKeyRegistry
 {
@@ -56,68 +40,105 @@ namespace CAIKeyRegistry
 		static const TArray<FAIBlackboardKeySpec> keySpecs =
 		{
 			// Targeting
-			{ CAIKey::Targeting::TargetActor, EAIBlackboardKeyValueType::Object },
-			{ CAIKey::Targeting::TargetPriority, EAIBlackboardKeyValueType::Int },
+			CAIKey::Targeting::TargetActor,
+			CAIKey::Targeting::TargetPriority,
 
 			// State
-			{ CAIKey::State::AIIntentState, EAIBlackboardKeyValueType::Enum },
+			CAIKey::State::AIIntentState,
 
 			// Perception
-			{ CAIKey::Perception::bHasLOS, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Perception::LastSeenTime, EAIBlackboardKeyValueType::Float },
-			{ CAIKey::Perception::LastKnownLocation, EAIBlackboardKeyValueType::Vector },
+			CAIKey::Perception::bHasLOS,
+			CAIKey::Perception::LastSeenTime,
+			CAIKey::Perception::LastKnownLocation,
 
 			// Metric
-			{ CAIKey::Metric::DistanceToTarget, EAIBlackboardKeyValueType::Float },
-			{ CAIKey::Metric::DistanceToHome, EAIBlackboardKeyValueType::Float },
+			CAIKey::Metric::DistanceToTarget,
+			CAIKey::Metric::DistanceToHome,
 
 			// Navigation
-			{ CAIKey::Navigation::bReturnHome, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Navigation::HomeLocation, EAIBlackboardKeyValueType::Vector },
+			CAIKey::Navigation::bReturnHome,
+			CAIKey::Navigation::HomeLocation,
 
 			// Patrol
-			{ CAIKey::Patrol::bUsePatrol, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Patrol::PatrolPath, EAIBlackboardKeyValueType::Object },
-			{ CAIKey::Patrol::PatrolMode, EAIBlackboardKeyValueType::Enum },
-			{ CAIKey::Patrol::bPatrolReverse, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Patrol::PatrolLocation, EAIBlackboardKeyValueType::Vector },
-			{ CAIKey::Patrol::PatrolIndex, EAIBlackboardKeyValueType::Int },
+			CAIKey::Patrol::bUsePatrol,
+			CAIKey::Patrol::PatrolPath,
+			CAIKey::Patrol::PatrolMode,
+			CAIKey::Patrol::bPatrolReverse,
+			CAIKey::Patrol::PatrolLocation,
+			CAIKey::Patrol::PatrolIndex,
 
 			// Investigate
-			{ CAIKey::Investigate::bUseInvestigate, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Investigate::InvestigateDuration, EAIBlackboardKeyValueType::Float },
-			{ CAIKey::Investigate::InvestigateMaxIndex, EAIBlackboardKeyValueType::Int },
-			{ CAIKey::Investigate::bCanInvestigate, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Investigate::bIsInvestigating, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Investigate::InvestigateLocation, EAIBlackboardKeyValueType::Vector },
-			{ CAIKey::Investigate::InvestigateIndex, EAIBlackboardKeyValueType::Int },
+			CAIKey::Investigate::bUseInvestigate,
+			CAIKey::Investigate::InvestigateDuration,
+			CAIKey::Investigate::InvestigateMaxIndex,
+			CAIKey::Investigate::bCanInvestigate,
+			CAIKey::Investigate::bIsInvestigating,
+			CAIKey::Investigate::InvestigateLocation,
+			CAIKey::Investigate::InvestigateIndex,
 
 			// Chase
-			{ CAIKey::Chase::ChaseOffsetRange, EAIBlackboardKeyValueType::Float },
-			{ CAIKey::Chase::ChaseEnterBuffer, EAIBlackboardKeyValueType::Float },
-			{ CAIKey::Chase::ChaseExitBuffer, EAIBlackboardKeyValueType::Float },
+			CAIKey::Chase::ChaseOffsetRange,
+			CAIKey::Chase::ChaseEnterBuffer,
+			CAIKey::Chase::ChaseExitBuffer,
 
 			// Alert
-			{ CAIKey::Alert::bUseAlertStep, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Alert::StepForwardDistance, EAIBlackboardKeyValueType::Float },
-			{ CAIKey::Alert::StepSideDistance, EAIBlackboardKeyValueType::Float },
-			{ CAIKey::Alert::bInAlertRange, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Alert::AlertStepLocation, EAIBlackboardKeyValueType::Vector },
+			CAIKey::Alert::bUseAlertStep,
+			CAIKey::Alert::StepForwardDistance,
+			CAIKey::Alert::StepSideDistance,
+			CAIKey::Alert::bInAlertRange,
+			CAIKey::Alert::AlertStepLocation,
 
 			// Engage
-			{ CAIKey::Engage::bShouldEngage, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Engage::bCanCombatAction, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Engage::bIsCombatAction, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Engage::bInEngageRange, EAIBlackboardKeyValueType::Bool },
-			{ CAIKey::Engage::NextCombatActionTime, EAIBlackboardKeyValueType::Float },
+			CAIKey::Engage::bShouldEngage,
+			CAIKey::Engage::bCanCombatAction,
+			CAIKey::Engage::bIsCombatAction,
+			CAIKey::Engage::bInEngageRange,
+			CAIKey::Engage::NextCombatActionTime,
 
 			// Reaction
-			{ CAIKey::Reaction::bIsActiveReaction, EAIBlackboardKeyValueType::Bool },
+			CAIKey::Reaction::bIsActiveReaction,
 
 			// Dead
-			{ CAIKey::Dead::DeadState, EAIBlackboardKeyValueType::Enum },
+			CAIKey::Dead::DeadState,
 		};
 
 		return keySpecs;
+	}
+
+	static bool ValidateKey(const UBlackboardData* InBlackboardAsset, const FAIBlackboardKeySpec& InKeySpec)
+	{
+		if (!IsValid(InBlackboardAsset)) return false;
+
+		return InBlackboardAsset->GetKeyID(InKeySpec.KeyName) != FBlackboard::InvalidKey;
+	}
+
+	static bool ValidateRequiredKeys(const UBlackboardData* InBlackboardAsset)
+	{
+		if (!IsValid(InBlackboardAsset)) return false;
+
+		TArray<FString> missingKeyMessages;
+
+		for (const FAIBlackboardKeySpec& keySpec : GetKeySpecs())
+		{
+			if (!keySpec.bRequired) continue;
+
+			const bool bValidKey = ValidateKey(InBlackboardAsset, keySpec);
+			if (bValidKey) continue;
+
+			missingKeyMessages.Add(FString::Printf(
+				TEXT("%s:%s"),
+				*keySpec.KeyName.ToString(),
+				GetValueTypeName(keySpec.ValueType)));
+		}
+
+		if (missingKeyMessages.IsEmpty()) return true;
+
+		const FString missingKeys = FString::Join(missingKeyMessages, TEXT(", "));
+		ensureMsgf(false,
+			TEXT("[AIKeyRegistry] Missing required Blackboard keys | Blackboard=%s | Missing=%s"),
+			*GetNameSafe(InBlackboardAsset),
+			*missingKeys);
+
+		return false;
 	}
 }

--- a/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
@@ -21,14 +21,14 @@ namespace CAIKeyRegistry
 		case EAIBlackboardKeyValueType::Float:
 			return TEXT("Float");
 
+		case EAIBlackboardKeyValueType::Vector:
+			return TEXT("Vector");
+
 		case EAIBlackboardKeyValueType::Enum:
 			return TEXT("Enum");
 
 		case EAIBlackboardKeyValueType::Object:
 			return TEXT("Object");
-
-		case EAIBlackboardKeyValueType::Vector:
-			return TEXT("Vector");
 
 		default:
 			return TEXT("Unknown");

--- a/Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+enum class EAIBlackboardKeyValueType : uint8
+{
+	Bool,
+	Int,
+	Float,
+	Vector,
+	Enum,
+	Object,
+};
+
+enum class EAIBlackboardInitialValuePolicy : uint8
+{
+	None,
+	Fixed,
+	FromOwnerLocation,
+	Custom,
+};
+
+struct FAIBlackboardKeySpec
+{
+	FName KeyName = NAME_None;
+	EAIBlackboardKeyValueType ValueType = EAIBlackboardKeyValueType::Bool;
+	EAIBlackboardInitialValuePolicy InitialValuePolicy = EAIBlackboardInitialValuePolicy::None;
+
+	bool BoolDefault = false;
+	int32 IntDefault = 0;
+	float FloatDefault = 0.f;
+	FVector VectorDefault = FVector::ZeroVector;
+	uint8 EnumDefault = 0;
+
+	bool bRequired = true;
+	bool bClearOnRuntimeTeardown = true;
+};

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -442,7 +442,7 @@ void ACEnemy::OnActionTypeChanged(ACharacter* InOwnerCharacter, EActionType InPr
 	if (!IsValid(blackboardComp)) return;
 
 	const bool bIsCombatAction = IsCombatActionType(InNewActionType);
-	blackboardComp->SetValueAsBool(CAIKey::Engage::bIsCombatAction, bIsCombatAction);
+	blackboardComp->SetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName, bIsCombatAction);
 }
 
 void ACEnemy::OnActionEvent(ACharacter* InOwnerCharacter, EActionType InActionType, int32 InActionIndex, EActionEventType InActionEventType)

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -513,7 +513,7 @@ AActor* UCCombatSignalSourceComponent::ResolveCueTargetActor() const
 	const UBlackboardComponent* blackboardComp = aiController->GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return nullptr;
 
-	return Cast<AActor>(blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor));
+	return Cast<AActor>(blackboardComp->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName));
 }
 
 FCombatSignal UCCombatSignalSourceComponent::BuildCueSignal(AActor* InTargetActor, FName InCueTag, const FVector& InCueLocation, const FVector& InDirection, AActor* InSignalCauser) const

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -410,144 +410,26 @@ bool ACAIController::ValidateBlackboardKeys(const UBlackboardData* InBlackboardA
 {
 	if (!IsValid(InBlackboardAsset)) return false;
 
-	// Targeting
-	const bool bTargetActorKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Targeting::TargetActor);
-	const bool bTargetPriorityKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Targeting::TargetPriority);
-
-	// StateType
-	const bool bAIIntentStateKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::State::AIIntentState);
-
-	// Perception
-	const bool bHasLOSKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Perception::bHasLOS);
-	const bool bLastSeenTimeKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Perception::LastSeenTime);
-	const bool bLastKnownLocationKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Perception::LastKnownLocation);
-
-	// Metric
-	const bool bDistanceToTargetKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Metric::DistanceToTarget);
-	const bool bDistanceToHomeKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Metric::DistanceToHome);
-
-	// Navigation
-	const bool bHomeLocationKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Navigation::HomeLocation);
-	const bool bReturnHomeKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Navigation::bReturnHome);
-
-	// Patrol
-	const bool bUsePatrolKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Patrol::bUsePatrol);
-	const bool bPatrolPathKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Patrol::PatrolPath);
-	const bool bPatrolModeKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Patrol::PatrolMode);
-
-	const bool bPatrolReverseKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Patrol::bPatrolReverse);
-	const bool bPatrolLocationKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Patrol::PatrolLocation);
-	const bool bPatrolIndexKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Patrol::PatrolIndex);
-
-	// Investigate
-	const bool bUseInvestigateKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Investigate::bUseInvestigate);
-	const bool bInvestigateDurationKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Investigate::InvestigateDuration);
-	const bool bInvestigateMaxIndexKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Investigate::InvestigateMaxIndex);
-
-	const bool bCanInvestigateKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Investigate::bCanInvestigate);
-	const bool bIsInvestigatingKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Investigate::bIsInvestigating);
-	const bool bInvestigateLocationKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Investigate::InvestigateLocation);
-	const bool bInvestigateIndexKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Investigate::InvestigateIndex);
-
-	// Chase
-	const bool bChaseOffsetDintanceKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Chase::ChaseOffsetRange);
-	const bool bChaseEnterBufferKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Chase::ChaseEnterBuffer);
-	const bool bChaseExitBufferKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Chase::ChaseExitBuffer);
-
-	// Alert
-	const bool bUseAlertStepKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Alert::bUseAlertStep);
-	const bool bStepForwardDistanceKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Alert::StepForwardDistance);
-	const bool bStepSideDistanceKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Alert::StepSideDistance);
-
-	const bool bInAlertRangeKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Alert::bInAlertRange);
-	const bool bAlertStepLocationKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Alert::AlertStepLocation);
-
-	// Engage
-	const bool bShouldEngageKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Engage::bShouldEngage);
-	const bool bCanCombatActionKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Engage::bCanCombatAction);
-
-	const bool bIsCombatActionKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Engage::bIsCombatAction);
-	const bool bInEngageRangeKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Engage::bInEngageRange);
-	const bool bNextCombatActionTimeKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Engage::NextCombatActionTime);
-
-	// Reaction
-	const bool bIsActiveReactionKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Reaction::bIsActiveReaction);
-
-	// Dead
-	const bool bDeadStateKey = ValidateBlackboardKey(InBlackboardAsset, CAIKey::Dead::DeadState);
-
 	bool bAllValid = true;
 
-	// Targeting
-	bAllValid &= bTargetActorKey;
-	bAllValid &= bTargetPriorityKey;
+	for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
+	{
+		if (!keySpec.bRequired) continue;
 
-	// StateType
-	bAllValid &= bAIIntentStateKey;
+		const bool bValidKey = ValidateBlackboardKey(InBlackboardAsset, keySpec.KeyName);
+		if (bValidKey) continue;
 
-	// Perception
-	bAllValid &= bHasLOSKey;
-	bAllValid &= bLastSeenTimeKey;
-	bAllValid &= bLastKnownLocationKey;
+		bAllValid = false;
 
-	// Metric
-	bAllValid &= bDistanceToTargetKey;
-	bAllValid &= bDistanceToHomeKey;
-
-	// Navigation
-	bAllValid &= bHomeLocationKey;
-	bAllValid &= bReturnHomeKey;
-
-	// Patrol
-	bAllValid &= bUsePatrolKey;
-	bAllValid &= bPatrolPathKey;
-	bAllValid &= bPatrolModeKey;
-
-	bAllValid &= bPatrolReverseKey;
-	bAllValid &= bPatrolLocationKey;
-	bAllValid &= bPatrolIndexKey;
-
-	// Investigate
-	bAllValid &= bUseInvestigateKey;
-	bAllValid &= bInvestigateDurationKey;
-	bAllValid &= bInvestigateMaxIndexKey;
-
-	bAllValid &= bCanInvestigateKey;
-	bAllValid &= bIsInvestigatingKey;
-	bAllValid &= bInvestigateLocationKey;
-	bAllValid &= bInvestigateIndexKey;
-
-	// Chase
-	bAllValid &= bChaseOffsetDintanceKey;
-	bAllValid &= bChaseEnterBufferKey;
-	bAllValid &= bChaseExitBufferKey;
-
-	bAllValid &= bInAlertRangeKey;
-
-	// Alert
-	bAllValid &= bUseAlertStepKey;
-	bAllValid &= bStepForwardDistanceKey;
-	bAllValid &= bStepSideDistanceKey;
-
-	bAllValid &= bAlertStepLocationKey;
-
-	// Engage
-	bAllValid &= bShouldEngageKey;
-	bAllValid &= bCanCombatActionKey;
-
-	bAllValid &= bIsCombatActionKey;
-	bAllValid &= bInEngageRangeKey;
-	bAllValid &= bNextCombatActionTimeKey;
-
-	// Reaction
-	bAllValid &= bIsActiveReactionKey;
-
-	// Dead
-	bAllValid &= bDeadStateKey;
+		FLog::Log(FString::Printf(
+			TEXT("[Error|ACAIController] Missing Blackboard key | Key=%s | ExpectedType=%s"),
+			*keySpec.KeyName.ToString(),
+			CAIKeyRegistry::GetValueTypeName(keySpec.ValueType)));
+	}
 
 	if (!bAllValid)
 	{
-		FLog::Log(FString::Printf(TEXT("%-20s"), TEXT("[Error|ACAIController] Missing Blackboard keys.")));
+		FLog::Log(TEXT("[Error|ACAIController] Missing required Blackboard keys."));
 		return false;
 	}
 

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -17,6 +17,7 @@
 #include "Type/CAIStructure.h"
 #include "AI/BlackBoard/CAIKey.h"
 #include "AI/BlackBoard/CAIKeyRegistry.h"
+#include "AI/Blackboard/CAIBlackboardValueHelper.h"
 
 ACAIController::ACAIController()
 {
@@ -106,7 +107,7 @@ bool ACAIController::InitializeControllerRuntime(APawn* InPawn)
 
 	if (!BindPerceptionEvents()) return false;
 	if (!SetupBlackboardComponent()) return false;
-	if (!InitializeBlackboardRuntimeValues()) return false;
+	if (!InitializeBlackboardValues()) return false;
 	if (!StartBehaviorTreeRuntime()) return false;
 
 	return true;
@@ -115,7 +116,7 @@ bool ACAIController::InitializeControllerRuntime(APawn* InPawn)
 void ACAIController::UninitializeControllerRuntime()
 {
 	StopBehaviorTreeRuntime();
-	ClearBlackboardRuntimeValues();
+	ClearBlackboardValues();
 	UnbindPerceptionEvents();
 
 	ClearTargetDataMap();
@@ -178,7 +179,7 @@ bool ACAIController::SetupBlackboardComponent()
 
 // Blackboard Runtime Value
 
-bool ACAIController::InitializeBlackboardRuntimeValues()
+bool ACAIController::InitializeBlackboardValues()
 {
 	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return false;
@@ -186,80 +187,13 @@ bool ACAIController::InitializeBlackboardRuntimeValues()
 
 	TSet<FName> pendingCustomKeys;
 
-	ApplyInitialBlackboardValues(blackboardComp, ControlledPawn_Cached, pendingCustomKeys);
-	ApplyCustomBlackboardValues(blackboardComp, ControlledPawn_Cached, pendingCustomKeys);
+	CAIBlackboardValueHelper::InitializeValues(blackboardComp, ControlledPawn_Cached, pendingCustomKeys);
+	InitializeCustomBlackboardValues(blackboardComp, ControlledPawn_Cached, pendingCustomKeys);
 
-	return ValidateCustomBlackboardKeysApplied(pendingCustomKeys);
+	return CAIBlackboardValueHelper::ValidateCustomKeysApplied(pendingCustomKeys, ControlledPawn_Cached);
 }
 
-void ACAIController::ApplyInitialBlackboardValues(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, TSet<FName>& OutPendingKeys) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-
-	for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
-	{
-		switch (keySpec.InitialValuePolicy)
-		{
-		case EAIBlackboardInitialValuePolicy::Fixed:
-			ApplyFixedInitialBlackboardValue(InBlackboardComp, keySpec);
-			break;
-
-		case EAIBlackboardInitialValuePolicy::FromOwnerLocation:
-			ApplyOwnerLocationInitialBlackboardValue(InBlackboardComp, InOwnerPawn, keySpec);
-			break;
-
-		case EAIBlackboardInitialValuePolicy::Custom:
-			OutPendingKeys.Add(keySpec.KeyName);
-			break;
-
-		case EAIBlackboardInitialValuePolicy::None:
-		default:
-			break;
-		}
-	}
-}
-
-void ACAIController::ApplyFixedInitialBlackboardValue(UBlackboardComponent* InBlackboardComp, const FAIBlackboardKeySpec& InKeySpec) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-
-	switch (InKeySpec.ValueType)
-	{
-	case EAIBlackboardKeyValueType::Bool:
-		InBlackboardComp->SetValueAsBool(InKeySpec.KeyName, InKeySpec.BoolDefault);
-		break;
-
-	case EAIBlackboardKeyValueType::Int:
-		InBlackboardComp->SetValueAsInt(InKeySpec.KeyName, InKeySpec.IntDefault);
-		break;
-
-	case EAIBlackboardKeyValueType::Float:
-		InBlackboardComp->SetValueAsFloat(InKeySpec.KeyName, InKeySpec.FloatDefault);
-		break;
-
-	case EAIBlackboardKeyValueType::Vector:
-		InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InKeySpec.VectorDefault);
-		break;
-
-	case EAIBlackboardKeyValueType::Enum:
-		InBlackboardComp->SetValueAsEnum(InKeySpec.KeyName, InKeySpec.EnumDefault);
-		break;
-
-	case EAIBlackboardKeyValueType::Object:
-		InBlackboardComp->ClearValue(InKeySpec.KeyName);
-		break;
-	}
-}
-
-void ACAIController::ApplyOwnerLocationInitialBlackboardValue(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, const FAIBlackboardKeySpec& InKeySpec) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-	if (!IsValid(InOwnerPawn)) return;
-
-	InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InOwnerPawn->GetActorLocation());
-}
-
-void ACAIController::ApplyCustomBlackboardValues(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, TSet<FName>& InOutPendingKeys) const
+void ACAIController::InitializeCustomBlackboardValues(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, TSet<FName>& InOutPendingKeys) const
 {
 	if (!IsValid(InBlackboardComp)) return;
 	if (!IsValid(InOwnerPawn)) return;
@@ -268,114 +202,29 @@ void ACAIController::ApplyCustomBlackboardValues(UBlackboardComponent* InBlackbo
 	if (!IsValid(enemy)) return;
 
 	// Patrol custom values
-	SetCustomBlackboardBoolValue(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::bUsePatrol, enemy->GetbUsePatrol());
-	SetCustomBlackboardObjectValue(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolPath, enemy->GetPatrolPath());
-	SetCustomBlackboardEnumValue(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolMode, static_cast<uint8>(enemy->GetPatrolMode()));
+	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::bUsePatrol, enemy->GetbUsePatrol(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomObject(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolPath, enemy->GetPatrolPath(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomEnum(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolMode, static_cast<uint8>(enemy->GetPatrolMode()), ControlledPawn_Cached);
 
 	// Investigate custom values
-	SetCustomBlackboardBoolValue(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::bUseInvestigate, enemy->GetbUseInvestigate());
-	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateDuration, enemy->GetInvestigateDuration());
-	SetCustomBlackboardIntValue(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateMaxIndex, enemy->GetInvestigateMaxIndex());
+	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::bUseInvestigate, enemy->GetbUseInvestigate(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateDuration, enemy->GetInvestigateDuration(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomInt(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateMaxIndex, enemy->GetInvestigateMaxIndex(), ControlledPawn_Cached);
 
 	// Chase custom values
-	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseOffsetRange, enemy->GetChaseOffsetRange());
-	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseEnterBuffer, enemy->GetChaseEnterBuffer());
-	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseExitBuffer, enemy->GetChaseExitBuffer());
+	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseOffsetRange, enemy->GetChaseOffsetRange(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseEnterBuffer, enemy->GetChaseEnterBuffer(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseExitBuffer, enemy->GetChaseExitBuffer(), ControlledPawn_Cached);
 
 	// Alert custom values
-	SetCustomBlackboardBoolValue(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::bUseAlertStep, enemy->GetbUseAlertStep());
-	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepForwardDistance, enemy->GetStepForwardDistance());
-	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepSideDistance, enemy->GetStepSideDistance());
+	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::bUseAlertStep, enemy->GetbUseAlertStep(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepForwardDistance, enemy->GetStepForwardDistance(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepSideDistance, enemy->GetStepSideDistance(), ControlledPawn_Cached);
 }
 
-void ACAIController::SetCustomBlackboardBoolValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, bool InValue) const
+void ACAIController::ClearBlackboardValues()
 {
-	if (!IsValid(InBlackboardComp)) return;
-
-	InBlackboardComp->SetValueAsBool(InKeySpec.KeyName, InValue);
-	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
-}
-
-void ACAIController::SetCustomBlackboardIntValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, int32 InValue) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-
-	InBlackboardComp->SetValueAsInt(InKeySpec.KeyName, InValue);
-	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
-}
-
-void ACAIController::SetCustomBlackboardFloatValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, float InValue) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-
-	InBlackboardComp->SetValueAsFloat(InKeySpec.KeyName, InValue);
-	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
-}
-
-void ACAIController::SetCustomBlackboardVectorValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, const FVector& InValue) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-
-	InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InValue);
-	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
-}
-
-void ACAIController::SetCustomBlackboardEnumValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, uint8 InValue) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-
-	InBlackboardComp->SetValueAsEnum(InKeySpec.KeyName, InValue);
-	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
-}
-
-void ACAIController::SetCustomBlackboardObjectValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, UObject* InValue) const
-{
-	if (!IsValid(InBlackboardComp)) return;
-
-	InBlackboardComp->SetValueAsObject(InKeySpec.KeyName, InValue);
-	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
-}
-
-void ACAIController::MarkCustomBlackboardKeyApplied(TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec) const
-{
-	ensureMsgf(
-		InOutPendingKeys.Remove(InKeySpec.KeyName) > 0,
-		TEXT("[AIController] Custom Blackboard key was not registered | Owner=%s | Key=%s"),
-		*GetNameSafe(ControlledPawn_Cached),
-		*InKeySpec.KeyName.ToString());
-}
-
-bool ACAIController::ValidateCustomBlackboardKeysApplied(const TSet<FName>& InPendingKeys) const
-{
-	if (InPendingKeys.IsEmpty()) return true;
-
-	TArray<FString> pendingKeyNames;
-	for (const FName& keyName : InPendingKeys)
-	{
-		pendingKeyNames.Add(keyName.ToString());
-	}
-
-	const FString pendingCustomKeys = FString::Join(pendingKeyNames, TEXT(", "));
-
-	ensureMsgf(false,
-		TEXT("[AIController] Missing custom Blackboard initial values | Owner=%s | Pending=%s"),
-		*GetNameSafe(ControlledPawn_Cached),
-		*pendingCustomKeys);
-
-	return false;
-}
-
-void ACAIController::ClearBlackboardRuntimeValues()
-{
-	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
-	if (!IsValid(blackboardComp)) return;
-
-	for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
-	{
-		if (!keySpec.bClearOnRuntimeTeardown) continue;
-
-		blackboardComp->ClearValue(keySpec.KeyName);
-	}
+	CAIBlackboardValueHelper::ClearValues(GetBlackboardComponent());
 }
 
 // Behavior Tree Runtime

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -16,6 +16,7 @@
 #include "Type/CStateStructure.h"
 #include "Type/CAIStructure.h"
 #include "AI/BlackBoard/CAIKey.h"
+#include "AI/BlackBoard/CAIKeyRegistry.h"
 
 ACAIController::ACAIController()
 {

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -370,67 +370,12 @@ void ACAIController::ClearBlackboardRuntimeValues()
 	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return;
 
-	// Targeting
-	blackboardComp->ClearValue(CAIKey::Targeting::TargetActor.KeyName);
-	blackboardComp->ClearValue(CAIKey::Targeting::TargetPriority.KeyName);
+	for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
+	{
+		if (!keySpec.bClearOnRuntimeTeardown) continue;
 
-	// State
-	blackboardComp->ClearValue(CAIKey::State::AIIntentState.KeyName);
-
-	// Perception
-	blackboardComp->ClearValue(CAIKey::Perception::bHasLOS.KeyName);
-	blackboardComp->ClearValue(CAIKey::Perception::LastSeenTime.KeyName);
-	blackboardComp->ClearValue(CAIKey::Perception::LastKnownLocation.KeyName);
-
-	// Metric
-	blackboardComp->ClearValue(CAIKey::Metric::DistanceToTarget.KeyName);
-	blackboardComp->ClearValue(CAIKey::Metric::DistanceToHome.KeyName);
-
-	// Navigation
-	blackboardComp->ClearValue(CAIKey::Navigation::HomeLocation.KeyName);
-	blackboardComp->ClearValue(CAIKey::Navigation::bReturnHome.KeyName);
-
-	// Patrol
-	blackboardComp->ClearValue(CAIKey::Patrol::bUsePatrol.KeyName);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolPath.KeyName);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolMode.KeyName);
-	blackboardComp->ClearValue(CAIKey::Patrol::bPatrolReverse.KeyName);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolLocation.KeyName);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolIndex.KeyName);
-
-	// Investigate
-	blackboardComp->ClearValue(CAIKey::Investigate::bUseInvestigate.KeyName);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateDuration.KeyName);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateMaxIndex.KeyName);
-	blackboardComp->ClearValue(CAIKey::Investigate::bCanInvestigate.KeyName);
-	blackboardComp->ClearValue(CAIKey::Investigate::bIsInvestigating.KeyName);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateLocation.KeyName);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateIndex.KeyName);
-
-	// Chase
-	blackboardComp->ClearValue(CAIKey::Chase::ChaseOffsetRange.KeyName);
-	blackboardComp->ClearValue(CAIKey::Chase::ChaseEnterBuffer.KeyName);
-	blackboardComp->ClearValue(CAIKey::Chase::ChaseExitBuffer.KeyName);
-
-	// Alert
-	blackboardComp->ClearValue(CAIKey::Alert::bUseAlertStep.KeyName);
-	blackboardComp->ClearValue(CAIKey::Alert::StepForwardDistance.KeyName);
-	blackboardComp->ClearValue(CAIKey::Alert::StepSideDistance.KeyName);
-	blackboardComp->ClearValue(CAIKey::Alert::bInAlertRange.KeyName);
-	blackboardComp->ClearValue(CAIKey::Alert::AlertStepLocation.KeyName);
-
-	// Engage
-	blackboardComp->ClearValue(CAIKey::Engage::bShouldEngage.KeyName);
-	blackboardComp->ClearValue(CAIKey::Engage::bCanCombatAction.KeyName);
-	blackboardComp->ClearValue(CAIKey::Engage::bIsCombatAction.KeyName);
-	blackboardComp->ClearValue(CAIKey::Engage::bInEngageRange.KeyName);
-	blackboardComp->ClearValue(CAIKey::Engage::NextCombatActionTime.KeyName);
-
-	// Reaction
-	blackboardComp->ClearValue(CAIKey::Reaction::bIsActiveReaction.KeyName);
-
-	// Dead
-	blackboardComp->ClearValue(CAIKey::Dead::DeadState.KeyName);
+		blackboardComp->ClearValue(keySpec.KeyName);
+	}
 }
 
 // Behavior Tree Runtime

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -15,8 +15,8 @@
 
 #include "Type/CStateStructure.h"
 #include "Type/CAIStructure.h"
-#include "AI/BlackBoard/CAIKey.h"
-#include "AI/BlackBoard/CAIKeyRegistry.h"
+#include "AI/Blackboard/CAIKey.h"
+#include "AI/Blackboard/CAIKeyRegistry.h"
 #include "AI/Blackboard/CAIBlackboardValueHelper.h"
 
 ACAIController::ACAIController()

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -167,7 +167,7 @@ void ACAIController::UnbindPerceptionEvents()
 bool ACAIController::SetupBlackboardComponent()
 {
 	if (!BlackboardAsset) return false;
-	if (!ValidateBlackboardKeys(BlackboardAsset)) return false;
+	if (!CAIKeyRegistry::ValidateRequiredKeys(BlackboardAsset)) return false;
 
 	// blackboardComp: Out Parameter
 	UBlackboardComponent* blackboardComp = nullptr;
@@ -184,21 +184,21 @@ bool ACAIController::SetInitialBlackboardRuntimeValues()
 	if (!IsValid(blackboardComp)) return false;
 
 	// Targeting 
-	blackboardComp->ClearValue(CAIKey::Targeting::TargetActor);
-	blackboardComp->SetValueAsInt(CAIKey::Targeting::TargetPriority, INT_MAX);
+	blackboardComp->ClearValue(CAIKey::Targeting::TargetActor.KeyName);
+	blackboardComp->SetValueAsInt(CAIKey::Targeting::TargetPriority.KeyName, INT_MAX);
 
 	// State
-	blackboardComp->SetValueAsEnum(CAIKey::State::AIIntentState, static_cast<uint8>(EAIIntentState::Idle));
+	blackboardComp->SetValueAsEnum(CAIKey::State::AIIntentState.KeyName, static_cast<uint8>(EAIIntentState::Idle));
 
 	// Perception
-	blackboardComp->SetValueAsBool(CAIKey::Perception::bHasLOS, false);
+	blackboardComp->SetValueAsBool(CAIKey::Perception::bHasLOS.KeyName, false);
 
 	// Navigation
-	blackboardComp->SetValueAsBool(CAIKey::Navigation::bReturnHome, false);
+	blackboardComp->SetValueAsBool(CAIKey::Navigation::bReturnHome.KeyName, false);
 
 	if (APawn* ownerPawn = GetPawn())
 	{
-		blackboardComp->SetValueAsVector(CAIKey::Navigation::HomeLocation, ownerPawn->GetActorLocation());
+		blackboardComp->SetValueAsVector(CAIKey::Navigation::HomeLocation.KeyName, ownerPawn->GetActorLocation());
 
 		if (ACEnemy* enemy = Cast<ACEnemy>(ownerPawn))
 		{
@@ -208,14 +208,14 @@ bool ACAIController::SetInitialBlackboardRuntimeValues()
 			EPatrolMode patrolMode = enemy->GetPatrolMode();
 
 			// Set
-			blackboardComp->SetValueAsBool(CAIKey::Patrol::bUsePatrol, bUsePatrol);
-			blackboardComp->SetValueAsObject(CAIKey::Patrol::PatrolPath, patrolPath ? patrolPath : nullptr);
-			blackboardComp->SetValueAsEnum(CAIKey::Patrol::PatrolMode, static_cast<uint8>(patrolMode));
+			blackboardComp->SetValueAsBool(CAIKey::Patrol::bUsePatrol.KeyName, bUsePatrol);
+			blackboardComp->SetValueAsObject(CAIKey::Patrol::PatrolPath.KeyName, patrolPath ? patrolPath : nullptr);
+			blackboardComp->SetValueAsEnum(CAIKey::Patrol::PatrolMode.KeyName, static_cast<uint8>(patrolMode));
 
 			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Patrol::bPatrolReverse, false);
-			blackboardComp->SetValueAsVector(CAIKey::Patrol::PatrolLocation, ownerPawn->GetActorLocation());
-			blackboardComp->SetValueAsInt(CAIKey::Patrol::PatrolIndex, -1);
+			blackboardComp->SetValueAsBool(CAIKey::Patrol::bPatrolReverse.KeyName, false);
+			blackboardComp->SetValueAsVector(CAIKey::Patrol::PatrolLocation.KeyName, ownerPawn->GetActorLocation());
+			blackboardComp->SetValueAsInt(CAIKey::Patrol::PatrolIndex.KeyName, -1);
 
 			// --- Investigate ---
 			bool bUseInvestigate = enemy->GetbUseInvestigate();
@@ -223,15 +223,15 @@ bool ACAIController::SetInitialBlackboardRuntimeValues()
 			int  investigateMaxIndex = enemy->GetInvestigateMaxIndex();
 
 			// Set
-			blackboardComp->SetValueAsBool(CAIKey::Investigate::bUseInvestigate, bUseInvestigate);
-			blackboardComp->SetValueAsFloat(CAIKey::Investigate::InvestigateDuration, investigateDuration);
-			blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateMaxIndex, investigateMaxIndex);
+			blackboardComp->SetValueAsBool(CAIKey::Investigate::bUseInvestigate.KeyName, bUseInvestigate);
+			blackboardComp->SetValueAsFloat(CAIKey::Investigate::InvestigateDuration.KeyName, investigateDuration);
+			blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateMaxIndex.KeyName, investigateMaxIndex);
 
 			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate, false);
-			blackboardComp->SetValueAsBool(CAIKey::Investigate::bIsInvestigating, false);
-			blackboardComp->SetValueAsVector(CAIKey::Investigate::InvestigateLocation, ownerPawn->GetActorLocation());
-			blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex, INDEX_NONE);
+			blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate.KeyName, false);
+			blackboardComp->SetValueAsBool(CAIKey::Investigate::bIsInvestigating.KeyName, false);
+			blackboardComp->SetValueAsVector(CAIKey::Investigate::InvestigateLocation.KeyName, ownerPawn->GetActorLocation());
+			blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName, INDEX_NONE);
 
 			// --- Chase ---
 			float chaseoffsetRange = enemy->GetChaseOffsetRange();
@@ -239,9 +239,9 @@ bool ACAIController::SetInitialBlackboardRuntimeValues()
 			float chaseExitBuffer = enemy->GetChaseExitBuffer();
 
 			// Set
-			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseOffsetRange, chaseoffsetRange);
-			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseEnterBuffer, chaseEnterBuffer);
-			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseExitBuffer, chaseExitBuffer);
+			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseOffsetRange.KeyName, chaseoffsetRange);
+			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseEnterBuffer.KeyName, chaseEnterBuffer);
+			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseExitBuffer.KeyName, chaseExitBuffer);
 
 			// --- Alert ---
 			bool bUseAlertStep = enemy->GetbUseAlertStep();
@@ -249,30 +249,30 @@ bool ACAIController::SetInitialBlackboardRuntimeValues()
 			float stepSideDistance = enemy->GetStepSideDistance();
 
 			// Set
-			blackboardComp->SetValueAsBool(CAIKey::Alert::bUseAlertStep, bUseAlertStep);
-			blackboardComp->SetValueAsFloat(CAIKey::Alert::StepForwardDistance, stepForwardDistance);
-			blackboardComp->SetValueAsFloat(CAIKey::Alert::StepSideDistance, stepSideDistance);
+			blackboardComp->SetValueAsBool(CAIKey::Alert::bUseAlertStep.KeyName, bUseAlertStep);
+			blackboardComp->SetValueAsFloat(CAIKey::Alert::StepForwardDistance.KeyName, stepForwardDistance);
+			blackboardComp->SetValueAsFloat(CAIKey::Alert::StepSideDistance.KeyName, stepSideDistance);
 
 			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Alert::bInAlertRange, false);
-			blackboardComp->SetValueAsVector(CAIKey::Alert::AlertStepLocation, ownerPawn->GetActorLocation());
+			blackboardComp->SetValueAsBool(CAIKey::Alert::bInAlertRange.KeyName, false);
+			blackboardComp->SetValueAsVector(CAIKey::Alert::AlertStepLocation.KeyName, ownerPawn->GetActorLocation());
 
 			// --- Engage ---
 			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bShouldEngage, false);
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bCanCombatAction, false);
+			blackboardComp->SetValueAsBool(CAIKey::Engage::bShouldEngage.KeyName, false);
+			blackboardComp->SetValueAsBool(CAIKey::Engage::bCanCombatAction.KeyName, false);
 
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bIsCombatAction, false);
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bInEngageRange, false);
-			blackboardComp->SetValueAsFloat(CAIKey::Engage::NextCombatActionTime, -1.f);
+			blackboardComp->SetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName, false);
+			blackboardComp->SetValueAsBool(CAIKey::Engage::bInEngageRange.KeyName, false);
+			blackboardComp->SetValueAsFloat(CAIKey::Engage::NextCombatActionTime.KeyName, -1.f);
 
 			// --- Reaction ---
 			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Reaction::bIsActiveReaction, false);
+			blackboardComp->SetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName, false);
 
 			// --- Dead ---
 			// Init
-			blackboardComp->SetValueAsEnum(CAIKey::Dead::DeadState, static_cast<uint8>(EDeadState::Alive));
+			blackboardComp->SetValueAsEnum(CAIKey::Dead::DeadState.KeyName, static_cast<uint8>(EDeadState::Alive));
 		}
 	}
 
@@ -285,66 +285,66 @@ void ACAIController::ClearBlackboardRuntimeValues()
 	if (!IsValid(blackboardComp)) return;
 
 	// Targeting
-	blackboardComp->ClearValue(CAIKey::Targeting::TargetActor);
-	blackboardComp->ClearValue(CAIKey::Targeting::TargetPriority);
+	blackboardComp->ClearValue(CAIKey::Targeting::TargetActor.KeyName);
+	blackboardComp->ClearValue(CAIKey::Targeting::TargetPriority.KeyName);
 
 	// State
-	blackboardComp->ClearValue(CAIKey::State::AIIntentState);
+	blackboardComp->ClearValue(CAIKey::State::AIIntentState.KeyName);
 
 	// Perception
-	blackboardComp->ClearValue(CAIKey::Perception::bHasLOS);
-	blackboardComp->ClearValue(CAIKey::Perception::LastSeenTime);
-	blackboardComp->ClearValue(CAIKey::Perception::LastKnownLocation);
+	blackboardComp->ClearValue(CAIKey::Perception::bHasLOS.KeyName);
+	blackboardComp->ClearValue(CAIKey::Perception::LastSeenTime.KeyName);
+	blackboardComp->ClearValue(CAIKey::Perception::LastKnownLocation.KeyName);
 
 	// Metric
-	blackboardComp->ClearValue(CAIKey::Metric::DistanceToTarget);
-	blackboardComp->ClearValue(CAIKey::Metric::DistanceToHome);
+	blackboardComp->ClearValue(CAIKey::Metric::DistanceToTarget.KeyName);
+	blackboardComp->ClearValue(CAIKey::Metric::DistanceToHome.KeyName);
 
 	// Navigation
-	blackboardComp->ClearValue(CAIKey::Navigation::HomeLocation);
-	blackboardComp->ClearValue(CAIKey::Navigation::bReturnHome);
+	blackboardComp->ClearValue(CAIKey::Navigation::HomeLocation.KeyName);
+	blackboardComp->ClearValue(CAIKey::Navigation::bReturnHome.KeyName);
 
 	// Patrol
-	blackboardComp->ClearValue(CAIKey::Patrol::bUsePatrol);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolPath);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolMode);
-	blackboardComp->ClearValue(CAIKey::Patrol::bPatrolReverse);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolLocation);
-	blackboardComp->ClearValue(CAIKey::Patrol::PatrolIndex);
+	blackboardComp->ClearValue(CAIKey::Patrol::bUsePatrol.KeyName);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolPath.KeyName);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolMode.KeyName);
+	blackboardComp->ClearValue(CAIKey::Patrol::bPatrolReverse.KeyName);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolLocation.KeyName);
+	blackboardComp->ClearValue(CAIKey::Patrol::PatrolIndex.KeyName);
 
 	// Investigate
-	blackboardComp->ClearValue(CAIKey::Investigate::bUseInvestigate);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateDuration);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateMaxIndex);
-	blackboardComp->ClearValue(CAIKey::Investigate::bCanInvestigate);
-	blackboardComp->ClearValue(CAIKey::Investigate::bIsInvestigating);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateLocation);
-	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateIndex);
+	blackboardComp->ClearValue(CAIKey::Investigate::bUseInvestigate.KeyName);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateDuration.KeyName);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateMaxIndex.KeyName);
+	blackboardComp->ClearValue(CAIKey::Investigate::bCanInvestigate.KeyName);
+	blackboardComp->ClearValue(CAIKey::Investigate::bIsInvestigating.KeyName);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateLocation.KeyName);
+	blackboardComp->ClearValue(CAIKey::Investigate::InvestigateIndex.KeyName);
 
 	// Chase
-	blackboardComp->ClearValue(CAIKey::Chase::ChaseOffsetRange);
-	blackboardComp->ClearValue(CAIKey::Chase::ChaseEnterBuffer);
-	blackboardComp->ClearValue(CAIKey::Chase::ChaseExitBuffer);
+	blackboardComp->ClearValue(CAIKey::Chase::ChaseOffsetRange.KeyName);
+	blackboardComp->ClearValue(CAIKey::Chase::ChaseEnterBuffer.KeyName);
+	blackboardComp->ClearValue(CAIKey::Chase::ChaseExitBuffer.KeyName);
 
 	// Alert
-	blackboardComp->ClearValue(CAIKey::Alert::bUseAlertStep);
-	blackboardComp->ClearValue(CAIKey::Alert::StepForwardDistance);
-	blackboardComp->ClearValue(CAIKey::Alert::StepSideDistance);
-	blackboardComp->ClearValue(CAIKey::Alert::bInAlertRange);
-	blackboardComp->ClearValue(CAIKey::Alert::AlertStepLocation);
+	blackboardComp->ClearValue(CAIKey::Alert::bUseAlertStep.KeyName);
+	blackboardComp->ClearValue(CAIKey::Alert::StepForwardDistance.KeyName);
+	blackboardComp->ClearValue(CAIKey::Alert::StepSideDistance.KeyName);
+	blackboardComp->ClearValue(CAIKey::Alert::bInAlertRange.KeyName);
+	blackboardComp->ClearValue(CAIKey::Alert::AlertStepLocation.KeyName);
 
 	// Engage
-	blackboardComp->ClearValue(CAIKey::Engage::bShouldEngage);
-	blackboardComp->ClearValue(CAIKey::Engage::bCanCombatAction);
-	blackboardComp->ClearValue(CAIKey::Engage::bIsCombatAction);
-	blackboardComp->ClearValue(CAIKey::Engage::bInEngageRange);
-	blackboardComp->ClearValue(CAIKey::Engage::NextCombatActionTime);
+	blackboardComp->ClearValue(CAIKey::Engage::bShouldEngage.KeyName);
+	blackboardComp->ClearValue(CAIKey::Engage::bCanCombatAction.KeyName);
+	blackboardComp->ClearValue(CAIKey::Engage::bIsCombatAction.KeyName);
+	blackboardComp->ClearValue(CAIKey::Engage::bInEngageRange.KeyName);
+	blackboardComp->ClearValue(CAIKey::Engage::NextCombatActionTime.KeyName);
 
 	// Reaction
-	blackboardComp->ClearValue(CAIKey::Reaction::bIsActiveReaction);
+	blackboardComp->ClearValue(CAIKey::Reaction::bIsActiveReaction.KeyName);
 
 	// Dead
-	blackboardComp->ClearValue(CAIKey::Dead::DeadState);
+	blackboardComp->ClearValue(CAIKey::Dead::DeadState.KeyName);
 }
 
 // Behavior Tree Runtime
@@ -402,50 +402,6 @@ EPerceptionBuildResult ACAIController::BuildPerceptionContext(FTargetData& OutTa
 {
 	UpdateTargetDataMap();
 	return SelectTopPriority(OutTargetData);
-}
-
-// Blackboard Validation
-
-bool ACAIController::ValidateBlackboardKeys(const UBlackboardData* InBlackboardAsset) const
-{
-	if (!IsValid(InBlackboardAsset)) return false;
-
-	bool bAllValid = true;
-
-	for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
-	{
-		if (!keySpec.bRequired) continue;
-
-		const bool bValidKey = ValidateBlackboardKey(InBlackboardAsset, keySpec.KeyName);
-		if (bValidKey) continue;
-
-		bAllValid = false;
-
-		FLog::Log(FString::Printf(
-			TEXT("[Error|ACAIController] Missing Blackboard key | Key=%s | ExpectedType=%s"),
-			*keySpec.KeyName.ToString(),
-			CAIKeyRegistry::GetValueTypeName(keySpec.ValueType)));
-	}
-
-	if (!bAllValid)
-	{
-		FLog::Log(TEXT("[Error|ACAIController] Missing required Blackboard keys."));
-		return false;
-	}
-
-	return true;
-}
-
-bool ACAIController::ValidateBlackboardKey(const UBlackboardData* InBlackboardAsset, const FName& InKeyName) const
-{
-	// -----------------------------------------------------------------------------
-	// [Blackboard Key Validate]
-	// [EngineAPI] GetKeyID (UBlackboardData / UBlackboardComponent)
-	// - true  : returns 'a valid FKey'
-	// - false : returns 'FBlackboard::InvalidKey'
-	// -----------------------------------------------------------------------------
-
-	return IsValid(InBlackboardAsset) && (InBlackboardAsset->GetKeyID(InKeyName) != FBlackboard::InvalidKey);
 }
 
 // Target Data

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -106,7 +106,7 @@ bool ACAIController::InitializeControllerRuntime(APawn* InPawn)
 
 	if (!BindPerceptionEvents()) return false;
 	if (!SetupBlackboardComponent()) return false;
-	if (!SetInitialBlackboardRuntimeValues()) return false;
+	if (!InitializeBlackboardRuntimeValues()) return false;
 	if (!StartBehaviorTreeRuntime()) return false;
 
 	return true;
@@ -178,105 +178,191 @@ bool ACAIController::SetupBlackboardComponent()
 
 // Blackboard Runtime Value
 
-bool ACAIController::SetInitialBlackboardRuntimeValues()
+bool ACAIController::InitializeBlackboardRuntimeValues()
 {
 	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return false;
+	if (!IsValid(ControlledPawn_Cached)) return false;
 
-	// Targeting 
-	blackboardComp->ClearValue(CAIKey::Targeting::TargetActor.KeyName);
-	blackboardComp->SetValueAsInt(CAIKey::Targeting::TargetPriority.KeyName, INT_MAX);
+	TSet<FName> pendingCustomKeys;
 
-	// State
-	blackboardComp->SetValueAsEnum(CAIKey::State::AIIntentState.KeyName, static_cast<uint8>(EAIIntentState::Idle));
+	ApplyInitialBlackboardValues(blackboardComp, ControlledPawn_Cached, pendingCustomKeys);
+	ApplyCustomBlackboardValues(blackboardComp, ControlledPawn_Cached, pendingCustomKeys);
 
-	// Perception
-	blackboardComp->SetValueAsBool(CAIKey::Perception::bHasLOS.KeyName, false);
+	return ValidateCustomBlackboardKeysApplied(pendingCustomKeys);
+}
 
-	// Navigation
-	blackboardComp->SetValueAsBool(CAIKey::Navigation::bReturnHome.KeyName, false);
+void ACAIController::ApplyInitialBlackboardValues(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, TSet<FName>& OutPendingKeys) const
+{
+	if (!IsValid(InBlackboardComp)) return;
 
-	if (APawn* ownerPawn = GetPawn())
+	for (const FAIBlackboardKeySpec& keySpec : CAIKeyRegistry::GetKeySpecs())
 	{
-		blackboardComp->SetValueAsVector(CAIKey::Navigation::HomeLocation.KeyName, ownerPawn->GetActorLocation());
-
-		if (ACEnemy* enemy = Cast<ACEnemy>(ownerPawn))
+		switch (keySpec.InitialValuePolicy)
 		{
-			// --- Patrol ---
-			bool bUsePatrol = enemy->GetbUsePatrol();
-			ACPatrolPath* patrolPath = enemy->GetPatrolPath();
-			EPatrolMode patrolMode = enemy->GetPatrolMode();
+		case EAIBlackboardInitialValuePolicy::Fixed:
+			ApplyFixedInitialBlackboardValue(InBlackboardComp, keySpec);
+			break;
 
-			// Set
-			blackboardComp->SetValueAsBool(CAIKey::Patrol::bUsePatrol.KeyName, bUsePatrol);
-			blackboardComp->SetValueAsObject(CAIKey::Patrol::PatrolPath.KeyName, patrolPath ? patrolPath : nullptr);
-			blackboardComp->SetValueAsEnum(CAIKey::Patrol::PatrolMode.KeyName, static_cast<uint8>(patrolMode));
+		case EAIBlackboardInitialValuePolicy::FromOwnerLocation:
+			ApplyOwnerLocationInitialBlackboardValue(InBlackboardComp, InOwnerPawn, keySpec);
+			break;
 
-			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Patrol::bPatrolReverse.KeyName, false);
-			blackboardComp->SetValueAsVector(CAIKey::Patrol::PatrolLocation.KeyName, ownerPawn->GetActorLocation());
-			blackboardComp->SetValueAsInt(CAIKey::Patrol::PatrolIndex.KeyName, -1);
+		case EAIBlackboardInitialValuePolicy::Custom:
+			OutPendingKeys.Add(keySpec.KeyName);
+			break;
 
-			// --- Investigate ---
-			bool bUseInvestigate = enemy->GetbUseInvestigate();
-			float investigateDuration = enemy->GetInvestigateDuration();
-			int  investigateMaxIndex = enemy->GetInvestigateMaxIndex();
-
-			// Set
-			blackboardComp->SetValueAsBool(CAIKey::Investigate::bUseInvestigate.KeyName, bUseInvestigate);
-			blackboardComp->SetValueAsFloat(CAIKey::Investigate::InvestigateDuration.KeyName, investigateDuration);
-			blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateMaxIndex.KeyName, investigateMaxIndex);
-
-			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Investigate::bCanInvestigate.KeyName, false);
-			blackboardComp->SetValueAsBool(CAIKey::Investigate::bIsInvestigating.KeyName, false);
-			blackboardComp->SetValueAsVector(CAIKey::Investigate::InvestigateLocation.KeyName, ownerPawn->GetActorLocation());
-			blackboardComp->SetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName, INDEX_NONE);
-
-			// --- Chase ---
-			float chaseoffsetRange = enemy->GetChaseOffsetRange();
-			float chaseEnterBuffer = enemy->GetChaseEnterBuffer();
-			float chaseExitBuffer = enemy->GetChaseExitBuffer();
-
-			// Set
-			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseOffsetRange.KeyName, chaseoffsetRange);
-			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseEnterBuffer.KeyName, chaseEnterBuffer);
-			blackboardComp->SetValueAsFloat(CAIKey::Chase::ChaseExitBuffer.KeyName, chaseExitBuffer);
-
-			// --- Alert ---
-			bool bUseAlertStep = enemy->GetbUseAlertStep();
-			float stepForwardDistance = enemy->GetStepForwardDistance();
-			float stepSideDistance = enemy->GetStepSideDistance();
-
-			// Set
-			blackboardComp->SetValueAsBool(CAIKey::Alert::bUseAlertStep.KeyName, bUseAlertStep);
-			blackboardComp->SetValueAsFloat(CAIKey::Alert::StepForwardDistance.KeyName, stepForwardDistance);
-			blackboardComp->SetValueAsFloat(CAIKey::Alert::StepSideDistance.KeyName, stepSideDistance);
-
-			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Alert::bInAlertRange.KeyName, false);
-			blackboardComp->SetValueAsVector(CAIKey::Alert::AlertStepLocation.KeyName, ownerPawn->GetActorLocation());
-
-			// --- Engage ---
-			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bShouldEngage.KeyName, false);
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bCanCombatAction.KeyName, false);
-
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName, false);
-			blackboardComp->SetValueAsBool(CAIKey::Engage::bInEngageRange.KeyName, false);
-			blackboardComp->SetValueAsFloat(CAIKey::Engage::NextCombatActionTime.KeyName, -1.f);
-
-			// --- Reaction ---
-			// Init
-			blackboardComp->SetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName, false);
-
-			// --- Dead ---
-			// Init
-			blackboardComp->SetValueAsEnum(CAIKey::Dead::DeadState.KeyName, static_cast<uint8>(EDeadState::Alive));
+		case EAIBlackboardInitialValuePolicy::None:
+		default:
+			break;
 		}
 	}
+}
 
-	return true;
+void ACAIController::ApplyFixedInitialBlackboardValue(UBlackboardComponent* InBlackboardComp, const FAIBlackboardKeySpec& InKeySpec) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+
+	switch (InKeySpec.ValueType)
+	{
+	case EAIBlackboardKeyValueType::Bool:
+		InBlackboardComp->SetValueAsBool(InKeySpec.KeyName, InKeySpec.BoolDefault);
+		break;
+
+	case EAIBlackboardKeyValueType::Int:
+		InBlackboardComp->SetValueAsInt(InKeySpec.KeyName, InKeySpec.IntDefault);
+		break;
+
+	case EAIBlackboardKeyValueType::Float:
+		InBlackboardComp->SetValueAsFloat(InKeySpec.KeyName, InKeySpec.FloatDefault);
+		break;
+
+	case EAIBlackboardKeyValueType::Vector:
+		InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InKeySpec.VectorDefault);
+		break;
+
+	case EAIBlackboardKeyValueType::Enum:
+		InBlackboardComp->SetValueAsEnum(InKeySpec.KeyName, InKeySpec.EnumDefault);
+		break;
+
+	case EAIBlackboardKeyValueType::Object:
+		InBlackboardComp->ClearValue(InKeySpec.KeyName);
+		break;
+	}
+}
+
+void ACAIController::ApplyOwnerLocationInitialBlackboardValue(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, const FAIBlackboardKeySpec& InKeySpec) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+	if (!IsValid(InOwnerPawn)) return;
+
+	InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InOwnerPawn->GetActorLocation());
+}
+
+void ACAIController::ApplyCustomBlackboardValues(UBlackboardComponent* InBlackboardComp, const APawn* InOwnerPawn, TSet<FName>& InOutPendingKeys) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+	if (!IsValid(InOwnerPawn)) return;
+
+	const ACEnemy* enemy = Cast<ACEnemy>(InOwnerPawn);
+	if (!IsValid(enemy)) return;
+
+	// Patrol custom values
+	SetCustomBlackboardBoolValue(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::bUsePatrol, enemy->GetbUsePatrol());
+	SetCustomBlackboardObjectValue(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolPath, enemy->GetPatrolPath());
+	SetCustomBlackboardEnumValue(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolMode, static_cast<uint8>(enemy->GetPatrolMode()));
+
+	// Investigate custom values
+	SetCustomBlackboardBoolValue(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::bUseInvestigate, enemy->GetbUseInvestigate());
+	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateDuration, enemy->GetInvestigateDuration());
+	SetCustomBlackboardIntValue(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateMaxIndex, enemy->GetInvestigateMaxIndex());
+
+	// Chase custom values
+	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseOffsetRange, enemy->GetChaseOffsetRange());
+	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseEnterBuffer, enemy->GetChaseEnterBuffer());
+	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseExitBuffer, enemy->GetChaseExitBuffer());
+
+	// Alert custom values
+	SetCustomBlackboardBoolValue(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::bUseAlertStep, enemy->GetbUseAlertStep());
+	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepForwardDistance, enemy->GetStepForwardDistance());
+	SetCustomBlackboardFloatValue(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepSideDistance, enemy->GetStepSideDistance());
+}
+
+void ACAIController::SetCustomBlackboardBoolValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, bool InValue) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+
+	InBlackboardComp->SetValueAsBool(InKeySpec.KeyName, InValue);
+	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
+}
+
+void ACAIController::SetCustomBlackboardIntValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, int32 InValue) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+
+	InBlackboardComp->SetValueAsInt(InKeySpec.KeyName, InValue);
+	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
+}
+
+void ACAIController::SetCustomBlackboardFloatValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, float InValue) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+
+	InBlackboardComp->SetValueAsFloat(InKeySpec.KeyName, InValue);
+	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
+}
+
+void ACAIController::SetCustomBlackboardVectorValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, const FVector& InValue) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+
+	InBlackboardComp->SetValueAsVector(InKeySpec.KeyName, InValue);
+	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
+}
+
+void ACAIController::SetCustomBlackboardEnumValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, uint8 InValue) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+
+	InBlackboardComp->SetValueAsEnum(InKeySpec.KeyName, InValue);
+	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
+}
+
+void ACAIController::SetCustomBlackboardObjectValue(UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, UObject* InValue) const
+{
+	if (!IsValid(InBlackboardComp)) return;
+
+	InBlackboardComp->SetValueAsObject(InKeySpec.KeyName, InValue);
+	MarkCustomBlackboardKeyApplied(InOutPendingKeys, InKeySpec);
+}
+
+void ACAIController::MarkCustomBlackboardKeyApplied(TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec) const
+{
+	ensureMsgf(
+		InOutPendingKeys.Remove(InKeySpec.KeyName) > 0,
+		TEXT("[AIController] Custom Blackboard key was not registered | Owner=%s | Key=%s"),
+		*GetNameSafe(ControlledPawn_Cached),
+		*InKeySpec.KeyName.ToString());
+}
+
+bool ACAIController::ValidateCustomBlackboardKeysApplied(const TSet<FName>& InPendingKeys) const
+{
+	if (InPendingKeys.IsEmpty()) return true;
+
+	TArray<FString> pendingKeyNames;
+	for (const FName& keyName : InPendingKeys)
+	{
+		pendingKeyNames.Add(keyName.ToString());
+	}
+
+	const FString pendingCustomKeys = FString::Join(pendingKeyNames, TEXT(", "));
+
+	ensureMsgf(false,
+		TEXT("[AIController] Missing custom Blackboard initial values | Owner=%s | Pending=%s"),
+		*GetNameSafe(ControlledPawn_Cached),
+		*pendingCustomKeys);
+
+	return false;
 }
 
 void ACAIController::ClearBlackboardRuntimeValues()

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -97,11 +97,6 @@ public:
 	EPerceptionBuildResult BuildPerceptionContext(FTargetData& OutTargetData);
 
 private:
-	// Blackboard Validation
-	bool ValidateBlackboardKeys(const UBlackboardData* InBlackboardAsset) const;
-	bool ValidateBlackboardKey(const UBlackboardData* InBlackboardAsset, const FName& InKeyName) const;
-
-private:
 	// Target Data
 	void UpdateTargetDataMap();
 	void ClearTargetDataMap();

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -73,24 +73,11 @@ private:
 	// Blackboard Setup
 	bool SetupBlackboardComponent();
 
-	// Blackboard Runtime Value
-	bool InitializeBlackboardRuntimeValues();
-	void ApplyInitialBlackboardValues(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, TSet<FName>& OutPendingKeys) const;
+	// Blackboard Value
+	bool InitializeBlackboardValues();
+	void InitializeCustomBlackboardValues(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, TSet<FName>& InOutPendingKeys) const;
 
-	void ApplyFixedInitialBlackboardValue(class UBlackboardComponent* InBlackboardComp, const struct FAIBlackboardKeySpec& InKeySpec) const;
-	void ApplyOwnerLocationInitialBlackboardValue(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, const struct FAIBlackboardKeySpec& InKeySpec) const;
-	void ApplyCustomBlackboardValues(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, TSet<FName>& InOutPendingKeys) const;
-	void SetCustomBlackboardBoolValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, bool InValue) const;
-	void SetCustomBlackboardIntValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, int32 InValue) const;
-	void SetCustomBlackboardFloatValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, float InValue) const;
-	void SetCustomBlackboardVectorValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, const FVector& InValue) const;
-	void SetCustomBlackboardEnumValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, uint8 InValue) const;
-	void SetCustomBlackboardObjectValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, class UObject* InValue) const;
-
-	void MarkCustomBlackboardKeyApplied(TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec) const;
-	bool ValidateCustomBlackboardKeysApplied(const TSet<FName>& InPendingKeys) const;
-
-	void ClearBlackboardRuntimeValues();
+	void ClearBlackboardValues();
 
 	// Behavior Tree Runtime
 	bool StartBehaviorTreeRuntime();

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -74,7 +74,22 @@ private:
 	bool SetupBlackboardComponent();
 
 	// Blackboard Runtime Value
-	bool SetInitialBlackboardRuntimeValues();
+	bool InitializeBlackboardRuntimeValues();
+	void ApplyInitialBlackboardValues(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, TSet<FName>& OutPendingKeys) const;
+
+	void ApplyFixedInitialBlackboardValue(class UBlackboardComponent* InBlackboardComp, const struct FAIBlackboardKeySpec& InKeySpec) const;
+	void ApplyOwnerLocationInitialBlackboardValue(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, const struct FAIBlackboardKeySpec& InKeySpec) const;
+	void ApplyCustomBlackboardValues(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, TSet<FName>& InOutPendingKeys) const;
+	void SetCustomBlackboardBoolValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, bool InValue) const;
+	void SetCustomBlackboardIntValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, int32 InValue) const;
+	void SetCustomBlackboardFloatValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, float InValue) const;
+	void SetCustomBlackboardVectorValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, const FVector& InValue) const;
+	void SetCustomBlackboardEnumValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, uint8 InValue) const;
+	void SetCustomBlackboardObjectValue(class UBlackboardComponent* InBlackboardComp, TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec, class UObject* InValue) const;
+
+	void MarkCustomBlackboardKeyApplied(TSet<FName>& InOutPendingKeys, const struct FAIBlackboardKeySpec& InKeySpec) const;
+	bool ValidateCustomBlackboardKeysApplied(const TSet<FName>& InPendingKeys) const;
+
 	void ClearBlackboardRuntimeValues();
 
 	// Behavior Tree Runtime


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P32: AI Blackboard Key Registry 정책 정리**

## 날짜

**2026.06.30**

## 상태

- [x] 작업 방향 수립
- [x] 코드 / 문서 반영
- [x] 검증 완료

---

## 브랜치

- `refactor/ai-blackboard-key-registry`

---

## 커밋

```text
docs(ai): plan blackboard key registry cleanup
refactor(ai): add blackboard key registry
refactor(ai): validate blackboard keys through registry
refactor(ai): define blackboard key specs
refactor(ai): organize blackboard key initialization policy
refactor(ai): apply blackboard clear policy from registry
refactor(ai): centralize blackboard key registry
style(ai): normalize blackboard include casing
```

---

## 요약

이번 PR은 AI blackboard key 정의 / 검증 / 초기화 / 정리 기준을 registry 중심으로 정리한다.

현재 `CAIKey`는 key category vocabulary 역할을 하지만, required key 검증과 runtime value 초기화 / 정리는 `ACAIController`에서 수동으로 길게 나열되어 있다. 이 구조는 key 추가 또는 삭제 시 누락 위험이 크고, BehaviorTree key 계약을 코드에서 설명하기 어렵다.

핵심 목표는 AI 행동 로직을 바꾸지 않고, blackboard key 계약을 한 곳에서 읽고 검증할 수 있게 만드는 것이다.

---

## 작업 배경

P31에서 `ACAIController` lifecycle cleanup을 정리하면서 blackboard setup / runtime value / behavior tree start 순서가 명확해졌다.

그 과정에서 다음 문제가 남아 있는 것이 확인됐다.

```text
CAIKey.h
-> key name만 정의
-> key type / required 여부는 별도 위치에 있음

ACAIController::ValidateBlackboardKeys
-> required key를 수동 나열

ACAIController::InitializeBlackboardValues
-> 초기 runtime 값을 수동 나열

ACAIController::ClearBlackboardValues
-> clear 대상을 수동 나열
```

즉 key를 하나 추가하면 최소 세 곳 이상을 같이 수정해야 한다.

---

## 사전 조회 결과

```text
핵심 key 정의:
Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
Source/Portfolio/AI/Blackboard/CAIKey.h
Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h

blackboard setup / validate / initialize / clear:
Source/Portfolio/Controller/CAIController.*

runtime key 사용처:
Source/Portfolio/AI/BehaviorTree/Service/*
Source/Portfolio/AI/BehaviorTree/Task/*
Source/Portfolio/AI/BehaviorTree/Decorator/*
Source/Portfolio/Component/CCombatSignalSourceComponent.cpp

blackboard key 직접 사용 파일:
23개
```

---

## 작업 범위

### 1. Blackboard key spec / registry 도입

목표:

```text
- key name
- expected blackboard value type
- required 여부
- initial value 적용 대상 여부
- clear 대상 여부
```

를 한 곳에서 확인할 수 있게 한다.

변경:

```text
Source/Portfolio/AI/Blackboard/CAIKey.h
-> FAIBlackboardKeySpec 기반 key 정의
-> CAIKeyFactory helper 기반 key spec 생성
-> RuntimeValue key는 possession 초기화에서 제외
-> CAIKey::Category::KeySpec.KeyName 사용

Source/Portfolio/AI/Blackboard/CAIKeyTypes.h
-> EAIBlackboardKeyValueType / EAIBlackboardInitialValuePolicy / FAIBlackboardKeySpec 정의

Source/Portfolio/AI/Blackboard/CAIKeyFactory.h
-> fixed / runtime / owner / custom key spec 생성 helper 분리

Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
-> 전체 key spec 등록
-> required key validation

Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
-> initial / custom / clear blackboard value 적용 helper
-> custom pending key mark / validate
```

`CAIKey`는 category namespace 사용감을 유지하고, `CAIKeyRegistry`는 전체 key 목록과 검증 흐름을 담당한다.

`CAIKey`를 자유 FName / DataAsset 기반 입력으로 풀지 않은 이유는 별도 결정 문서에 정리했다.

```text
Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
```

### 2. Required key validation 단일화

기존 `ValidateBlackboardKeys()`는 모든 required key를 수동 변수로 선언하고 다시 `bAllValid`에 합산했다.

변경 방향:

```text
CAIKeyRegistry::GetKeySpecs 순회
-> CAIKeyRegistry::ValidateRequiredKeys 호출
-> 누락 key 이름과 expected type ensure
```

### 3. Initial / Clear runtime value 기준 정리

초기값이 필요한 key와 단순 clear만 필요한 key를 구분한다.

```text
InitializeBlackboardValues
-> CAIBlackboardValueHelper::InitializeValues: registry 1회 순회
-> Fixed / FromOwnerLocation / Custom policy 분기
-> Custom key는 pending set에 등록
-> InitializeCustomBlackboardValues에서 처리된 custom key 제거
-> CAIBlackboardValueHelper::ValidateCustomKeysApplied로 누락 검증

ClearBlackboardValues
-> CAIBlackboardValueHelper::ClearValues 호출
-> CAIKeyRegistry::GetKeySpecs 순회
-> bClearOnRuntimeTeardown 대상만 ClearValue
```

### 4. BT Service / Task / Decorator 사용처 확인

BT 노드의 blackboard read / write 로직은 이번 PR에서 기능 변경하지 않는다.

확인 기준:

```text
- registry에 없는 key를 직접 사용하지 않는지
- key type과 GetValueAs / SetValueAs API가 일치하는지
- controller 초기화 / clear 대상에서 누락된 key가 없는지
- Blackboard API 호출부가 `CAIKey::Category::KeySpec.KeyName` 형태로 정리됐는지
```

---

## 제외 범위

```text
- BehaviorTree asset 재설계
- BT Service / Task / Decorator 행동 로직 변경
- AI update interval 조정
- perception / target selection 정책 변경
- engage assignment 알고리즘 변경
- Enhanced Input migration
```

---

## 검증 계획

```text
rg 기반 CAIKey / blackboard 사용처 전수 확인
registry required key와 ValidateRequiredKeys 경로 확인
CAIKey spec과 Blackboard API KeyName 전달 경로 확인
CAIKeyTypes / CAIKeyFactory / CAIKey / CAIKeyRegistry 책임 분리 확인
CAIBlackboardValueHelper initial / custom / clear helper 경로 확인
initial blackboard value policy / default value 순회 확인
blackboard clear 대상 bClearOnRuntimeTeardown 순회 확인
git diff --check
PortfolioEditor Win64 Development 빌드
PIE AI basic loop smoke test
```

현재 확인:

```text
git diff --check 통과
PortfolioEditor Win64 Development 빌드 통과
required key 누락 시 ensureMsgf 경로 적용
initial blackboard value fixed / owner는 registry 순회 적용
custom value source 적용은 controller에 유지
common blackboard value 적용 / pending 검증은 CAIBlackboardValueHelper로 분리
clear runtime value는 bClearOnRuntimeTeardown 기준 registry 순회 적용
PIE AI basic loop smoke test 통과
combat damage / guard / parry / stagger / enemy Blink cue delivery 정상 확인
player Blink cue reject는 player-side target resolve 부재로 인한 기존 기능 범위 밖 동작으로 분류
```

---

## 관련 문서

```text
Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
Docs/06_notes/N15_AI_Blackboard_Key_Registry_Policy_Note.md
Docs/06_notes/N16_AI_Blackboard_Key_Contract_Decision_Note.md
Docs/04_Pull_Request/P31_UE5_Portfolio_Pull_Request.md
Docs/06_notes/N13_Component_Lifecycle_Cleanup_Policy_Note.md
```

---
