### PR TITLE
P43: CVar Ownership Policy

### DIFF
--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -7,6 +7,7 @@
 | ID | 제목 | 파일 | 브랜치 | GitHub PR | 관련 문서 |
 | --- | --- | --- | --- | --- | --- |
 | P42 | Debug Log Policy v1 | `P42_UE5_Portfolio_Pull_Request.md` | `refactor/debug-log-policy-v1` |  | W05, N22, N23, N24, N25, N26 |
+| P43 | CVar Ownership Policy | `P43_UE5_Portfolio_Pull_Request.md` | `refactor/cvar-ownership-policy` |  | W05, N23, N26, N27 |
 | P01 | Character / Camera Core | `P01_UE5_Portfolio_Pull_Request.md` | `feature/character-camera-core` |  | D02 |
 | P02 | Character Movement Core | `P02_UE5_Portfolio_Pull_Request.md` | `feature/character-move-core` |  | D03, B01 |
 | P03 | Weapon Equip | `P03_UE5_Portfolio_Pull_Request.md` | `feature/character-weapon-equip` |  | D04, B02 |

--- a/Docs/04_Pull_Request/P42_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P42_UE5_Portfolio_Pull_Request.md
@@ -131,6 +131,7 @@ Docs/06_notes/N23_Debug_Log_And_Diagnostic_Code_Policy_Note.md
 Docs/06_notes/N24_Debug_Log_Cleanup_Inventory_Note.md
 Docs/06_notes/N25_Diagnostic_Log_Gating_And_Audit_Category_Plan_Note.md
 Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
+Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md
 
 Source/Portfolio/Core/Debug/*Debug.*
 Source/Portfolio/Core/Debug/FComponentReferenceHelper.h

--- a/Docs/04_Pull_Request/P42_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P42_UE5_Portfolio_Pull_Request.md
@@ -131,7 +131,6 @@ Docs/06_notes/N23_Debug_Log_And_Diagnostic_Code_Policy_Note.md
 Docs/06_notes/N24_Debug_Log_Cleanup_Inventory_Note.md
 Docs/06_notes/N25_Diagnostic_Log_Gating_And_Audit_Category_Plan_Note.md
 Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
-Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md
 
 Source/Portfolio/Core/Debug/*Debug.*
 Source/Portfolio/Core/Debug/FComponentReferenceHelper.h

--- a/Docs/04_Pull_Request/P43_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P43_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,224 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P43: CVar Ownership Policy**
+
+## 날짜
+
+**2026.07.22**
+
+## 상태
+
+- [x] Debug / Diagnostic CVar ownership 재점검
+- [x] Profiling audit / CSV counter CVar ownership 분리
+- [x] RuntimeLOD policy / tuning CVar 유지 기준 정리
+- [x] `CSV_CUSTOM_STAT_GLOBAL` 직접 호출을 `Core/Profiling` helper로 이동
+- [x] `CSV_SCOPED_TIMING_STAT_GLOBAL`은 측정 scope 본문 유지
+- [x] RuntimeLOD policy의 profiling audit gate 노출 제거
+- [x] CVar ownership 최종 기준 문서화
+- [x] `PortfolioEditor Win64 Development` build 통과
+
+## 브랜치
+
+- `refactor/cvar-ownership-policy`
+
+## 요약
+
+이번 PR은 P42 `Debug Log Policy v1` 이후 남아 있던 CVar ownership 경계를 정리한다.
+
+P42에서 debug log / diagnostic helper 분리는 완료했지만, 일부 profiling gate, CSV counter, RuntimeLOD policy CVar의 책임 경계가 아직 섞여 있었다. 이번 PR에서는 CVar를 다음 기준으로 재분류했다.
+
+```text
+Core/Debug
+-> 사람이 읽는 Output Log / diagnostic text / debug dump CVar 소유
+
+Core/Profiling
+-> profiling audit gate / CSV counter / profiling behavior gate 소유
+
+AI/RuntimeLOD 또는 owner system
+-> 실제 gameplay policy / tuning CVar 소유
+```
+
+이 기준에 따라 debug 출력 CVar, profiling audit CVar, RuntimeLOD policy/tuning CVar를 분리하고, CSV counter 직접 호출도 profiling helper 내부로 모았다.
+
+## 주요 변경
+
+```text
+1. AI audit / debug CVar gate 정리
+   - AI perception audit summary 출력 helper 분리
+   - AI combat BT / CanMove decorator audit gate 정리
+   - CombatEngage assignment audit output helper 분리
+
+2. Profiling behavior gate CVar 분리
+   - DisableEnemyPerception
+   - DisableEnemyHitProcessing
+   - DisableEnemyWeaponActor
+   - DisableEnemyCombatFeedback
+   - StatePolicyAudit
+   - AnimationRefreshAudit
+
+3. CSV counter ownership 정리
+   - animation refresh counter를 CAIAnimationProfiling으로 이동
+   - BT service / interval preset counter를 CAIBehaviorTreeProfiling으로 이동
+   - Core/Profiling 밖 CSV_CUSTOM_STAT_GLOBAL 직접 호출 제거
+
+4. RuntimeLOD policy 경계 정리
+   - StatePolicyMode는 policy source 선택만 담당
+   - StatePolicyAudit은 state tier CSV counter만 담당
+   - FAIAnimationRuntimeLODPolicy에서 profiling audit gate 노출 제거
+
+5. 문서화
+   - N26 ownership inventory 정정
+   - N27 CVar ownership final rule 추가
+```
+
+## 최종 CVar ownership 기준
+
+```text
+Debug / Diagnostic output CVar
+-> Core/Debug helper
+
+Debug Dump CVar
+-> Core/Debug helper
+
+Profiling audit / CSV counter CVar
+-> Core/Profiling helper
+
+Runtime policy / tuning CVar
+-> owning policy/system cpp
+```
+
+혼합 CVar는 금지한다.
+
+```text
+StatePolicyMode
+-> RuntimeLOD policy source만 선택
+
+StatePolicyAudit
+-> state tier CSV profiling counter만 제어
+```
+
+## CSV macro 기준
+
+```text
+CSV_CUSTOM_STAT_GLOBAL
+-> event / counter 기록
+-> 직접 호출은 Core/Profiling helper 구현부에만 둔다.
+
+CSV_SCOPED_TIMING_STAT_GLOBAL
+-> RAII scope timing 계측
+-> 측정 범위가 중요하므로 측정 대상 scope 본문에 둔다.
+```
+
+## 주요 CVar
+
+Core/Debug:
+
+```text
+Portfolio.Debug.*
+Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit
+Portfolio.AI.RuntimeLOD.BlackboardEngageLatencyAudit
+Portfolio.AI.RuntimeLOD.CanMoveDecoratorAudit
+Portfolio.AI.RuntimeLOD.EngageAssignmentAudit
+Portfolio.AI.RuntimeLOD.EngageAssignmentVerboseAudit
+```
+
+Core/Profiling:
+
+```text
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit
+Portfolio.AI.RuntimeLOD.StatePolicyAudit
+Portfolio.AI.RuntimeLOD.DisableEnemyPerception
+Portfolio.AI.RuntimeLOD.DisableEnemyHitProcessing
+Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor
+Portfolio.AI.RuntimeLOD.DisableEnemyCombatFeedback
+```
+
+Runtime policy / tuning owner 유지:
+
+```text
+Portfolio.AI.RuntimeLOD.StatePolicyMode
+Portfolio.AI.RuntimeLOD.EnemyMovementMode
+Portfolio.AI.RuntimeLOD.EnemyAnimationMode
+Portfolio.AI.RuntimeLOD.EnemyAnimationReducedRefreshInterval
+Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode
+Portfolio.AI.RuntimeLOD.EngageAssignmentWarmupTime
+Portfolio.AI.RuntimeLOD.EngageAssignmentEngageCap
+Portfolio.AI.RuntimeLOD.EngageAssignmentAlertCap
+```
+
+## 변경 파일 범위
+
+```text
+Docs/04_Pull_Request/00_Pull_Request_Index.md
+Docs/04_Pull_Request/P43_UE5_Portfolio_Pull_Request.md
+Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
+Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md
+
+Source/Portfolio/Core/Debug/*
+Source/Portfolio/Core/Profiling/*
+Source/Portfolio/AI/RuntimeLOD/*
+Source/Portfolio/AI/BehaviorTree/*
+Source/Portfolio/Character/*
+Source/Portfolio/System/Combat/*
+```
+
+## 검증
+
+### Build
+
+```text
+PortfolioEditor Win64 Development
+Result: Pass
+```
+
+### Static check
+
+```text
+Core/Debug 밖 직접 출력 호출
+Result: 0
+
+Core/Profiling 밖 CSV_CUSTOM_STAT_GLOBAL 직접 호출
+Result: 0
+
+Core/Profiling 밖 남은 CSV_ 호출
+Result: CSV_SCOPED_TIMING_STAT_GLOBAL only
+
+Core/Debug / Core/Profiling 밖 TAutoConsoleVariable
+Result: RuntimeLOD policy / tuning CVar만 유지
+```
+
+### Remaining Direct Scoped Timing
+
+```text
+CWorldSubsystem_CombatEngage
+-> PortfolioAI_CombatEngage_Tick
+-> PortfolioAI_CombatEngage_RebuildAssignments
+
+BT services
+-> PortfolioAI_BT_UpdateAIContext
+-> PortfolioAI_BT_UpdateAIIntentState
+-> PortfolioAI_BT_UpdateEngageContext
+-> PortfolioAI_BT_UpdateInvestigateContext
+```
+
+위 항목은 `CSV_SCOPED_TIMING_STAT_GLOBAL`이라 helper로 이동하지 않고 측정 scope 본문에 유지한다.
+
+## 후속 작업
+
+이번 PR에서 처리하지 않는 항목:
+
+```text
+EBTServiceIntervalPreset 위치
+-> 구조체 나누기 / 헤더 배치 규칙에서 처리
+
+combat profiling API suffix 통일
+-> 네이밍 / 매개변수 작명 규칙에서 처리
+
+Debug helper 섹션명 전체 통일
+-> TODO / 주석 및 섹션 정리에서 처리
+
+CEnemy RuntimeLOD CVar 이동
+-> 데이터 에셋 분리 또는 RuntimeLOD config 구조 정리에서 처리
+```

--- a/Docs/04_Pull_Request/P43_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P43_UE5_Portfolio_Pull_Request.md
@@ -60,6 +60,7 @@ AI/RuntimeLOD 또는 owner system
 
 3. CSV counter ownership 정리
    - animation refresh counter를 CAIAnimationProfiling으로 이동
+   - 현재 profiling plan의 animation refresh counter CVar를 AnimationRefreshAudit으로 통일
    - BT service / interval preset counter를 CAIBehaviorTreeProfiling으로 이동
    - Core/Profiling 밖 CSV_CUSTOM_STAT_GLOBAL 직접 호출 제거
 

--- a/Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
+++ b/Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
@@ -2,6 +2,13 @@
 
 ## 2026-07-21 CVar ownership update
 
+최신 ownership 기준:
+
+```text
+최종 CVar ownership 기준은 N27_Debug_Profiling_CVar_Ownership_Final_Note.md를 따른다.
+N26은 audit inventory와 이전 migration context를 유지한다.
+```
+
 Current ownership rule:
 
 ```text
@@ -35,10 +42,10 @@ Core/Profiling:
 - DisableEnemyWeaponActor
 - DisableEnemyCombatFeedback
 - AnimationRefreshAudit
+- StatePolicyAudit
 
 Policy owner:
 - StatePolicyMode controls policy source only.
-- StatePolicyAudit controls state tier CSV counters.
 - StatePolicyMode 0 means per-system RuntimeLOD CVar modes.
 - StatePolicyMode 1 means state-based RuntimeLOD tier snapshot.
 ```

--- a/Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
+++ b/Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
@@ -1,5 +1,66 @@
 # N26. Diagnostic Log Full Audit Inventory Note
 
+## 2026-07-21 CVar ownership update
+
+Current ownership rule:
+
+```text
+1. Debug / Diagnostic output CVar
+   -> Core/Debug helper owns the CVar, gate, message format, and non-shipping no-op.
+
+2. Profiling gate CVar that can change runtime behavior
+   -> Core/Profiling helper owns the CVar and non-shipping no-op.
+   -> Gameplay classes keep semantic methods such as ShouldSkip...ForProfiling().
+
+3. CSV / profiling audit CVar
+   -> Core/Profiling helper or the narrow policy helper owns the audit gate.
+   -> Runtime policy selector CVar must not also imply audit/counter output.
+
+4. Runtime policy / tuning CVar
+   -> The owning policy/system cpp may keep the CVar when it is the natural owner.
+   -> The CVar should be read through a policy API, not scattered through gameplay flow.
+```
+
+Applied ownership:
+
+```text
+Core/Debug:
+- AI combat BT audit and CanMoveDecoratorAudit
+- AI perception audit gates
+- CombatEngage assignment audit gates and output format
+
+Core/Profiling:
+- DisableEnemyPerception
+- DisableEnemyHitProcessing
+- DisableEnemyWeaponActor
+- DisableEnemyCombatFeedback
+- AnimationRefreshAudit
+
+Policy owner:
+- StatePolicyMode controls policy source only.
+- StatePolicyAudit controls state tier CSV counters.
+- StatePolicyMode 0 means per-system RuntimeLOD CVar modes.
+- StatePolicyMode 1 means state-based RuntimeLOD tier snapshot.
+```
+
+Remaining runtime policy/tuning CVars intentionally kept in owner files:
+
+```text
+CombatEngage assignment tuning:
+- EngageAssignmentWarmupTime
+- EngageAssignmentEngageCap
+- EngageAssignmentAlertCap
+
+Enemy / RuntimeLOD policy:
+- EnemyMeshMode
+- EnemyActorTickMode
+- EnemyMovementMode
+- EnemyAnimationMode
+- EnemyAnimationReducedRefreshInterval
+- BTUpdateIntervalMode
+- StatePolicyMode
+```
+
 ## PR final rescan override
 
 2026-07-21 PR 전 잔여 로그 재스캔 기준으로 아래 판단을 기존 요약보다 우선한다.

--- a/Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md
+++ b/Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md
@@ -1,0 +1,167 @@
+# N27. Debug Profiling CVar Ownership Final Note
+
+## Purpose
+
+This note records the final ownership rule after the debug log, diagnostic hook, profiling audit, and CSV counter cleanup.
+
+Related notes:
+
+```text
+N23_Debug_Log_And_Diagnostic_Code_Policy_Note.md
+N24_Debug_Log_Cleanup_Inventory_Note.md
+N25_Diagnostic_Log_Gating_And_Audit_Category_Plan_Note.md
+N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
+```
+
+N23 keeps the general policy.
+N24 keeps cleanup inventory.
+N25 keeps helper/gating design.
+N26 keeps full audit inventory.
+This note fixes the final ownership boundary so future cleanup does not mix debug, profiling, and runtime policy concerns again.
+
+---
+
+## Final Ownership Rule
+
+```text
+1. Debug / Diagnostic output CVar
+   Owner: Core/Debug helper
+   Responsibility: CVar, gate, message format, Output Log call, non-shipping no-op
+
+2. Debug Dump CVar
+   Owner: Core/Debug helper
+   Responsibility: verbose context/payload/result dump gate and print formatting
+
+3. Profiling audit / CSV counter CVar
+   Owner: Core/Profiling helper
+   Responsibility: CVar, gate, CSV counter, profiling summary, non-shipping no-op
+
+4. Runtime policy / tuning CVar
+   Owner: owning policy/system cpp
+   Responsibility: actual gameplay policy selection or tuning value
+```
+
+Runtime policy/tuning CVar can stay in the owning policy/system file when it changes actual game behavior.
+However, audit/counter output must not be implied by a policy selector CVar.
+
+---
+
+## Mixed CVar Rule
+
+Do not let one CVar control both runtime behavior and diagnostic/profiling output.
+
+Correct split:
+
+```text
+StatePolicyMode
+-> selects RuntimeLOD policy source only
+
+StatePolicyAudit
+-> controls state tier CSV profiling counter only
+```
+
+Incorrect split:
+
+```text
+StatePolicyMode
+-> selects policy source
+-> also controls audit/counter output
+```
+
+This rule also applies to animation, movement, BT interval, perception, combat feedback, and combat collision profiling.
+
+---
+
+## CSV Macro Rule
+
+```text
+CSV_CUSTOM_STAT_GLOBAL
+-> event / counter recording
+-> direct macro calls live in Core/Profiling helper implementation
+-> gameplay / BT / anim code calls Record...ForProfiling() only
+
+CSV_SCOPED_TIMING_STAT_GLOBAL
+-> RAII scope timing
+-> stays in the measured scope body
+-> do not hide it behind a helper, because that can change the measured range
+```
+
+Final scan expectation:
+
+```text
+Core/Profiling outside direct CSV_CUSTOM_STAT_GLOBAL count: 0
+Core/Profiling outside direct CSV_SCOPED_TIMING_STAT_GLOBAL: allowed only at measured scope entry
+```
+
+---
+
+## Current Applied Result
+
+Core/Debug owns:
+
+```text
+AI combat BT audit gates
+AI perception audit summaries
+CombatEngage assignment audit output format
+Combat signal / result / feedback diagnostic output
+Action / reaction / movement / overlay / component reference diagnostic output
+```
+
+Core/Profiling owns:
+
+```text
+DisableEnemyPerception
+DisableEnemyHitProcessing
+DisableEnemyWeaponActor
+DisableEnemyCombatFeedback
+AnimationRefreshAudit
+StatePolicyAudit
+AI animation refresh CSV counters
+AI behavior tree CSV counters
+AI state RuntimeLOD tier CSV counters
+Combat collision CSV counters
+Combat feedback CSV counters
+```
+
+Runtime policy/system owners keep:
+
+```text
+EngageAssignmentWarmupTime
+EngageAssignmentEngageCap
+EngageAssignmentAlertCap
+EnemyMeshMode
+EnemyActorTickMode
+EnemyMovementMode
+EnemyAnimationMode
+EnemyAnimationReducedRefreshInterval
+BTUpdateIntervalMode
+StatePolicyMode
+```
+
+These remaining CVars are policy/tuning controls, not debug output gates.
+
+---
+
+## Review Checklist
+
+Use this checklist when adding or reviewing a new CVar:
+
+```text
+1. Does it print text or control diagnostic output?
+   -> Core/Debug helper
+
+2. Does it emit CSV counters, profiling summaries, or profiling audit output?
+   -> Core/Profiling helper
+
+3. Does it select gameplay policy or tuning behavior?
+   -> owning policy/system cpp
+
+4. Does it do more than one of the above?
+   -> split it before merging
+
+5. Is it CSV_CUSTOM_STAT_GLOBAL?
+   -> direct call must be inside Core/Profiling
+
+6. Is it CSV_SCOPED_TIMING_STAT_GLOBAL?
+   -> keep it at the measured scope entry
+```

--- a/Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md
+++ b/Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md
@@ -1,10 +1,10 @@
-# N27. Debug Profiling CVar Ownership Final Note
+# N27. Debug / Profiling CVar Ownership Final Note
 
-## Purpose
+## 목적
 
-This note records the final ownership rule after the debug log, diagnostic hook, profiling audit, and CSV counter cleanup.
+이 문서는 debug log, diagnostic hook, profiling audit, CSV counter 정리 이후의 최종 CVar 소유권 기준을 기록한다.
 
-Related notes:
+관련 문서:
 
 ```text
 N23_Debug_Log_And_Diagnostic_Code_Policy_Note.md
@@ -13,24 +13,30 @@ N25_Diagnostic_Log_Gating_And_Audit_Category_Plan_Note.md
 N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
 ```
 
-N23 keeps the general policy.
-N24 keeps cleanup inventory.
-N25 keeps helper/gating design.
-N26 keeps full audit inventory.
-This note fixes the final ownership boundary so future cleanup does not mix debug, profiling, and runtime policy concerns again.
+책임 범위:
+
+```text
+N23: 일반 debug / diagnostic 정책
+N24: cleanup inventory
+N25: helper / gating 설계
+N26: full audit inventory
+N27: CVar ownership 최종 기준
+```
+
+이 문서는 이후 작업에서 debug, profiling, runtime policy 책임이 다시 섞이지 않도록 최종 경계를 고정한다.
 
 ---
 
-## Final Ownership Rule
+## 최종 소유권 기준
 
 ```text
 1. Debug / Diagnostic output CVar
    Owner: Core/Debug helper
-   Responsibility: CVar, gate, message format, Output Log call, non-shipping no-op
+   Responsibility: CVar, gate, message format, Output Log 호출, non-shipping no-op
 
 2. Debug Dump CVar
    Owner: Core/Debug helper
-   Responsibility: verbose context/payload/result dump gate and print formatting
+   Responsibility: context / payload / result 상세 dump gate와 print formatting
 
 3. Profiling audit / CSV counter CVar
    Owner: Core/Profiling helper
@@ -38,66 +44,66 @@ This note fixes the final ownership boundary so future cleanup does not mix debu
 
 4. Runtime policy / tuning CVar
    Owner: owning policy/system cpp
-   Responsibility: actual gameplay policy selection or tuning value
+   Responsibility: 실제 gameplay policy 선택 또는 tuning 값
 ```
 
-Runtime policy/tuning CVar can stay in the owning policy/system file when it changes actual game behavior.
-However, audit/counter output must not be implied by a policy selector CVar.
+실제 게임 동작을 바꾸는 runtime policy / tuning CVar는 해당 policy 또는 system cpp에 남길 수 있다.
+다만 policy selector CVar가 audit / counter 출력 의미까지 함께 가져서는 안 된다.
 
 ---
 
-## Mixed CVar Rule
+## Mixed CVar 금지
 
-Do not let one CVar control both runtime behavior and diagnostic/profiling output.
+하나의 CVar가 runtime behavior와 diagnostic / profiling output을 동시에 제어하지 않도록 분리한다.
 
-Correct split:
+올바른 분리:
 
 ```text
 StatePolicyMode
--> selects RuntimeLOD policy source only
+-> RuntimeLOD policy source만 선택
 
 StatePolicyAudit
--> controls state tier CSV profiling counter only
+-> state tier CSV profiling counter만 제어
 ```
 
-Incorrect split:
+잘못된 분리:
 
 ```text
 StatePolicyMode
--> selects policy source
--> also controls audit/counter output
+-> policy source 선택
+-> audit / counter output까지 같이 제어
 ```
 
-This rule also applies to animation, movement, BT interval, perception, combat feedback, and combat collision profiling.
+이 기준은 animation, movement, BT interval, perception, combat feedback, combat collision profiling에도 동일하게 적용한다.
 
 ---
 
-## CSV Macro Rule
+## CSV macro 기준
 
 ```text
 CSV_CUSTOM_STAT_GLOBAL
--> event / counter recording
--> direct macro calls live in Core/Profiling helper implementation
--> gameplay / BT / anim code calls Record...ForProfiling() only
+-> event / counter 기록
+-> 직접 macro 호출은 Core/Profiling helper 구현부에 둔다.
+-> gameplay / BT / anim code는 Record...ForProfiling() API만 호출한다.
 
 CSV_SCOPED_TIMING_STAT_GLOBAL
--> RAII scope timing
--> stays in the measured scope body
--> do not hide it behind a helper, because that can change the measured range
+-> RAII scope timing 계측
+-> 측정 대상 scope 본문에 유지한다.
+-> helper 뒤로 숨기면 측정 범위가 helper 호출 범위로 왜곡될 수 있다.
 ```
 
-Final scan expectation:
+최종 scan 기대값:
 
 ```text
-Core/Profiling outside direct CSV_CUSTOM_STAT_GLOBAL count: 0
-Core/Profiling outside direct CSV_SCOPED_TIMING_STAT_GLOBAL: allowed only at measured scope entry
+Core/Profiling 밖 직접 CSV_CUSTOM_STAT_GLOBAL: 0개
+Core/Profiling 밖 직접 CSV_SCOPED_TIMING_STAT_GLOBAL: 측정 scope 진입부만 허용
 ```
 
 ---
 
-## Current Applied Result
+## 현재 적용 결과
 
-Core/Debug owns:
+Core/Debug 소유:
 
 ```text
 AI combat BT audit gates
@@ -107,7 +113,7 @@ Combat signal / result / feedback diagnostic output
 Action / reaction / movement / overlay / component reference diagnostic output
 ```
 
-Core/Profiling owns:
+Core/Profiling 소유:
 
 ```text
 DisableEnemyPerception
@@ -123,7 +129,7 @@ Combat collision CSV counters
 Combat feedback CSV counters
 ```
 
-Runtime policy/system owners keep:
+Runtime policy / system owner 유지:
 
 ```text
 EngageAssignmentWarmupTime
@@ -138,30 +144,30 @@ BTUpdateIntervalMode
 StatePolicyMode
 ```
 
-These remaining CVars are policy/tuning controls, not debug output gates.
+위 CVar들은 debug output gate가 아니라 policy / tuning control이므로 owner cpp에 남긴다.
 
 ---
 
-## Review Checklist
+## 리뷰 체크리스트
 
-Use this checklist when adding or reviewing a new CVar:
+새 CVar를 추가하거나 기존 CVar를 검토할 때 다음 기준으로 판단한다.
 
 ```text
-1. Does it print text or control diagnostic output?
+1. text 출력 또는 diagnostic output을 제어하는가?
    -> Core/Debug helper
 
-2. Does it emit CSV counters, profiling summaries, or profiling audit output?
+2. CSV counter, profiling summary, profiling audit output을 만드는가?
    -> Core/Profiling helper
 
-3. Does it select gameplay policy or tuning behavior?
+3. gameplay policy 또는 tuning behavior를 선택하는가?
    -> owning policy/system cpp
 
-4. Does it do more than one of the above?
-   -> split it before merging
+4. 위 책임 중 둘 이상을 동시에 갖는가?
+   -> merge 전에 CVar를 분리한다.
 
-5. Is it CSV_CUSTOM_STAT_GLOBAL?
-   -> direct call must be inside Core/Profiling
+5. CSV_CUSTOM_STAT_GLOBAL인가?
+   -> 직접 호출은 Core/Profiling 내부에만 둔다.
 
-6. Is it CSV_SCOPED_TIMING_STAT_GLOBAL?
-   -> keep it at the measured scope entry
+6. CSV_SCOPED_TIMING_STAT_GLOBAL인가?
+   -> 측정 대상 scope 진입부에 둔다.
 ```

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_AlertCap_Comparison_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_AlertCap_Comparison_Plan.md
@@ -55,7 +55,7 @@ Portfolio.AI.RuntimeLOD.EngageAssignmentEngageCap 2
 Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode 0
 Portfolio.AI.RuntimeLOD.EnemyMeshMode 0
 Portfolio.AI.RuntimeLOD.EnemyAnimationMode 0
-Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter 0
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit 0
 Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor 0
 Portfolio.AI.RuntimeLOD.DisableEnemyPerception 0
 Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit 0

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Animation_Pose_LOD_Measurement_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Animation_Pose_LOD_Measurement_Plan.md
@@ -244,7 +244,7 @@ CVar 후보:
 ```text
 Portfolio.AI.RuntimeLOD.EnemyAnimationMode
 Portfolio.AI.RuntimeLOD.EnemyAnimationReducedRefreshInterval
-Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit
 ```
 
 기본 reduced interval:
@@ -263,11 +263,11 @@ Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter
 `PoseSkipIsolation`은 후속 이관 대상이다.
 첫 구현에서는 parameter refresh 주기 축소만 측정한다.
 
-정규 측정에서는 `EnemyAnimationRefreshCounter`를 켠다.
+정규 측정에서는 `AnimationRefreshAudit`을 켠다.
 이 카운터는 refresh gate의 attempt / executed / skipped 횟수를 CSV에 누적해, ReducedParameterRefresh가 실제로 호출 빈도를 줄였는지 확인하기 위한 측정 전용 값이다.
 
 ```text
-Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter 1
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit 1
 ```
 
 카운터가 없는 기존 40 Enemy baseline / reduced 측정은 preliminary 측정으로만 보고 정규 결과표에는 사용하지 않는다.
@@ -302,7 +302,7 @@ PerceptionCandidateAudit 0
 BlackboardEngageLatencyAudit 0
 DisableEnemyWeaponActor 0
 EnemyMeshMode 0
-EnemyAnimationRefreshCounter 1
+AnimationRefreshAudit 1
 EnemyAnimationReducedRefreshInterval 0.1
 ```
 

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_BT_Update_Interval_LOD_Measurement_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_BT_Update_Interval_LOD_Measurement_Plan.md
@@ -41,7 +41,7 @@ GC Event: none
 Runtime LOD CVar:
 EnemyMeshMode 0
 EnemyAnimationMode 0
-EnemyAnimationRefreshCounter 0
+AnimationRefreshAudit 0
 DisableEnemyWeaponActor 0
 DisableEnemyPerception 0
 PerceptionCandidateAudit 0
@@ -127,7 +127,7 @@ GC Event: none
 Runtime LOD CVar:
 EnemyMeshMode 0
 EnemyAnimationMode 0
-EnemyAnimationRefreshCounter 0
+AnimationRefreshAudit 0
 DisableEnemyWeaponActor 0
 DisableEnemyPerception 0
 PerceptionCandidateAudit 0
@@ -401,7 +401,7 @@ PIE: F11 fullscreen
 Camera: fixed camera
 EnemyMeshMode 0
 EnemyAnimationMode 0
-EnemyAnimationRefreshCounter 0
+AnimationRefreshAudit 0
 DisableEnemyWeaponActor 0
 DisableEnemyPerception 0
 PerceptionCandidateAudit 0
@@ -524,7 +524,7 @@ Log State: -noailogging
 PIE: F11 fullscreen
 EnemyMeshMode 0
 EnemyAnimationMode 0
-EnemyAnimationRefreshCounter 0
+AnimationRefreshAudit 0
 DisableEnemyWeaponActor 0
 DisableEnemyPerception 0
 PerceptionCandidateAudit 0
@@ -605,7 +605,7 @@ Log State: -noailogging
 PIE: F11 fullscreen
 EnemyMeshMode 0
 EnemyAnimationMode 0
-EnemyAnimationRefreshCounter 0
+AnimationRefreshAudit 0
 DisableEnemyWeaponActor 0
 DisableEnemyPerception 0
 PerceptionCandidateAudit 0

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Combat_Collision_HitWindow_Measurement_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Combat_Collision_HitWindow_Measurement_Plan.md
@@ -238,7 +238,7 @@ Portfolio.AI.RuntimeLOD.EngageAssignmentAlertCap 6
 Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode 0
 Portfolio.AI.RuntimeLOD.EnemyMeshMode 0
 Portfolio.AI.RuntimeLOD.EnemyAnimationMode 0
-Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter 0
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit 0
 Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor 0
 Portfolio.AI.RuntimeLOD.DisableEnemyPerception 0
 Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit 0

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Combat_Feedback_Presentation_Measurement_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Combat_Feedback_Presentation_Measurement_Plan.md
@@ -111,7 +111,7 @@ Portfolio.AI.RuntimeLOD.DisableEnemyCombatFeedback 0 / 1
 Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode 0
 Portfolio.AI.RuntimeLOD.EnemyMeshMode 0
 Portfolio.AI.RuntimeLOD.EnemyAnimationMode 0
-Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter 0
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit 0
 Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor 0
 Portfolio.AI.RuntimeLOD.DisableEnemyPerception 0
 Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit 0

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Enemy_Actor_Tick_Audit_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Enemy_Actor_Tick_Audit_Plan.md
@@ -66,7 +66,7 @@ GC 이벤트 없음
 Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode 0
 Portfolio.AI.RuntimeLOD.EnemyMeshMode 0
 Portfolio.AI.RuntimeLOD.EnemyAnimationMode 0
-Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter 0
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit 0
 Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor 0
 Portfolio.AI.RuntimeLOD.DisableEnemyPerception 0
 Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit 0

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Movement_Nav_LOD_Measurement_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Movement_Nav_LOD_Measurement_Plan.md
@@ -388,7 +388,7 @@ PIE: F11 fullscreen
 Camera: fixed camera
 EnemyMeshMode 0
 EnemyAnimationMode 0
-EnemyAnimationRefreshCounter 0
+AnimationRefreshAudit 0
 DisableEnemyWeaponActor 0
 DisableEnemyPerception 0
 PerceptionCandidateAudit 0

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Runtime_LOD_Tier_Snapshot_Refactor_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_Runtime_LOD_Tier_Snapshot_Refactor_Plan.md
@@ -446,7 +446,7 @@ EngageAssignmentAlertCap 6
 BTUpdateIntervalMode 2
 EnemyMovementMode 0
 EnemyAnimationMode 0
-EnemyAnimationRefreshCounter 1
+AnimationRefreshAudit 1
 -noailogging
 F11 fullscreen
 fixed camera

--- a/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_State_Based_Runtime_LOD_Policy_Plan.md
+++ b/Docs/07_Profiling/AI_Performance/Runtime_LOD/AI_State_Based_Runtime_LOD_Policy_Plan.md
@@ -516,7 +516,7 @@ Portfolio.AI.RuntimeLOD.EngageAssignmentVerboseAudit 0
 Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode 2
 Portfolio.AI.RuntimeLOD.EnemyMovementMode 0
 Portfolio.AI.RuntimeLOD.EnemyAnimationMode 0
-Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter 1
+Portfolio.AI.RuntimeLOD.AnimationRefreshAudit 1
 
 Portfolio.AI.RuntimeLOD.DisableEnemyPerception 0
 Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit 0

--- a/Source/Portfolio/AI/BehaviorTree/Decorator/CBTDecorator_CanMove.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Decorator/CBTDecorator_CanMove.cpp
@@ -2,19 +2,10 @@
 #include "ProjectGlobal.h"
 
 #include "AIController.h"
+#include "Core/Debug/FAICombatBTDebug.h"
 #include "GameFramework/Pawn.h"
-#include "HAL/IConsoleManager.h"
 
 #include "Component/CMovementComponent.h"
-
-namespace
-{
-	TAutoConsoleVariable<int32> CVarAIRuntimeLODCanMoveDecoratorAudit(
-		TEXT("Portfolio.AI.RuntimeLOD.CanMoveDecoratorAudit"),
-		0,
-		TEXT("Print CBTDecorator_CanMove result for runtime LOD debugging. 0: disabled, 1: enabled."),
-		ECVF_Default);
-}
 
 UCBTDecorator_CanMove::UCBTDecorator_CanMove()
 {
@@ -33,14 +24,7 @@ bool UCBTDecorator_CanMove::CalculateRawConditionValue(UBehaviorTreeComponent& O
 	if (!IsValid(movementComp)) return false;
 
 	const bool bCanMove = movementComp->CanAcceptMoveInput();
-
-	if (CVarAIRuntimeLODCanMoveDecoratorAudit.GetValueOnGameThread() != 0)
-	{
-		FLog::Log(FString::Printf(
-			TEXT("[CanMoveDecoratorAudit] Owner=%s | CanMove=%s"),
-			*GetNameSafe(pawn),
-			bCanMove ? TEXT("true") : TEXT("false")));
-	}
+	FAICombatBTDebug::RecordCanMoveDecoratorResultForAudit(pawn, bCanMove);
 
 	return bCanMove;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
@@ -3,11 +3,11 @@
 #include "BehaviorTree/BehaviorTreeComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
 #include "HAL/IConsoleManager.h"
-#include "ProfilingDebugging/CsvProfiler.h"
 
 #include "AI/RuntimeLOD/CAIRuntimeLODTierResolver.h"
 #include "AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h"
 #include "Controller/CAIController.h"
+#include "Core/Profiling/CAIStateRuntimeLODProfiling.h"
 
 namespace
 {
@@ -122,9 +122,7 @@ namespace
 
 	void RecordStateRuntimeLODTier(EAIRuntimeLODTier InTier)
 	{
-		if (!FAIStateRuntimeLODPolicy::IsStatePolicyAuditEnabled()) return;
-
-		FAIStateRuntimeLODPolicy::RecordResolvedTierForProfiling(InTier);
+		FAIStateRuntimeLODProfiling::RecordResolvedTierForProfiling(InTier);
 	}
 
 	// AIIntentState

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
@@ -15,7 +15,7 @@ namespace
 	TAutoConsoleVariable<int32> CVarBTUpdateIntervalMode(
 		TEXT("Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode"),
 		0,
-		TEXT("Controls AI BT service update interval profiling mode. 0: default, 1: reduced, 2: aggressive reduced."),
+		TEXT("Controls AI BT service update interval Runtime LOD mode. 0: default, 1: reduced, 2: aggressive reduced."),
 		ECVF_Default);
 
 	// Interval Preset

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
@@ -7,6 +7,7 @@
 #include "AI/RuntimeLOD/CAIRuntimeLODTierResolver.h"
 #include "AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h"
 #include "Controller/CAIController.h"
+#include "Core/Profiling/CAIBehaviorTreeProfiling.h"
 #include "Core/Profiling/CAIStateRuntimeLODProfiling.h"
 
 namespace
@@ -17,14 +18,6 @@ namespace
 		0,
 		TEXT("Controls AI BT service update interval Runtime LOD mode. 0: default, 1: reduced, 2: aggressive reduced."),
 		ECVF_Default);
-
-	// Interval Preset
-	enum class EBTServiceIntervalPreset : uint8
-	{
-		Default,
-		Reduced,
-		Aggressive
-	};
 
 	// AIContext
 	constexpr float DefaultAIContextInterval = 0.1f;
@@ -129,21 +122,7 @@ namespace
 	// Record Counter (AIIntentState)
 	void RecordAIIntentStateIntervalPreset(EBTServiceIntervalPreset InPreset)
 	{
-		switch (InPreset)
-		{
-		case EBTServiceIntervalPreset::Default:
-			CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_AIIntentInterval_Default_Count, 1, ECsvCustomStatOp::Accumulate);
-			return;
-
-		case EBTServiceIntervalPreset::Reduced:
-			CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_AIIntentInterval_Reduced_Count, 1, ECsvCustomStatOp::Accumulate);
-			return;
-
-		case EBTServiceIntervalPreset::Aggressive:
-		default:
-			CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_AIIntentInterval_Aggressive_Count, 1, ECsvCustomStatOp::Accumulate);
-			return;
-		}
+		FAIBehaviorTreeProfiling::RecordAIIntentIntervalPresetForProfiling(InPreset);
 	}
 
 	// Interval Enum Preset -> Interval float value (AIIntentState)

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.h
@@ -4,6 +4,13 @@
 
 class UBehaviorTreeComponent;
 
+enum class EBTServiceIntervalPreset : uint8
+{
+	Default,
+	Reduced,
+	Aggressive
+};
+
 namespace CBTServiceIntervalHelper
 {
 	float GetAIContextInterval(const UBehaviorTreeComponent& InOwnerComp);

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -16,6 +16,7 @@
 #include "AI/Blackboard/CAIKey.h"
 #include "AI/Blackboard/CAIBlackboardValueHelper.h"
 #include "Core/Debug/FAICombatBTDebug.h"
+#include "Core/Profiling/CAIBehaviorTreeProfiling.h"
 #include "Type/CAIStructure.h"
 #include "Type/CWorldSubSystemStructure.h"
 
@@ -31,7 +32,7 @@ UCBTService_UpdateAIContext::UCBTService_UpdateAIContext()
 void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds)
 {
 	CSV_SCOPED_TIMING_STAT_GLOBAL(PortfolioAI_BT_UpdateAIContext);
-	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateAIContext_Count, 1, ECsvCustomStatOp::Accumulate);
+	FAIBehaviorTreeProfiling::RecordUpdateAIContextTickForProfiling();
 	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
 
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
@@ -11,6 +11,7 @@
 #include "Component/CMovementComponent.h"
 #include "Component/CWeaponComponent.h"
 #include "Controller/CAIController.h"
+#include "Core/Profiling/CAIBehaviorTreeProfiling.h"
 
 #include "Type/CStateStructure.h"
 #include "Type/CWeaponStructure.h"
@@ -31,7 +32,7 @@ UCBTService_UpdateAIIntentState::UCBTService_UpdateAIIntentState()
 void UCBTService_UpdateAIIntentState::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds)
 {
 	CSV_SCOPED_TIMING_STAT_GLOBAL(PortfolioAI_BT_UpdateAIIntentState);
-	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateAIIntentState_Count, 1, ECsvCustomStatOp::Accumulate);
+	FAIBehaviorTreeProfiling::RecordUpdateAIIntentStateTickForProfiling();
 	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
 
 	UWorld* world = GetWorld();

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -11,6 +11,7 @@
 #include "AI/Blackboard/CAIKey.h"
 #include "AI/Blackboard/CAIBlackboardValueHelper.h"
 #include "Core/Debug/FAICombatBTDebug.h"
+#include "Core/Profiling/CAIBehaviorTreeProfiling.h"
 #include "Type/CAIStructure.h"
 
 UCBTService_UpdateEngageContext::UCBTService_UpdateEngageContext()
@@ -25,7 +26,7 @@ UCBTService_UpdateEngageContext::UCBTService_UpdateEngageContext()
 void UCBTService_UpdateEngageContext::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds)
 {
 	CSV_SCOPED_TIMING_STAT_GLOBAL(PortfolioAI_BT_UpdateEngageContext);
-	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateEngageContext_Count, 1, ECsvCustomStatOp::Accumulate);
+	FAIBehaviorTreeProfiling::RecordUpdateEngageContextTickForProfiling();
 	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
 
 	UBlackboardComponent* blackBoardComp = OwnerComp.GetBlackboardComponent();

--- a/Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
+++ b/Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
@@ -128,7 +128,7 @@ namespace CAIBlackboardValueHelper
 	{
 		ensureMsgf(
 			InOutPendingKeys.Remove(InKeySpec.KeyName) > 0,
-			TEXT("[AIBlackboardValueHelper] Custom Blackboard key was not registered | Owner=%s | Key=%s"),
+			TEXT("[AI|Blackboard|CustomKeyNotRegistered] Reason=MissingPendingKey | Owner=%s | Key=%s"),
 			*GetNameSafe(InOwnerContext),
 			*InKeySpec.KeyName.ToString());
 	}
@@ -194,7 +194,7 @@ namespace CAIBlackboardValueHelper
 		const FString pendingCustomKeys = FString::Join(pendingKeyNames, TEXT(", "));
 
 		ensureMsgf(false,
-			TEXT("[AIBlackboardValueHelper] Missing custom Blackboard initial values | Owner=%s | Pending=%s"),
+			TEXT("[AI|Blackboard|CustomInitialValuesMissing] Reason=PendingCustomKeys | Owner=%s | Missing=%s"),
 			*GetNameSafe(InOwnerContext),
 			*pendingCustomKeys);
 

--- a/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKeyRegistry.h
@@ -137,7 +137,7 @@ namespace CAIKeyRegistry
 
 		const FString missingKeys = FString::Join(missingKeyMessages, TEXT(", "));
 		ensureMsgf(false,
-			TEXT("[AIKeyRegistry] Missing required Blackboard keys | Blackboard=%s | Missing=%s"),
+			TEXT("[AI|Blackboard|RequiredKeysMissing] Reason=MissingRequiredKeys | Asset=%s | Missing=%s"),
 			*GetNameSafe(InBlackboardAsset),
 			*missingKeys);
 

--- a/Source/Portfolio/AI/RuntimeLOD/CAIAnimationRuntimeLODPolicy.cpp
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIAnimationRuntimeLODPolicy.cpp
@@ -3,6 +3,7 @@
 #include "AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h"
 #include "Character/Enemy/CEnemy.h"
 #include "Controller/CAIController.h"
+#include "Core/Profiling/CAIAnimationProfiling.h"
 #include "GameFramework/Pawn.h"
 #include "HAL/IConsoleManager.h"
 
@@ -20,11 +21,6 @@ namespace
 		TEXT("Refresh interval for ACEnemy reduced animation parameter mode."),
 		ECVF_Default);
 
-	TAutoConsoleVariable<int32> CVarEnemyAnimationRefreshCounter(
-		TEXT("Portfolio.AI.RuntimeLOD.EnemyAnimationRefreshCounter"),
-		0,
-		TEXT("Enable ACEnemy animation parameter refresh counters for runtime LOD measurement. 0: disabled, 1: enabled."),
-		ECVF_Default);
 }
 
 int32 FAIAnimationRuntimeLODPolicy::GetEnemyAnimationMode()
@@ -34,7 +30,7 @@ int32 FAIAnimationRuntimeLODPolicy::GetEnemyAnimationMode()
 
 int32 FAIAnimationRuntimeLODPolicy::GetEnemyAnimationMode(const AActor* InOwner)
 {
-	if (FAIStateRuntimeLODPolicy::GetStatePolicyMode() > 0)
+	if (FAIStateRuntimeLODPolicy::ShouldUseStateBasedPolicy())
 	{
 		return GetStateBasedAnimationMode(InOwner);
 	}
@@ -54,7 +50,7 @@ float FAIAnimationRuntimeLODPolicy::GetReducedAnimationRefreshInterval()
 
 bool FAIAnimationRuntimeLODPolicy::ShouldAuditAnimationRefresh()
 {
-	return CVarEnemyAnimationRefreshCounter.GetValueOnGameThread() != 0;
+	return FAIAnimationProfiling::ShouldAuditAnimationRefresh();
 }
 
 int32 FAIAnimationRuntimeLODPolicy::GetStateBasedAnimationMode(const AActor* InOwner)

--- a/Source/Portfolio/AI/RuntimeLOD/CAIAnimationRuntimeLODPolicy.cpp
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIAnimationRuntimeLODPolicy.cpp
@@ -3,7 +3,6 @@
 #include "AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h"
 #include "Character/Enemy/CEnemy.h"
 #include "Controller/CAIController.h"
-#include "Core/Profiling/CAIAnimationProfiling.h"
 #include "GameFramework/Pawn.h"
 #include "HAL/IConsoleManager.h"
 
@@ -46,11 +45,6 @@ bool FAIAnimationRuntimeLODPolicy::IsEnemyAnimationRuntimeLODTarget(const AActor
 float FAIAnimationRuntimeLODPolicy::GetReducedAnimationRefreshInterval()
 {
 	return FMath::Max(CVarEnemyAnimationReducedRefreshInterval.GetValueOnGameThread(), KINDA_SMALL_NUMBER);
-}
-
-bool FAIAnimationRuntimeLODPolicy::ShouldAuditAnimationRefresh()
-{
-	return FAIAnimationProfiling::ShouldAuditAnimationRefresh();
 }
 
 int32 FAIAnimationRuntimeLODPolicy::GetStateBasedAnimationMode(const AActor* InOwner)

--- a/Source/Portfolio/AI/RuntimeLOD/CAIAnimationRuntimeLODPolicy.h
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIAnimationRuntimeLODPolicy.h
@@ -12,7 +12,6 @@ public:
 	static bool IsEnemyAnimationRuntimeLODTarget(const AActor* InOwner);
 
 	static float GetReducedAnimationRefreshInterval();
-	static bool ShouldAuditAnimationRefresh();
 
 private:
 	static int32 GetStateBasedAnimationMode(const AActor* InOwner);

--- a/Source/Portfolio/AI/RuntimeLOD/CAIMovementRuntimeLODPolicy.cpp
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIMovementRuntimeLODPolicy.cpp
@@ -22,7 +22,7 @@ int32 FAIMovementRuntimeLODPolicy::GetEnemyMovementMode()
 
 int32 FAIMovementRuntimeLODPolicy::GetEnemyMovementMode(const AActor* InOwner)
 {
-	if (FAIStateRuntimeLODPolicy::GetStatePolicyMode() > 0)
+	if (FAIStateRuntimeLODPolicy::ShouldUseStateBasedPolicy())
 	{
 		return GetStateBasedMovementMode(InOwner);
 	}

--- a/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.cpp
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.cpp
@@ -1,7 +1,6 @@
 #include "AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h"
 
 #include "HAL/IConsoleManager.h"
-#include "ProfilingDebugging/CsvProfiler.h"
 
 namespace
 {
@@ -10,14 +9,6 @@ namespace
 		0,
 		TEXT("Controls AI Runtime LOD policy source. 0: per-system RuntimeLOD CVar modes, 1: state-based RuntimeLOD tier snapshot."),
 		ECVF_Default);
-
-#if !UE_BUILD_SHIPPING
-	TAutoConsoleVariable<int32> CVarAIStateRuntimeLODPolicyAudit(
-		TEXT("Portfolio.AI.RuntimeLOD.StatePolicyAudit"),
-		0,
-		TEXT("Emit AI Runtime LOD state policy tier CSV counters. 0: disabled, 1: enabled."),
-		ECVF_Default);
-#endif
 }
 
 int32 FAIStateRuntimeLODPolicy::GetStatePolicyMode()
@@ -28,42 +19,4 @@ int32 FAIStateRuntimeLODPolicy::GetStatePolicyMode()
 bool FAIStateRuntimeLODPolicy::ShouldUseStateBasedPolicy()
 {
 	return GetStatePolicyMode() > 0;
-}
-
-bool FAIStateRuntimeLODPolicy::IsStatePolicyAuditEnabled()
-{
-#if !UE_BUILD_SHIPPING
-	return CVarAIStateRuntimeLODPolicyAudit.GetValueOnGameThread() != 0;
-#else
-	return false;
-#endif
-}
-
-void FAIStateRuntimeLODPolicy::RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier)
-{
-	if (!IsStatePolicyAuditEnabled()) return;
-
-	switch (InTier)
-	{
-	case EAIRuntimeLODTier::CombatCritical:
-		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_CombatCritical_Count, 1, ECsvCustomStatOp::Accumulate);
-		return;
-
-	case EAIRuntimeLODTier::CombatSupport:
-		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_CombatSupport_Count, 1, ECsvCustomStatOp::Accumulate);
-		return;
-
-	case EAIRuntimeLODTier::Awareness:
-		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_Awareness_Count, 1, ECsvCustomStatOp::Accumulate);
-		return;
-
-	case EAIRuntimeLODTier::Background:
-		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_Background_Count, 1, ECsvCustomStatOp::Accumulate);
-		return;
-
-	case EAIRuntimeLODTier::Dormant:
-	default:
-		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_Dormant_Count, 1, ECsvCustomStatOp::Accumulate);
-		return;
-	}
 }

--- a/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.cpp
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.cpp
@@ -8,8 +8,16 @@ namespace
 	TAutoConsoleVariable<int32> CVarAIStateRuntimeLODPolicyMode(
 		TEXT("Portfolio.AI.RuntimeLOD.StatePolicyMode"),
 		0,
-		TEXT("Controls state-based AI Runtime LOD policy. 0: disabled, 1: conservative policy audit."),
+		TEXT("Controls AI Runtime LOD policy source. 0: per-system RuntimeLOD CVar modes, 1: state-based RuntimeLOD tier snapshot."),
 		ECVF_Default);
+
+#if !UE_BUILD_SHIPPING
+	TAutoConsoleVariable<int32> CVarAIStateRuntimeLODPolicyAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.StatePolicyAudit"),
+		0,
+		TEXT("Emit AI Runtime LOD state policy tier CSV counters. 0: disabled, 1: enabled."),
+		ECVF_Default);
+#endif
 }
 
 int32 FAIStateRuntimeLODPolicy::GetStatePolicyMode()
@@ -17,9 +25,18 @@ int32 FAIStateRuntimeLODPolicy::GetStatePolicyMode()
 	return FMath::Clamp(CVarAIStateRuntimeLODPolicyMode.GetValueOnGameThread(), 0, 1);
 }
 
-bool FAIStateRuntimeLODPolicy::IsStatePolicyAuditEnabled()
+bool FAIStateRuntimeLODPolicy::ShouldUseStateBasedPolicy()
 {
 	return GetStatePolicyMode() > 0;
+}
+
+bool FAIStateRuntimeLODPolicy::IsStatePolicyAuditEnabled()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarAIStateRuntimeLODPolicyAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
 }
 
 void FAIStateRuntimeLODPolicy::RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier)

--- a/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h
@@ -7,6 +7,7 @@ class FAIStateRuntimeLODPolicy
 {
 public:
 	static int32 GetStatePolicyMode();
+	static bool ShouldUseStateBasedPolicy();
 	static bool IsStatePolicyAuditEnabled();
 
 	static void RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier);

--- a/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.h
@@ -8,7 +8,4 @@ class FAIStateRuntimeLODPolicy
 public:
 	static int32 GetStatePolicyMode();
 	static bool ShouldUseStateBasedPolicy();
-	static bool IsStatePolicyAuditEnabled();
-
-	static void RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier);
 };

--- a/Source/Portfolio/Character/CAnimInstance.cpp
+++ b/Source/Portfolio/Character/CAnimInstance.cpp
@@ -145,7 +145,7 @@ bool UCAnimInstance::ShouldRefreshAnimationParameters(float DeltaSeconds)
 
 bool UCAnimInstance::ShouldAuditAnimationRefreshForProfiling() const
 {
-	return IsEnemyAnimationProfilingTarget() && FAIAnimationRuntimeLODPolicy::ShouldAuditAnimationRefresh();
+	return IsEnemyAnimationProfilingTarget() && FAIAnimationProfiling::ShouldAuditAnimationRefresh();
 }
 
 void UCAnimInstance::RecordAnimationRefreshAttemptForProfiling() const

--- a/Source/Portfolio/Character/CAnimInstance.cpp
+++ b/Source/Portfolio/Character/CAnimInstance.cpp
@@ -2,8 +2,8 @@
 #include "ProjectGlobal.h"
 
 #include "AI/RuntimeLOD/CAIAnimationRuntimeLODPolicy.h"
+#include "Core/Profiling/CAIAnimationProfiling.h"
 #include "GameFramework/Character.h"
-#include "ProfilingDebugging/CsvProfiler.h"
 
 #include "Component/CMovementComponent.h"
 #include "Component/CWeaponComponent.h"
@@ -152,21 +152,21 @@ void UCAnimInstance::RecordAnimationRefreshAttemptForProfiling() const
 {
 	if (!ShouldAuditAnimationRefreshForProfiling()) return;
 
-	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Attempt, 1, ECsvCustomStatOp::Accumulate);
+	FAIAnimationProfiling::RecordAnimationRefreshAttemptForProfiling();
 }
 
 void UCAnimInstance::RecordAnimationRefreshExecutedForProfiling() const
 {
 	if (!ShouldAuditAnimationRefreshForProfiling()) return;
 
-	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Executed, 1, ECsvCustomStatOp::Accumulate);
+	FAIAnimationProfiling::RecordAnimationRefreshExecutedForProfiling();
 }
 
 void UCAnimInstance::RecordAnimationRefreshSkippedForProfiling() const
 {
 	if (!ShouldAuditAnimationRefreshForProfiling()) return;
 
-	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Skipped, 1, ECsvCustomStatOp::Accumulate);
+	FAIAnimationProfiling::RecordAnimationRefreshSkippedForProfiling();
 }
 
 // Parameter Refresh

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -41,7 +41,7 @@ namespace
 	TAutoConsoleVariable<int32> CVarAIRuntimeLODEnemyActorTickMode(
 		TEXT("Portfolio.AI.RuntimeLOD.EnemyActorTickMode"),
 		0,
-		TEXT("Controls ACEnemy actor tick profiling mode. 0: default, 1: disable ACEnemy actor tick."),
+		TEXT("Controls ACEnemy actor tick Runtime LOD mode. 0: default, 1: disable ACEnemy actor tick."),
 		ECVF_Default);
 }
 

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -5,25 +5,19 @@
 #include "BehaviorTree/BlackboardComponent.h"
 #include "Components/ShapeComponent.h"
 #include "GameFramework/Character.h"
-#include "HAL/IConsoleManager.h"
 
 #include "AI/Blackboard/CAIKey.h"
 #include "Character/Enemy/CEnemy.h"
 #include "Component/CCombatSignalTargetComponent.h"
 
 #include "Core/Debug/FCombatSignalDebug.h"
+#include "Core/Profiling/CCombatCollisionProfiling.h"
 #include "Core/Profiling/CCombatCollisionProfilingCounters.h"
 
 #include "Type/CWeaponStructure.h"
 
 namespace
 {
-	TAutoConsoleVariable<int32> CVarDisableEnemyHitProcessing(
-		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyHitProcessing"),
-		0,
-		TEXT("Disable Enemy hit processing for combat collision profiling. 0: process hit, 1: skip Enemy hit processing after overlap."),
-		ECVF_Default);
-
 	const FName CombatTimingCueSignalTag(TEXT("Combat.Signal.TimingCue"));
 }
 
@@ -182,14 +176,7 @@ void UCCombatSignalSourceComponent::ProcessCombatSignalSource(const FHitContext&
 
 bool UCCombatSignalSourceComponent::ShouldSkipEnemyHitProcessingForProfiling() const
 {
-	if (CVarDisableEnemyHitProcessing.GetValueOnGameThread() == 0) return false;
-
-	return IsEnemyHitProcessingProfilingTarget();
-}
-
-bool UCCombatSignalSourceComponent::IsEnemyHitProcessingProfilingTarget() const
-{
-	return IsValid(OwnerCharacter_Injected) && OwnerCharacter_Injected->IsA<ACEnemy>();
+	return FCombatCollisionProfiling::ShouldSkipEnemyHitProcessing(OwnerCharacter_Injected);
 }
 
 bool UCCombatSignalSourceComponent::ValidateRequest(const FHitContext& InHitContext) const

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.h
@@ -55,7 +55,6 @@ private:
 private:
 	// Profiling
 	bool ShouldSkipEnemyHitProcessingForProfiling() const;
-	bool IsEnemyHitProcessingProfilingTarget() const;
 
 private:
 	// Receive

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -206,7 +206,13 @@ bool UCWeaponComponent::CreateWeaponActor(AActor* InOwnerCharacter, EWeaponType 
 {
 	if (!IsValid(InOwnerCharacter)) return false;
 
-	if (!ensureMsgf(*InWeaponActorClass, TEXT("UCWeaponComponent: InWeaponActorClass is not set.")))
+	if (!ensureMsgf(
+		*InWeaponActorClass,
+		TEXT("[Weapon|Component|WeaponActorClassMissing] Reason=MissingWeaponActorClass | Owner=%s | Component=%s | Asset=%s | WeaponType=%s"),
+		*GetNameSafe(InOwnerCharacter),
+		*GetNameSafe(this),
+		*GetNameSafe(*InWeaponActorClass),
+		*UEnum::GetValueAsString(InWeaponType)))
 		return false;
 
 	UWorld* World = InOwnerCharacter->GetWorld();
@@ -222,7 +228,13 @@ bool UCWeaponComponent::CreateWeaponActor(AActor* InOwnerCharacter, EWeaponType 
 	ACWeaponActor* weaponActor = World->SpawnActor<ACWeaponActor>(InWeaponActorClass, SpawnParams);
 
 	// 3) Check WeaponActor Validation
-	if (!ensureMsgf(IsValid(weaponActor), TEXT("UCWeaponComponent: WeaponActor was not created")))
+	if (!ensureMsgf(
+		IsValid(weaponActor),
+		TEXT("[Weapon|Component|WeaponActorSpawnFailed] Reason=SpawnActorReturnedInvalid | Owner=%s | Component=%s | Asset=%s | WeaponType=%s"),
+		*GetNameSafe(InOwnerCharacter),
+		*GetNameSafe(this),
+		*GetNameSafe(*InWeaponActorClass),
+		*UEnum::GetValueAsString(InWeaponType)))
 		return false;
 
 	const FCharacterComponentReferences references = BuildWeaponActorReferences();

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -2,23 +2,13 @@
 #include "ProjectGlobal.h"
 
 #include "GameFramework/Character.h"
-#include "HAL/IConsoleManager.h"
 
-#include "Character/Enemy/CEnemy.h"
 #include "Component/CCombatSignalSourceComponent.h"
+#include "Core/Profiling/CCombatCollisionProfiling.h"
 #include "Core/Profiling/CCombatCollisionProfilingCounters.h"
 #include "Weapon/CWeaponActor.h"
 
 #include "Type/CWeaponStructure.h"
-
-namespace
-{
-	TAutoConsoleVariable<int32> CVarDisableEnemyWeaponActor(
-		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor"),
-		0,
-		TEXT("Disable Enemy WeaponActor creation for runtime LOD measurement. 0: spawn WeaponActor, 1: skip Enemy WeaponActor."),
-		ECVF_Default);
-}
 
 UCWeaponComponent::UCWeaponComponent()
 {
@@ -248,9 +238,7 @@ bool UCWeaponComponent::CreateWeaponActor(AActor* InOwnerCharacter, EWeaponType 
 
 bool UCWeaponComponent::ShouldSkipWeaponActorCreationForProfiling() const
 {
-	if (CVarDisableEnemyWeaponActor.GetValueOnGameThread() == 0) return false;
-
-	return IsValid(OwnerCharacter_Injected) && OwnerCharacter_Injected->IsA<ACEnemy>();
+	return FCombatCollisionProfiling::ShouldSkipEnemyWeaponActorCreation(OwnerCharacter_Injected);
 }
 
 void UCWeaponComponent::SkipWeaponActorCreationForProfiling()

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -11,6 +11,7 @@
 
 #include "Character/Player/CPlayer.h"
 #include "Character/Enemy/CEnemy.h"
+#include "Core/Debug/FAIPerceptionDebug.h"
 #include "AI/Patrol/CPatrolPath.h"
 
 #include "Interface/TargetContextProvider.h"
@@ -30,17 +31,6 @@ namespace
 		TEXT("Disable Enemy AI Perception for runtime LOD measurement. 0: enable perception, 1: disable Enemy perception."),
 		ECVF_Default);
 
-	TAutoConsoleVariable<int32> CVarEnablePerceptionCandidateAudit(
-		TEXT("Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit"),
-		0,
-		TEXT("Enable Enemy Perception candidate audit for runtime LOD measurement. 0: disabled, 1: enabled."),
-		ECVF_Default);
-
-	TAutoConsoleVariable<int32> CVarEnableBlackboardEngageLatencyAudit(
-		TEXT("Portfolio.AI.RuntimeLOD.BlackboardEngageLatencyAudit"),
-		0,
-		TEXT("Enable Enemy Blackboard / Engage latency audit for runtime LOD measurement. 0: disabled, 1: enabled."),
-		ECVF_Default);
 }
 
 ACAIController::ACAIController()
@@ -573,7 +563,7 @@ void ACAIController::ClearPerceptionCandidateAudit()
 
 bool ACAIController::ShouldAuditPerceptionCandidates() const
 {
-	if (CVarEnablePerceptionCandidateAudit.GetValueOnGameThread() == 0) return false;
+	if (!FAIPerceptionDebug::ShouldAuditPerceptionCandidates()) return false;
 
 	return IsValid(ControlledPawn_Cached) && ControlledPawn_Cached->IsA<ACEnemy>();
 }
@@ -649,7 +639,7 @@ void ACAIController::ClearBlackboardEngageLatencyAudit()
 
 bool ACAIController::ShouldAuditBlackboardEngageLatency() const
 {
-	if (CVarEnableBlackboardEngageLatencyAudit.GetValueOnGameThread() == 0) return false;
+	if (!FAIPerceptionDebug::ShouldAuditBlackboardEngageLatency()) return false;
 
 	return IsValid(ControlledPawn_Cached) && ControlledPawn_Cached->IsA<ACEnemy>();
 }

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -7,11 +7,11 @@
 #include "Perception/AIPerceptionTypes.h"
 #include "BehaviorTree/BlackboardComponent.h"
 #include "BrainComponent.h"
-#include "HAL/IConsoleManager.h"
 
 #include "Character/Player/CPlayer.h"
 #include "Character/Enemy/CEnemy.h"
 #include "Core/Debug/FAIPerceptionDebug.h"
+#include "Core/Profiling/CAIPerceptionProfiling.h"
 #include "AI/Patrol/CPatrolPath.h"
 
 #include "Interface/TargetContextProvider.h"
@@ -22,16 +22,6 @@
 #include "AI/Blackboard/CAIKeyRegistry.h"
 #include "AI/Blackboard/CAIBlackboardValueHelper.h"
 #include "AI/RuntimeLOD/CAIRuntimeLODTierResolver.h"
-
-namespace
-{
-	TAutoConsoleVariable<int32> CVarDisableEnemyPerception(
-		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyPerception"),
-		0,
-		TEXT("Disable Enemy AI Perception for runtime LOD measurement. 0: enable perception, 1: disable Enemy perception."),
-		ECVF_Default);
-
-}
 
 ACAIController::ACAIController()
 {
@@ -514,9 +504,7 @@ void ACAIController::ClearPerceptionStateForProfiling()
 
 bool ACAIController::ShouldDisableEnemyPerceptionForProfiling() const
 {
-	if (CVarDisableEnemyPerception.GetValueOnGameThread() == 0) return false;
-
-	return IsValid(ControlledPawn_Cached) && ControlledPawn_Cached->IsA<ACEnemy>();
+	return FAIPerceptionProfiling::ShouldDisableEnemyPerception(ControlledPawn_Cached);
 }
 
 void ACAIController::DisableEnemyPerceptionForProfiling()

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -154,8 +154,8 @@ void ACAIController::UninitializeControllerRuntime()
 	ClearBlackboardValues();
 	UnbindPerceptionEvents();
 
-	PrintPerceptionCandidateAuditSummary();
-	PrintBlackboardEngageLatencyAuditSummary();
+	FAIPerceptionDebug::PrintPerceptionCandidateAuditSummary(ControlledPawn_Cached, PerceptionCandidateAuditState);
+	FAIPerceptionDebug::PrintBlackboardEngageLatencyAuditSummary(ControlledPawn_Cached, BlackboardEngageLatencyAuditState);
 
 	ClearBlackboardEngageLatencyAudit();
 	ClearPerceptionCandidateAudit();
@@ -682,77 +682,3 @@ void ACAIController::RecordEngageAssignmentResolvedForAudit(AActor* InTargetActo
 	BlackboardEngageLatencyAuditState.FirstEngageAssignmentTargetActor = InTargetActor;
 }
 
-// Profiling Debug
-
-void ACAIController::PrintPerceptionCandidateAuditSummary() const
-{
-	if (!PerceptionCandidateAuditState.bEnabled) return;
-
-	const bool bHasRawPerception = PerceptionCandidateAuditState.FirstRawPerceptionTime >= 0.f;
-	const bool bHasValidTarget = PerceptionCandidateAuditState.FirstValidTargetTime >= 0.f;
-
-	const float firstRawLatency = bHasRawPerception
-		? PerceptionCandidateAuditState.FirstRawPerceptionTime - PerceptionCandidateAuditState.RuntimeStartTime
-		: -1.f;
-
-	const float firstValidLatency = bHasValidTarget
-		? PerceptionCandidateAuditState.FirstValidTargetTime - PerceptionCandidateAuditState.RuntimeStartTime
-		: -1.f;
-
-	FLog::Log(FString::Printf(
-		TEXT("[PerceptionCandidateAudit] Owner=%s | RawEvents=%d | RawActors=%d | ValidProviders=%d | InvalidProviders=%d | MaxTargetDataMap=%d | FirstRawLatency=%.3f | FirstValidLatency=%.3f | StartFrame=%llu | FirstRawFrame=%llu | FirstValidFrame=%llu"),
-		*GetNameSafe(ControlledPawn_Cached),
-		PerceptionCandidateAuditState.RawPerceptionEventCount,
-		PerceptionCandidateAuditState.RawPerceptionActors.Num(),
-		PerceptionCandidateAuditState.ValidTargetProviderActors.Num(),
-		PerceptionCandidateAuditState.InvalidTargetProviderActors.Num(),
-		PerceptionCandidateAuditState.MaxTargetDataMapSize,
-		firstRawLatency,
-		firstValidLatency,
-		PerceptionCandidateAuditState.RuntimeStartFrame,
-		PerceptionCandidateAuditState.FirstRawPerceptionFrame,
-		PerceptionCandidateAuditState.FirstValidTargetFrame));
-}
-
-void ACAIController::PrintBlackboardEngageLatencyAuditSummary() const
-{
-	if (!BlackboardEngageLatencyAuditState.bEnabled) return;
-
-	const bool bHasPerceptionContext = BlackboardEngageLatencyAuditState.FirstPerceptionContextTime >= 0.f;
-	const bool bHasBlackboardTarget = BlackboardEngageLatencyAuditState.FirstBlackboardTargetTime >= 0.f;
-	const bool bHasEngageRequest = BlackboardEngageLatencyAuditState.FirstEngageRequestTime >= 0.f;
-	const bool bHasEngageAssignment = BlackboardEngageLatencyAuditState.FirstEngageAssignmentTime >= 0.f;
-
-	const float perceptionContextLatency = bHasPerceptionContext
-		? BlackboardEngageLatencyAuditState.FirstPerceptionContextTime - BlackboardEngageLatencyAuditState.RuntimeStartTime
-		: -1.f;
-
-	const float blackboardTargetLatency = bHasBlackboardTarget
-		? BlackboardEngageLatencyAuditState.FirstBlackboardTargetTime - BlackboardEngageLatencyAuditState.RuntimeStartTime
-		: -1.f;
-
-	const float engageRequestLatency = bHasEngageRequest
-		? BlackboardEngageLatencyAuditState.FirstEngageRequestTime - BlackboardEngageLatencyAuditState.RuntimeStartTime
-		: -1.f;
-
-	const float engageAssignmentLatency = bHasEngageAssignment
-		? BlackboardEngageLatencyAuditState.FirstEngageAssignmentTime - BlackboardEngageLatencyAuditState.RuntimeStartTime
-		: -1.f;
-
-	FLog::Log(FString::Printf(
-		TEXT("[BlackboardEngageLatencyAudit] Owner=%s | PerceptionContextLatency=%.3f | BlackboardTargetLatency=%.3f | EngageRequestLatency=%.3f | EngageAssignmentLatency=%.3f | StartFrame=%llu | PerceptionContextFrame=%llu | BlackboardTargetFrame=%llu | EngageRequestFrame=%llu | EngageAssignmentFrame=%llu | PerceptionTarget=%s | BlackboardTarget=%s | EngageRequestTarget=%s | EngageAssignmentTarget=%s"),
-		*GetNameSafe(ControlledPawn_Cached),
-		perceptionContextLatency,
-		blackboardTargetLatency,
-		engageRequestLatency,
-		engageAssignmentLatency,
-		BlackboardEngageLatencyAuditState.RuntimeStartFrame,
-		BlackboardEngageLatencyAuditState.FirstPerceptionContextFrame,
-		BlackboardEngageLatencyAuditState.FirstBlackboardTargetFrame,
-		BlackboardEngageLatencyAuditState.FirstEngageRequestFrame,
-		BlackboardEngageLatencyAuditState.FirstEngageAssignmentFrame,
-		*GetNameSafe(BlackboardEngageLatencyAuditState.FirstPerceptionTargetActor.Get()),
-		*GetNameSafe(BlackboardEngageLatencyAuditState.FirstBlackboardTargetActor.Get()),
-		*GetNameSafe(BlackboardEngageLatencyAuditState.FirstEngageRequestTargetActor.Get()),
-		*GetNameSafe(BlackboardEngageLatencyAuditState.FirstEngageAssignmentTargetActor.Get())));
-}

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -8,98 +8,6 @@
 
 enum class EAIRuntimeLODTier : uint8;
 
-struct FPerceptionCandidateAuditState
-{
-	bool bEnabled = false;
-
-	float RuntimeStartTime = 0.f;
-	uint64 RuntimeStartFrame = 0;
-
-	float FirstRawPerceptionTime = -1.f;
-	uint64 FirstRawPerceptionFrame = 0;
-
-	float FirstValidTargetTime = -1.f;
-	uint64 FirstValidTargetFrame = 0;
-
-	int32 RawPerceptionEventCount = 0;
-	int32 MaxTargetDataMapSize = 0;
-
-	TSet<TWeakObjectPtr<class AActor>> RawPerceptionActors;
-	TSet<TWeakObjectPtr<class AActor>> ValidTargetProviderActors;
-	TSet<TWeakObjectPtr<class AActor>> InvalidTargetProviderActors;
-
-	void Reset()
-	{
-		bEnabled = false;
-
-		RuntimeStartTime = 0.f;
-		RuntimeStartFrame = 0;
-
-		FirstRawPerceptionTime = -1.f;
-		FirstRawPerceptionFrame = 0;
-
-		FirstValidTargetTime = -1.f;
-		FirstValidTargetFrame = 0;
-
-		RawPerceptionEventCount = 0;
-		MaxTargetDataMapSize = 0;
-
-		RawPerceptionActors.Reset();
-		ValidTargetProviderActors.Reset();
-		InvalidTargetProviderActors.Reset();
-	}
-};
-
-struct FBlackboardEngageLatencyAuditState
-{
-	bool bEnabled = false;
-
-	float RuntimeStartTime = 0.f;
-	uint64 RuntimeStartFrame = 0;
-
-	float FirstPerceptionContextTime = -1.f;
-	uint64 FirstPerceptionContextFrame = 0;
-
-	float FirstBlackboardTargetTime = -1.f;
-	uint64 FirstBlackboardTargetFrame = 0;
-
-	float FirstEngageRequestTime = -1.f;
-	uint64 FirstEngageRequestFrame = 0;
-
-	float FirstEngageAssignmentTime = -1.f;
-	uint64 FirstEngageAssignmentFrame = 0;
-
-	TWeakObjectPtr<class AActor> FirstPerceptionTargetActor;
-	TWeakObjectPtr<class AActor> FirstBlackboardTargetActor;
-	TWeakObjectPtr<class AActor> FirstEngageRequestTargetActor;
-	TWeakObjectPtr<class AActor> FirstEngageAssignmentTargetActor;
-
-	void Reset()
-	{
-		bEnabled = false;
-
-		RuntimeStartTime = 0.f;
-		RuntimeStartFrame = 0;
-
-		FirstPerceptionContextTime = -1.f;
-		FirstPerceptionContextFrame = 0;
-
-		FirstBlackboardTargetTime = -1.f;
-		FirstBlackboardTargetFrame = 0;
-
-		FirstEngageRequestTime = -1.f;
-		FirstEngageRequestFrame = 0;
-
-		FirstEngageAssignmentTime = -1.f;
-		FirstEngageAssignmentFrame = 0;
-
-		FirstPerceptionTargetActor.Reset();
-		FirstBlackboardTargetActor.Reset();
-		FirstEngageRequestTargetActor.Reset();
-		FirstEngageAssignmentTargetActor.Reset();
-	}
-};
-
 UCLASS()
 class PORTFOLIO_API ACAIController : public AAIController
 {
@@ -271,10 +179,6 @@ private:
 	// 2. Condition
 	bool ShouldAuditBlackboardEngageLatency() const;
 
-private:
-	// Profiling Debug
-	void PrintPerceptionCandidateAuditSummary() const;
-	void PrintBlackboardEngageLatencyAuditSummary() const;
 };
 
 

--- a/Source/Portfolio/Core/Debug/FAICombatBTDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FAICombatBTDebug.cpp
@@ -13,6 +13,12 @@ namespace
 		0,
 		TEXT("Print AI combat behavior tree boundary diagnostic hook logs. 0: disabled, 1: enabled."),
 		ECVF_Default);
+
+	TAutoConsoleVariable<int32> CVarCanMoveDecoratorAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.CanMoveDecoratorAudit"),
+		0,
+		TEXT("Print CBTDecorator_CanMove result for runtime LOD debugging. 0: disabled, 1: enabled."),
+		ECVF_Default);
 #endif
 
 	FString FormatAICombatBTController(const AAIController* InAIController)
@@ -54,6 +60,27 @@ bool FAICombatBTDebug::ShouldAuditAICombatBT()
 #else
 	return false;
 #endif
+}
+
+bool FAICombatBTDebug::ShouldAuditCanMoveDecorator()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarCanMoveDecoratorAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
+}
+
+// Can Move Decorator Diagnostic Hook
+
+void FAICombatBTDebug::RecordCanMoveDecoratorResultForAudit(const APawn* InOwnerPawn, bool bInCanMove)
+{
+	if (!ShouldAuditCanMoveDecorator()) return;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|CombatBT|CanMoveDecoratorResult] Owner=%s | CanMove=%s"),
+		*GetNameSafe(InOwnerPawn),
+		bInCanMove ? TEXT("true") : TEXT("false")));
 }
 
 // AI Context / Engage Assignment Diagnostic Hook

--- a/Source/Portfolio/Core/Debug/FAICombatBTDebug.h
+++ b/Source/Portfolio/Core/Debug/FAICombatBTDebug.h
@@ -13,6 +13,11 @@ class PORTFOLIO_API FAICombatBTDebug
 public:
 	// Gate
 	static bool ShouldAuditAICombatBT();
+	static bool ShouldAuditCanMoveDecorator();
+
+public:
+	// Can Move Decorator Diagnostic Hook
+	static void RecordCanMoveDecoratorResultForAudit(const APawn* InOwnerPawn, bool bInCanMove);
 
 public:
 	// AI Context / Engage Assignment Diagnostic Hook

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
@@ -1,5 +1,6 @@
 #include "Core/Debug/FAIPerceptionDebug.h"
 
+#include "Core/Debug/FLog.h"
 #include "HAL/IConsoleManager.h"
 
 namespace
@@ -37,4 +38,79 @@ bool FAIPerceptionDebug::ShouldAuditBlackboardEngageLatency()
 #else
 	return false;
 #endif
+}
+
+// Profiling Audit
+
+void FAIPerceptionDebug::PrintPerceptionCandidateAuditSummary(const AActor* InOwnerActor, const FPerceptionCandidateAuditState& InState)
+{
+	if (!InState.bEnabled) return;
+
+	const bool bHasRawPerception = InState.FirstRawPerceptionTime >= 0.f;
+	const bool bHasValidTarget = InState.FirstValidTargetTime >= 0.f;
+
+	const float firstRawLatency = bHasRawPerception
+		? InState.FirstRawPerceptionTime - InState.RuntimeStartTime
+		: -1.f;
+
+	const float firstValidLatency = bHasValidTarget
+		? InState.FirstValidTargetTime - InState.RuntimeStartTime
+		: -1.f;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|Perception|CandidateAuditSummary] Owner=%s | RawEvents=%d | RawActors=%d | ValidProviders=%d | InvalidProviders=%d | MaxTargetDataMap=%d | FirstRawLatency=%.3f | FirstValidLatency=%.3f | StartFrame=%llu | FirstRawFrame=%llu | FirstValidFrame=%llu"),
+		*GetNameSafe(InOwnerActor),
+		InState.RawPerceptionEventCount,
+		InState.RawPerceptionActors.Num(),
+		InState.ValidTargetProviderActors.Num(),
+		InState.InvalidTargetProviderActors.Num(),
+		InState.MaxTargetDataMapSize,
+		firstRawLatency,
+		firstValidLatency,
+		InState.RuntimeStartFrame,
+		InState.FirstRawPerceptionFrame,
+		InState.FirstValidTargetFrame));
+}
+
+void FAIPerceptionDebug::PrintBlackboardEngageLatencyAuditSummary(const AActor* InOwnerActor, const FBlackboardEngageLatencyAuditState& InState)
+{
+	if (!InState.bEnabled) return;
+
+	const bool bHasPerceptionContext = InState.FirstPerceptionContextTime >= 0.f;
+	const bool bHasBlackboardTarget = InState.FirstBlackboardTargetTime >= 0.f;
+	const bool bHasEngageRequest = InState.FirstEngageRequestTime >= 0.f;
+	const bool bHasEngageAssignment = InState.FirstEngageAssignmentTime >= 0.f;
+
+	const float perceptionContextLatency = bHasPerceptionContext
+		? InState.FirstPerceptionContextTime - InState.RuntimeStartTime
+		: -1.f;
+
+	const float blackboardTargetLatency = bHasBlackboardTarget
+		? InState.FirstBlackboardTargetTime - InState.RuntimeStartTime
+		: -1.f;
+
+	const float engageRequestLatency = bHasEngageRequest
+		? InState.FirstEngageRequestTime - InState.RuntimeStartTime
+		: -1.f;
+
+	const float engageAssignmentLatency = bHasEngageAssignment
+		? InState.FirstEngageAssignmentTime - InState.RuntimeStartTime
+		: -1.f;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|Perception|BlackboardEngageLatencyAuditSummary] Owner=%s | PerceptionContextLatency=%.3f | BlackboardTargetLatency=%.3f | EngageRequestLatency=%.3f | EngageAssignmentLatency=%.3f | StartFrame=%llu | PerceptionContextFrame=%llu | BlackboardTargetFrame=%llu | EngageRequestFrame=%llu | EngageAssignmentFrame=%llu | PerceptionTarget=%s | BlackboardTarget=%s | EngageRequestTarget=%s | EngageAssignmentTarget=%s"),
+		*GetNameSafe(InOwnerActor),
+		perceptionContextLatency,
+		blackboardTargetLatency,
+		engageRequestLatency,
+		engageAssignmentLatency,
+		InState.RuntimeStartFrame,
+		InState.FirstPerceptionContextFrame,
+		InState.FirstBlackboardTargetFrame,
+		InState.FirstEngageRequestFrame,
+		InState.FirstEngageAssignmentFrame,
+		*GetNameSafe(InState.FirstPerceptionTargetActor.Get()),
+		*GetNameSafe(InState.FirstBlackboardTargetActor.Get()),
+		*GetNameSafe(InState.FirstEngageRequestTargetActor.Get()),
+		*GetNameSafe(InState.FirstEngageAssignmentTargetActor.Get())));
 }

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
@@ -1,0 +1,40 @@
+#include "Core/Debug/FAIPerceptionDebug.h"
+
+#include "HAL/IConsoleManager.h"
+
+namespace
+{
+#if !UE_BUILD_SHIPPING
+	TAutoConsoleVariable<int32> CVarPerceptionCandidateAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit"),
+		0,
+		TEXT("Enable Enemy Perception candidate audit for runtime LOD measurement. 0: disabled, 1: enabled."),
+		ECVF_Default);
+
+	TAutoConsoleVariable<int32> CVarBlackboardEngageLatencyAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.BlackboardEngageLatencyAudit"),
+		0,
+		TEXT("Enable Enemy Blackboard / Engage latency audit for runtime LOD measurement. 0: disabled, 1: enabled."),
+		ECVF_Default);
+#endif
+}
+
+// Gate
+
+bool FAIPerceptionDebug::ShouldAuditPerceptionCandidates()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarPerceptionCandidateAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
+}
+
+bool FAIPerceptionDebug::ShouldAuditBlackboardEngageLatency()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarBlackboardEngageLatencyAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
+}

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
@@ -40,7 +40,7 @@ bool FAIPerceptionDebug::ShouldAuditBlackboardEngageLatency()
 #endif
 }
 
-// Profiling Audit
+// Profiling Audit Summary
 
 void FAIPerceptionDebug::PrintPerceptionCandidateAuditSummary(const AActor* InOwnerActor, const FPerceptionCandidateAuditState& InState)
 {

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.h
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Type/CAIStructure.h"
 
 class PORTFOLIO_API FAIPerceptionDebug
 {
@@ -8,4 +9,8 @@ public:
 	// Gate
 	static bool ShouldAuditPerceptionCandidates();
 	static bool ShouldAuditBlackboardEngageLatency();
+
+	// Profiling Audit
+	static void PrintPerceptionCandidateAuditSummary(const AActor* InOwnerActor, const FPerceptionCandidateAuditState& InState);
+	static void PrintBlackboardEngageLatencyAuditSummary(const AActor* InOwnerActor, const FBlackboardEngageLatencyAuditState& InState);
 };

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.h
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.h
@@ -10,7 +10,7 @@ public:
 	static bool ShouldAuditPerceptionCandidates();
 	static bool ShouldAuditBlackboardEngageLatency();
 
-	// Profiling Audit
+	// Profiling Audit Summary
 	static void PrintPerceptionCandidateAuditSummary(const AActor* InOwnerActor, const FPerceptionCandidateAuditState& InState);
 	static void PrintBlackboardEngageLatencyAuditSummary(const AActor* InOwnerActor, const FBlackboardEngageLatencyAuditState& InState);
 };

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.h
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class PORTFOLIO_API FAIPerceptionDebug
+{
+public:
+	// Gate
+	static bool ShouldAuditPerceptionCandidates();
+	static bool ShouldAuditBlackboardEngageLatency();
+};

--- a/Source/Portfolio/Core/Debug/FCombatEngageDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FCombatEngageDebug.cpp
@@ -1,0 +1,218 @@
+#include "Core/Debug/FCombatEngageDebug.h"
+#include "Core/Debug/FLog.h"
+
+#include "Controller/CAIController.h"
+#include "GameFramework/Pawn.h"
+#include "HAL/IConsoleManager.h"
+
+namespace
+{
+#if !UE_BUILD_SHIPPING
+	TAutoConsoleVariable<int32> CVarEngageAssignmentAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentAudit"),
+		0,
+		TEXT("Print minimal CombatEngage assignment warmup audit logs. 0: disabled, 1: enabled."),
+		ECVF_Default);
+
+	TAutoConsoleVariable<int32> CVarEngageAssignmentVerboseAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentVerboseAudit"),
+		0,
+		TEXT("Print detailed CombatEngage assignment candidate logs. 0: disabled, 1: enabled."),
+		ECVF_Default);
+#endif
+}
+
+// Gate
+
+bool FCombatEngageDebug::ShouldAuditEngageAssignment()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarEngageAssignmentAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
+}
+
+bool FCombatEngageDebug::ShouldAuditEngageAssignmentVerbose()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarEngageAssignmentVerboseAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
+}
+
+// Assignment Diagnostic Hook
+
+void FCombatEngageDebug::RecordFreshEngageAssignmentAppliedForAudit(const FEngageRequestContext& InRequestContext, int32 InIndex, ECombatRole InCombatRole, const FEngageAssignmentSlotState& InSlotState, int32 InEngageCap, int32 InAlertCap)
+{
+	if (!ShouldAuditEngageAssignmentVerbose()) return;
+
+	const APawn* controlledPawn = IsValid(InRequestContext.RequestController) ? InRequestContext.RequestController->GetPawn() : nullptr;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|CombatEngage|FreshAssignmentApplied] Controller=%s | Pawn=%s | Target=%s | Priority=%d | Index=%d | Distance=%.3f | CombatRole=%s | EngageSlot=%d/%d | AlertSlot=%d/%d"),
+		*GetNameSafe(InRequestContext.RequestController),
+		*GetNameSafe(controlledPawn),
+		*GetNameSafe(InRequestContext.TargetActor),
+		InRequestContext.TargetPriority,
+		InIndex,
+		InRequestContext.DistanceToTarget,
+		*UEnum::GetValueAsString(InCombatRole),
+		InSlotState.EngageCount,
+		InEngageCap,
+		InSlotState.AlertCount,
+		InAlertCap));
+}
+
+void FCombatEngageDebug::RecordEngageAssignmentPromotedForAudit(const FEngageRequestContext& InRequestContext, const FEngageAssignmentSlotState& InSlotState, int32 InEngageCap, int32 InAlertCap)
+{
+	if (!ShouldAuditEngageAssignmentVerbose()) return;
+
+	const APawn* controlledPawn = IsValid(InRequestContext.RequestController) ? InRequestContext.RequestController->GetPawn() : nullptr;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|CombatEngage|AssignmentPromoted] Controller=%s | Pawn=%s | Target=%s | Priority=%d | Distance=%.3f | PreviousRole=%s | CombatRole=%s | EngageSlot=%d/%d | AlertSlot=%d/%d"),
+		*GetNameSafe(InRequestContext.RequestController),
+		*GetNameSafe(controlledPawn),
+		*GetNameSafe(InRequestContext.TargetActor),
+		InRequestContext.TargetPriority,
+		InRequestContext.DistanceToTarget,
+		*UEnum::GetValueAsString(ECombatRole::Alert),
+		*UEnum::GetValueAsString(ECombatRole::Engage),
+		InSlotState.EngageCount,
+		InEngageCap,
+		InSlotState.AlertCount,
+		InAlertCap));
+}
+
+void FCombatEngageDebug::RecordEngageAssignmentPreservedForAudit(const ACAIController* InAIController, const FEngageAssignmentContext& InAssignment, const FEngageAssignmentSlotState& InSlotState, float InLeaseAge, float InLeaseRemaining, int32 InEngageCap, int32 InAlertCap)
+{
+	if (!ShouldAuditEngageAssignmentVerbose()) return;
+
+	const APawn* controlledPawn = IsValid(InAIController) ? InAIController->GetPawn() : nullptr;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|CombatEngage|AssignmentPreserved] Controller=%s | Pawn=%s | Target=%s | CombatRole=%s | LeaseAge=%.3f | LeaseRemaining=%.3f | EngageSlot=%d/%d | AlertSlot=%d/%d"),
+		*GetNameSafe(InAIController),
+		*GetNameSafe(controlledPawn),
+		*GetNameSafe(InAssignment.TargetActor),
+		*UEnum::GetValueAsString(InAssignment.CombatRole),
+		InLeaseAge,
+		InLeaseRemaining,
+		InSlotState.EngageCount,
+		InEngageCap,
+		InSlotState.AlertCount,
+		InAlertCap));
+}
+
+void FCombatEngageDebug::RecordEngageAssignmentWarmupDelayedForAudit(int32 InRebuildId, int32 InRequestCount, float InWarmupElapsedTime, float InWarmupTime)
+{
+	if (!ShouldAuditEngageAssignment()) return;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|CombatEngage|AssignmentWarmupDelayed] RebuildId=%d | RequestCount=%d | WarmupElapsed=%.3f | WarmupTime=%.3f"),
+		InRebuildId,
+		InRequestCount,
+		InWarmupElapsedTime,
+		InWarmupTime));
+}
+
+void FCombatEngageDebug::RecordEngageRequestSnapshotForAudit(int32 InRebuildId, const TMap<ACAIController*, FEngageRequestContext>& InRequestSnapshot, const TMap<AActor*, TArray<FEngageRequestContext>>& InRequestBucket)
+{
+	if (!ShouldAuditEngageAssignmentVerbose()) return;
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|CombatEngage|RequestSnapshot] RebuildId=%d | RequestCount=%d | TargetBucketCount=%d"),
+		InRebuildId,
+		InRequestSnapshot.Num(),
+		InRequestBucket.Num()));
+
+	for (const TPair<AActor*, TArray<FEngageRequestContext>>& pair : InRequestBucket)
+	{
+		AActor* targetActor = pair.Key;
+		TArray<FEngageRequestContext> requestContexts = pair.Value;
+		requestContexts.Sort([](const FEngageRequestContext& A, const FEngageRequestContext& B)
+			{
+				if (A.TargetPriority != B.TargetPriority)
+				{
+					return A.TargetPriority < B.TargetPriority;
+				}
+
+				if (A.bWasEngaged != B.bWasEngaged)
+				{
+					return A.bWasEngaged;
+				}
+
+				return A.DistanceToTarget < B.DistanceToTarget;
+			});
+
+		FLog::Log(FString::Printf(
+			TEXT("[AI|CombatEngage|RequestBucket] RebuildId=%d | Target=%s | CandidateCount=%d"),
+			InRebuildId,
+			*GetNameSafe(targetActor),
+			requestContexts.Num()));
+
+		for (int32 i = 0; i < requestContexts.Num(); ++i)
+		{
+			const FEngageRequestContext& requestContext = requestContexts[i];
+			const APawn* controlledPawn = IsValid(requestContext.RequestController) ? requestContext.RequestController->GetPawn() : nullptr;
+
+			FLog::Log(FString::Printf(
+				TEXT("[AI|CombatEngage|RequestCandidate] RebuildId=%d | Target=%s | Index=%d | Controller=%s | Pawn=%s | Priority=%d | WasEngaged=%s | Distance=%.3f"),
+				InRebuildId,
+				*GetNameSafe(targetActor),
+				i,
+				*GetNameSafe(requestContext.RequestController),
+				*GetNameSafe(controlledPawn),
+				requestContext.TargetPriority,
+				requestContext.bWasEngaged ? TEXT("true") : TEXT("false"),
+				requestContext.DistanceToTarget));
+		}
+	}
+}
+
+void FCombatEngageDebug::RecordEngageAssignmentRebuildSummaryForAudit(int32 InRebuildId, const FEngageAssignmentRebuildDebugState& InDebugState, const TMap<ACAIController*, FEngageAssignmentContext>& InAssignments, int32 InEngageCap, int32 InAlertCap)
+{
+	if (!ShouldAuditEngageAssignment()) return;
+
+	int32 engageCount = 0;
+	int32 alertCount = 0;
+	int32 noneCount = 0;
+
+	for (const TPair<ACAIController*, FEngageAssignmentContext>& pair : InAssignments)
+	{
+		switch (pair.Value.CombatRole)
+		{
+		case ECombatRole::Engage:
+			++engageCount;
+			break;
+
+		case ECombatRole::Alert:
+			++alertCount;
+			break;
+
+		case ECombatRole::None:
+		default:
+			++noneCount;
+			break;
+		}
+	}
+
+	FLog::Log(FString::Printf(
+		TEXT("[AI|CombatEngage|AssignmentRebuildSummary] RebuildId=%d | EngageCap=%d | AlertCap=%d | RequestSnapshot=%d | TargetBuckets=%d | WarmupRequest=%d | FreshApplied=%d | Promoted=%d | PreservedEngage=%d | PreservedAlert=%d | FinalEngage=%d | FinalAlert=%d | FinalNone=%d | FinalTotal=%d"),
+		InRebuildId,
+		InEngageCap,
+		InAlertCap,
+		InDebugState.RequestSnapshotCount,
+		InDebugState.RequestBucketCount,
+		InDebugState.WarmupRequestCount,
+		InDebugState.FreshAppliedCount,
+		InDebugState.PromotedCount,
+		InDebugState.PreservedEngageCount,
+		InDebugState.PreservedAlertCount,
+		engageCount,
+		alertCount,
+		noneCount,
+		InAssignments.Num()));
+}

--- a/Source/Portfolio/Core/Debug/FCombatEngageDebug.h
+++ b/Source/Portfolio/Core/Debug/FCombatEngageDebug.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Type/CWorldSubSystemStructure.h"
+
+class AActor;
+class ACAIController;
+
+class PORTFOLIO_API FCombatEngageDebug
+{
+public:
+	// Gate
+	static bool ShouldAuditEngageAssignment();
+	static bool ShouldAuditEngageAssignmentVerbose();
+
+public:
+	// Assignment Diagnostic Hook
+	static void RecordFreshEngageAssignmentAppliedForAudit(const FEngageRequestContext& InRequestContext, int32 InIndex, ECombatRole InCombatRole, const FEngageAssignmentSlotState& InSlotState, int32 InEngageCap, int32 InAlertCap);
+	static void RecordEngageAssignmentPromotedForAudit(const FEngageRequestContext& InRequestContext, const FEngageAssignmentSlotState& InSlotState, int32 InEngageCap, int32 InAlertCap);
+	static void RecordEngageAssignmentPreservedForAudit(const ACAIController* InAIController, const FEngageAssignmentContext& InAssignment, const FEngageAssignmentSlotState& InSlotState, float InLeaseAge, float InLeaseRemaining, int32 InEngageCap, int32 InAlertCap);
+	static void RecordEngageAssignmentWarmupDelayedForAudit(int32 InRebuildId, int32 InRequestCount, float InWarmupElapsedTime, float InWarmupTime);
+	static void RecordEngageRequestSnapshotForAudit(int32 InRebuildId, const TMap<ACAIController*, FEngageRequestContext>& InRequestSnapshot, const TMap<AActor*, TArray<FEngageRequestContext>>& InRequestBucket);
+	static void RecordEngageAssignmentRebuildSummaryForAudit(int32 InRebuildId, const FEngageAssignmentRebuildDebugState& InDebugState, const TMap<ACAIController*, FEngageAssignmentContext>& InAssignments, int32 InEngageCap, int32 InAlertCap);
+};

--- a/Source/Portfolio/Core/Debug/FComponentReferenceHelper.h
+++ b/Source/Portfolio/Core/Debug/FComponentReferenceHelper.h
@@ -19,7 +19,7 @@ public:
 
 		if (!ensureMsgf(
 			IsValid(resolvedComponent),
-			TEXT("[ComponentReference|Recovery|Failed] Owner=%s | Component=%s"),
+			TEXT("[ComponentReference|Recovery|Failed] Reason=FindComponentByClassFailed | Owner=%s | Component=%s"),
 			*GetNameSafe(InOwnerActor),
 			*GetNameSafe(TComponent::StaticClass())
 		))

--- a/Source/Portfolio/Core/Debug/FLog.cpp
+++ b/Source/Portfolio/Core/Debug/FLog.cpp
@@ -2,7 +2,8 @@
 
 DEFINE_LOG_CATEGORY_STATIC(Custom_FLog, Display, All);
 
-// === Console Log ===
+// Log Output
+
 void FLog::Log(int32 InValue)
 {
 	UE_LOG(Custom_FLog, Display, TEXT("%d"), InValue);
@@ -44,7 +45,8 @@ void FLog::Log(const UObject* InValue)
 	UE_LOG(Custom_FLog, Display, TEXT("%s (Valid)"), *InValue->GetName());
 }
 
-// === Screen Debug Message ===
+// Screen Output
+
 void FLog::Print(int InValue, int32 InKey, float InDuration, const FColor& InColor)
 {
 	if (GEngine)

--- a/Source/Portfolio/Core/Debug/FLog.h
+++ b/Source/Portfolio/Core/Debug/FLog.h
@@ -5,7 +5,7 @@
 class PORTFOLIO_API FLog
 {
 public:
-	// === Print Log ===
+	// Log Output
 	static void Log(int32 InValue);
 	static void Log(float InValue);
 	static void Log(const FString& InValue);
@@ -13,7 +13,7 @@ public:
 	static void Log(const FRotator& InValue);
 	static void Log(const UObject* InValue);
 
-	// === Print Screen ===
+	// Screen Output
 	static void Print(int InValue, int32 InKey, float InDuration = 10.f, const FColor& InColor = FColor::Blue);
 	static void Print(float InValue, int32 InKey, float InDuration = 10.f, const FColor& InColor = FColor::Blue);
 	static void Print(const FString& InValue, int32 InKey, float InDuration = 10.f, const FColor& InColor = FColor::Blue);

--- a/Source/Portfolio/Core/Debug/FReferenceValidation.h
+++ b/Source/Portfolio/Core/Debug/FReferenceValidation.h
@@ -13,6 +13,11 @@ class FReferenceValidation
 public:
 	static bool EnsureRequiredReference(const UObject* InObject, const TCHAR* InLabel, const UObject* InOwner, const UObject* InContext)
 	{
-		return ensureMsgf(IsValid(InObject), TEXT("Missing required %s | Owner=%s | This=%s"), InLabel, *GetNameSafe(InOwner), *GetNameSafe(InContext));
+		return ensureMsgf(
+			IsValid(InObject),
+			TEXT("[ComponentReference|Validation|RequiredReferenceMissing] Reason=MissingRequiredReference | Owner=%s | Component=%s | Required=%s"),
+			*GetNameSafe(InOwner),
+			*GetNameSafe(InContext),
+			InLabel);
 	}
 };

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
@@ -1,0 +1,23 @@
+#include "Core/Profiling/CAIAnimationProfiling.h"
+
+#include "HAL/IConsoleManager.h"
+
+namespace
+{
+#if !UE_BUILD_SHIPPING
+	TAutoConsoleVariable<int32> CVarAnimationRefreshAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.AnimationRefreshAudit"),
+		0,
+		TEXT("Emit ACEnemy animation parameter refresh CSV counters. 0: disabled, 1: enabled."),
+		ECVF_Default);
+#endif
+}
+
+bool FAIAnimationProfiling::ShouldAuditAnimationRefresh()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarAnimationRefreshAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
+}

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
@@ -1,6 +1,7 @@
 #include "Core/Profiling/CAIAnimationProfiling.h"
 
 #include "HAL/IConsoleManager.h"
+#include "ProfilingDebugging/CsvProfiler.h"
 
 namespace
 {
@@ -20,4 +21,25 @@ bool FAIAnimationProfiling::ShouldAuditAnimationRefresh()
 #else
 	return false;
 #endif
+}
+
+void FAIAnimationProfiling::RecordAnimationRefreshAttemptForProfiling()
+{
+	if (!ShouldAuditAnimationRefresh()) return;
+
+	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Attempt, 1, ECsvCustomStatOp::Accumulate);
+}
+
+void FAIAnimationProfiling::RecordAnimationRefreshExecutedForProfiling()
+{
+	if (!ShouldAuditAnimationRefresh()) return;
+
+	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Executed, 1, ECsvCustomStatOp::Accumulate);
+}
+
+void FAIAnimationProfiling::RecordAnimationRefreshSkippedForProfiling()
+{
+	if (!ShouldAuditAnimationRefresh()) return;
+
+	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Skipped, 1, ECsvCustomStatOp::Accumulate);
 }

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FAIAnimationProfiling
+{
+public:
+	static bool ShouldAuditAnimationRefresh();
+};

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
@@ -5,5 +5,6 @@
 class FAIAnimationProfiling
 {
 public:
+	// Gate
 	static bool ShouldAuditAnimationRefresh();
 };

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
@@ -7,4 +7,9 @@ class FAIAnimationProfiling
 public:
 	// Gate
 	static bool ShouldAuditAnimationRefresh();
+
+	// Counter
+	static void RecordAnimationRefreshAttemptForProfiling();
+	static void RecordAnimationRefreshExecutedForProfiling();
+	static void RecordAnimationRefreshSkippedForProfiling();
 };

--- a/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.cpp
@@ -1,0 +1,46 @@
+#include "Core/Profiling/CAIBehaviorTreeProfiling.h"
+
+#include "AI/BehaviorTree/Service/CBTServiceIntervalHelper.h"
+#include "ProfilingDebugging/CsvProfiler.h"
+
+void FAIBehaviorTreeProfiling::RecordUpdateAIContextTickForProfiling()
+{
+#if !UE_BUILD_SHIPPING
+	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateAIContext_Count, 1, ECsvCustomStatOp::Accumulate);
+#endif
+}
+
+void FAIBehaviorTreeProfiling::RecordUpdateAIIntentStateTickForProfiling()
+{
+#if !UE_BUILD_SHIPPING
+	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateAIIntentState_Count, 1, ECsvCustomStatOp::Accumulate);
+#endif
+}
+
+void FAIBehaviorTreeProfiling::RecordUpdateEngageContextTickForProfiling()
+{
+#if !UE_BUILD_SHIPPING
+	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateEngageContext_Count, 1, ECsvCustomStatOp::Accumulate);
+#endif
+}
+
+void FAIBehaviorTreeProfiling::RecordAIIntentIntervalPresetForProfiling(EBTServiceIntervalPreset InPreset)
+{
+#if !UE_BUILD_SHIPPING
+	switch (InPreset)
+	{
+	case EBTServiceIntervalPreset::Default:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_AIIntentInterval_Default_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+
+	case EBTServiceIntervalPreset::Reduced:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_AIIntentInterval_Reduced_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+
+	case EBTServiceIntervalPreset::Aggressive:
+	default:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_AIIntentInterval_Aggressive_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+	}
+#endif
+}

--- a/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+enum class EBTServiceIntervalPreset : uint8;
+
+class FAIBehaviorTreeProfiling
+{
+public:
+	// Counter
+	static void RecordUpdateAIContextTickForProfiling();
+	static void RecordUpdateAIIntentStateTickForProfiling();
+	static void RecordUpdateEngageContextTickForProfiling();
+	static void RecordAIIntentIntervalPresetForProfiling(EBTServiceIntervalPreset InPreset);
+};

--- a/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.h
@@ -7,9 +7,11 @@ enum class EBTServiceIntervalPreset : uint8;
 class FAIBehaviorTreeProfiling
 {
 public:
-	// Counter
+	// Service Tick Counter
 	static void RecordUpdateAIContextTickForProfiling();
 	static void RecordUpdateAIIntentStateTickForProfiling();
 	static void RecordUpdateEngageContextTickForProfiling();
+
+	// Interval Preset Counter
 	static void RecordAIIntentIntervalPresetForProfiling(EBTServiceIntervalPreset InPreset);
 };

--- a/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.cpp
@@ -1,0 +1,27 @@
+#include "Core/Profiling/CAIPerceptionProfiling.h"
+
+#include "HAL/IConsoleManager.h"
+
+#include "Character/Enemy/CEnemy.h"
+
+namespace
+{
+#if !UE_BUILD_SHIPPING
+	TAutoConsoleVariable<int32> CVarDisableEnemyPerception(
+		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyPerception"),
+		0,
+		TEXT("Disable Enemy AI Perception for runtime LOD measurement. 0: enable perception, 1: disable Enemy perception."),
+		ECVF_Default);
+#endif
+}
+
+bool FAIPerceptionProfiling::ShouldDisableEnemyPerception(const AActor* InOwnerActor)
+{
+#if !UE_BUILD_SHIPPING
+	if (CVarDisableEnemyPerception.GetValueOnGameThread() == 0) return false;
+
+	return IsValid(InOwnerActor) && InOwnerActor->IsA<ACEnemy>();
+#else
+	return false;
+#endif
+}

--- a/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FAIPerceptionProfiling
+{
+public:
+	static bool ShouldDisableEnemyPerception(const class AActor* InOwnerActor);
+};

--- a/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.h
@@ -5,5 +5,6 @@
 class FAIPerceptionProfiling
 {
 public:
+	// Gate
 	static bool ShouldDisableEnemyPerception(const class AActor* InOwnerActor);
 };

--- a/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.cpp
@@ -1,0 +1,53 @@
+#include "Core/Profiling/CAIStateRuntimeLODProfiling.h"
+
+#include "HAL/IConsoleManager.h"
+#include "ProfilingDebugging/CsvProfiler.h"
+
+namespace
+{
+#if !UE_BUILD_SHIPPING
+	TAutoConsoleVariable<int32> CVarStateRuntimeLODAudit(
+		TEXT("Portfolio.AI.RuntimeLOD.StatePolicyAudit"),
+		0,
+		TEXT("Emit AI Runtime LOD state policy tier CSV counters. 0: disabled, 1: enabled."),
+		ECVF_Default);
+#endif
+}
+
+bool FAIStateRuntimeLODProfiling::ShouldAuditStateRuntimeLOD()
+{
+#if !UE_BUILD_SHIPPING
+	return CVarStateRuntimeLODAudit.GetValueOnGameThread() != 0;
+#else
+	return false;
+#endif
+}
+
+void FAIStateRuntimeLODProfiling::RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier)
+{
+	if (!ShouldAuditStateRuntimeLOD()) return;
+
+	switch (InTier)
+	{
+	case EAIRuntimeLODTier::CombatCritical:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_CombatCritical_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+
+	case EAIRuntimeLODTier::CombatSupport:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_CombatSupport_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+
+	case EAIRuntimeLODTier::Awareness:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_Awareness_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+
+	case EAIRuntimeLODTier::Background:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_Background_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+
+	case EAIRuntimeLODTier::Dormant:
+	default:
+		CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_StateLOD_Tier_Dormant_Count, 1, ECsvCustomStatOp::Accumulate);
+		return;
+	}
+}

--- a/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.h
@@ -6,6 +6,9 @@
 class FAIStateRuntimeLODProfiling
 {
 public:
+	// Gate
 	static bool ShouldAuditStateRuntimeLOD();
+
+	// Counter
 	static void RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier);
 };

--- a/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AI/RuntimeLOD/CAIRuntimeLODTierResolver.h"
+
+class FAIStateRuntimeLODProfiling
+{
+public:
+	static bool ShouldAuditStateRuntimeLOD();
+	static void RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier);
+};

--- a/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.cpp
@@ -1,0 +1,49 @@
+#include "Core/Profiling/CCombatCollisionProfiling.h"
+
+#include "HAL/IConsoleManager.h"
+
+#include "Character/Enemy/CEnemy.h"
+
+namespace
+{
+#if !UE_BUILD_SHIPPING
+	TAutoConsoleVariable<int32> CVarDisableEnemyHitProcessing(
+		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyHitProcessing"),
+		0,
+		TEXT("Disable Enemy hit processing for combat collision profiling. 0: process hit, 1: skip Enemy hit processing after overlap."),
+		ECVF_Default);
+
+	TAutoConsoleVariable<int32> CVarDisableEnemyWeaponActor(
+		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor"),
+		0,
+		TEXT("Disable Enemy WeaponActor creation for runtime LOD measurement. 0: spawn WeaponActor, 1: skip Enemy WeaponActor."),
+		ECVF_Default);
+#endif
+
+	bool IsEnemyProfilingTarget(const AActor* InOwnerActor)
+	{
+		return IsValid(InOwnerActor) && InOwnerActor->IsA<ACEnemy>();
+	}
+}
+
+bool FCombatCollisionProfiling::ShouldSkipEnemyHitProcessing(const AActor* InOwnerActor)
+{
+#if !UE_BUILD_SHIPPING
+	if (CVarDisableEnemyHitProcessing.GetValueOnGameThread() == 0) return false;
+
+	return IsEnemyProfilingTarget(InOwnerActor);
+#else
+	return false;
+#endif
+}
+
+bool FCombatCollisionProfiling::ShouldSkipEnemyWeaponActorCreation(const AActor* InOwnerActor)
+{
+#if !UE_BUILD_SHIPPING
+	if (CVarDisableEnemyWeaponActor.GetValueOnGameThread() == 0) return false;
+
+	return IsEnemyProfilingTarget(InOwnerActor);
+#else
+	return false;
+#endif
+}

--- a/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FCombatCollisionProfiling
+{
+public:
+	static bool ShouldSkipEnemyHitProcessing(const class AActor* InOwnerActor);
+	static bool ShouldSkipEnemyWeaponActorCreation(const class AActor* InOwnerActor);
+};

--- a/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.h
@@ -5,6 +5,7 @@
 class FCombatCollisionProfiling
 {
 public:
+	// Gate
 	static bool ShouldSkipEnemyHitProcessing(const class AActor* InOwnerActor);
 	static bool ShouldSkipEnemyWeaponActorCreation(const class AActor* InOwnerActor);
 };

--- a/Source/Portfolio/Core/Profiling/CCombatCollisionProfilingCounters.cpp
+++ b/Source/Portfolio/Core/Profiling/CCombatCollisionProfilingCounters.cpp
@@ -4,53 +4,181 @@
 
 namespace
 {
+#if !UE_BUILD_SHIPPING
+	// Collision Notify Counter
 	int32 CollisionNotifyBeginCount = 0;
 	int32 CollisionNotifyEndCount = 0;
+
+	// Action Collision Window Counter
 	int32 ActionCollisionWindowBeginCount = 0;
 	int32 ActionCollisionWindowEndCount = 0;
+
+	// Weapon Component Counter
 	int32 WeaponComponentOpenCollisionWindowCount = 0;
 	int32 WeaponComponentCloseCollisionWindowCount = 0;
+
+	// Hit Window Counter
 	int32 HitWindowOpenCount = 0;
 	int32 HitWindowCloseCount = 0;
 	int32 HitWindowOverlapCount = 0;
 	int32 HitProcessingCount = 0;
+
+	// Combat Signal Counter
 	int32 CombatSignalCount = 0;
 	int32 CombatSignalCueNotifyCount = 0;
 	int32 ActionCombatSignalCueCount = 0;
 	int32 AICombatSignalCueRequestCount = 0;
 	int32 CombatSignalCueRequestCount = 0;
 	int32 CombatSignalCueSendCount = 0;
+#endif
 }
 
-void FCombatCollisionProfilingCounters::RecordCollisionNotifyBegin() { ++CollisionNotifyBeginCount; }
-void FCombatCollisionProfilingCounters::RecordCollisionNotifyEnd() { ++CollisionNotifyEndCount; }
-void FCombatCollisionProfilingCounters::RecordActionCollisionWindowBegin() { ++ActionCollisionWindowBeginCount; }
-void FCombatCollisionProfilingCounters::RecordActionCollisionWindowEnd() { ++ActionCollisionWindowEndCount; }
-void FCombatCollisionProfilingCounters::RecordWeaponComponentOpenCollisionWindow() { ++WeaponComponentOpenCollisionWindowCount; }
-void FCombatCollisionProfilingCounters::RecordWeaponComponentCloseCollisionWindow() { ++WeaponComponentCloseCollisionWindowCount; }
-void FCombatCollisionProfilingCounters::RecordHitWindowOpen() { ++HitWindowOpenCount; }
-void FCombatCollisionProfilingCounters::RecordHitWindowClose() { ++HitWindowCloseCount; }
-void FCombatCollisionProfilingCounters::RecordHitWindowOverlap() { ++HitWindowOverlapCount; }
-void FCombatCollisionProfilingCounters::RecordHitProcessing() { ++HitProcessingCount; }
-void FCombatCollisionProfilingCounters::RecordCombatSignal() { ++CombatSignalCount; }
-void FCombatCollisionProfilingCounters::RecordCombatSignalCueNotify() { ++CombatSignalCueNotifyCount; }
-void FCombatCollisionProfilingCounters::RecordActionCombatSignalCue() { ++ActionCombatSignalCueCount; }
-void FCombatCollisionProfilingCounters::RecordAICombatSignalCueRequest() { ++AICombatSignalCueRequestCount; }
-void FCombatCollisionProfilingCounters::RecordCombatSignalCueRequest() { ++CombatSignalCueRequestCount; }
-void FCombatCollisionProfilingCounters::RecordCombatSignalCueSend() { ++CombatSignalCueSendCount; }
+// Collision Notify Counter
+
+void FCombatCollisionProfilingCounters::RecordCollisionNotifyBegin()
+{
+#if !UE_BUILD_SHIPPING
+	++CollisionNotifyBeginCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordCollisionNotifyEnd()
+{
+#if !UE_BUILD_SHIPPING
+	++CollisionNotifyEndCount;
+#endif
+}
+
+// Action Collision Window Counter
+
+void FCombatCollisionProfilingCounters::RecordActionCollisionWindowBegin()
+{
+#if !UE_BUILD_SHIPPING
+	++ActionCollisionWindowBeginCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordActionCollisionWindowEnd()
+{
+#if !UE_BUILD_SHIPPING
+	++ActionCollisionWindowEndCount;
+#endif
+}
+
+// Weapon Component Counter
+
+void FCombatCollisionProfilingCounters::RecordWeaponComponentOpenCollisionWindow()
+{
+#if !UE_BUILD_SHIPPING
+	++WeaponComponentOpenCollisionWindowCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordWeaponComponentCloseCollisionWindow()
+{
+#if !UE_BUILD_SHIPPING
+	++WeaponComponentCloseCollisionWindowCount;
+#endif
+}
+
+// Hit Window Counter
+
+void FCombatCollisionProfilingCounters::RecordHitWindowOpen()
+{
+#if !UE_BUILD_SHIPPING
+	++HitWindowOpenCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordHitWindowClose()
+{
+#if !UE_BUILD_SHIPPING
+	++HitWindowCloseCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordHitWindowOverlap()
+{
+#if !UE_BUILD_SHIPPING
+	++HitWindowOverlapCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordHitProcessing()
+{
+#if !UE_BUILD_SHIPPING
+	++HitProcessingCount;
+#endif
+}
+
+// Combat Signal Counter
+
+void FCombatCollisionProfilingCounters::RecordCombatSignal()
+{
+#if !UE_BUILD_SHIPPING
+	++CombatSignalCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordCombatSignalCueNotify()
+{
+#if !UE_BUILD_SHIPPING
+	++CombatSignalCueNotifyCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordActionCombatSignalCue()
+{
+#if !UE_BUILD_SHIPPING
+	++ActionCombatSignalCueCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordAICombatSignalCueRequest()
+{
+#if !UE_BUILD_SHIPPING
+	++AICombatSignalCueRequestCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordCombatSignalCueRequest()
+{
+#if !UE_BUILD_SHIPPING
+	++CombatSignalCueRequestCount;
+#endif
+}
+
+void FCombatCollisionProfilingCounters::RecordCombatSignalCueSend()
+{
+#if !UE_BUILD_SHIPPING
+	++CombatSignalCueSendCount;
+#endif
+}
+
+// Flush
 
 void FCombatCollisionProfilingCounters::FlushToCsv()
 {
+#if !UE_BUILD_SHIPPING
+	// Collision Notify Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_CollisionNotify_Begin_FlushCount, CollisionNotifyBeginCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_CollisionNotify_End_FlushCount, CollisionNotifyEndCount, ECsvCustomStatOp::Accumulate);
+
+	// Action Collision Window Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionCollisionWindow_Begin_FlushCount, ActionCollisionWindowBeginCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionCollisionWindow_End_FlushCount, ActionCollisionWindowEndCount, ECsvCustomStatOp::Accumulate);
+
+	// Weapon Component Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_WeaponComponent_OpenCollisionWindow_FlushCount, WeaponComponentOpenCollisionWindowCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_WeaponComponent_CloseCollisionWindow_FlushCount, WeaponComponentCloseCollisionWindowCount, ECsvCustomStatOp::Accumulate);
+
+	// Hit Window Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitWindow_Open_FlushCount, HitWindowOpenCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitWindow_Close_FlushCount, HitWindowCloseCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitWindow_Overlap_FlushCount, HitWindowOverlapCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitProcessing_FlushCount, HitProcessingCount, ECsvCustomStatOp::Accumulate);
+
+	// Combat Signal Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_CombatSignal_FlushCount, CombatSignalCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_CombatSignalCue_Notify_FlushCount, CombatSignalCueNotifyCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionCombatSignalCue_FlushCount, ActionCombatSignalCueCount, ECsvCustomStatOp::Accumulate);
@@ -58,20 +186,30 @@ void FCombatCollisionProfilingCounters::FlushToCsv()
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_CombatSignalCue_Request_FlushCount, CombatSignalCueRequestCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_CombatSignalCue_Send_FlushCount, CombatSignalCueSendCount, ECsvCustomStatOp::Accumulate);
 
+	// Collision Notify Counter
 	CollisionNotifyBeginCount = 0;
 	CollisionNotifyEndCount = 0;
+
+	// Action Collision Window Counter
 	ActionCollisionWindowBeginCount = 0;
 	ActionCollisionWindowEndCount = 0;
+
+	// Weapon Component Counter
 	WeaponComponentOpenCollisionWindowCount = 0;
 	WeaponComponentCloseCollisionWindowCount = 0;
+
+	// Hit Window Counter
 	HitWindowOpenCount = 0;
 	HitWindowCloseCount = 0;
 	HitWindowOverlapCount = 0;
 	HitProcessingCount = 0;
+
+	// Combat Signal Counter
 	CombatSignalCount = 0;
 	CombatSignalCueNotifyCount = 0;
 	ActionCombatSignalCueCount = 0;
 	AICombatSignalCueRequestCount = 0;
 	CombatSignalCueRequestCount = 0;
 	CombatSignalCueSendCount = 0;
+#endif
 }

--- a/Source/Portfolio/Core/Profiling/CCombatCollisionProfilingCounters.h
+++ b/Source/Portfolio/Core/Profiling/CCombatCollisionProfilingCounters.h
@@ -5,16 +5,25 @@
 class FCombatCollisionProfilingCounters
 {
 public:
+	// Collision Notify Counter
 	static void RecordCollisionNotifyBegin();
 	static void RecordCollisionNotifyEnd();
+
+	// Action Collision Window Counter
 	static void RecordActionCollisionWindowBegin();
 	static void RecordActionCollisionWindowEnd();
+
+	// Weapon Component Counter
 	static void RecordWeaponComponentOpenCollisionWindow();
 	static void RecordWeaponComponentCloseCollisionWindow();
+
+	// Hit Window Counter
 	static void RecordHitWindowOpen();
 	static void RecordHitWindowClose();
 	static void RecordHitWindowOverlap();
 	static void RecordHitProcessing();
+
+	// Combat Signal Counter
 	static void RecordCombatSignal();
 	static void RecordCombatSignalCueNotify();
 	static void RecordActionCombatSignalCue();
@@ -22,5 +31,6 @@ public:
 	static void RecordCombatSignalCueRequest();
 	static void RecordCombatSignalCueSend();
 
+	// Flush
 	static void FlushToCsv();
 };

--- a/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.cpp
@@ -13,8 +13,8 @@ namespace
 		0,
 		TEXT("Disable Enemy combat feedback presentation for runtime LOD profiling. 0: play feedback, 1: skip Enemy feedback presentation."),
 		ECVF_Default);
-#endif
 
+	// Action Counter
 	int32 ActionFeedbackRequestCount = 0;
 	int32 ActionFeedbackSkippedCount = 0;
 	int32 ActionTrailCount = 0;
@@ -22,17 +22,22 @@ namespace
 	int32 ActionVFXCount = 0;
 	int32 ActionSFXCount = 0;
 
+	// Reaction Counter
 	int32 ReactionFeedbackRequestCount = 0;
 	int32 ReactionFeedbackSkippedCount = 0;
 	int32 ReactionVFXCount = 0;
 	int32 ReactionSFXCount = 0;
 
+	// Hit Counter
 	int32 HitFeedbackRequestCount = 0;
 	int32 HitFeedbackPresentationSkippedCount = 0;
 	int32 HitVFXCount = 0;
 	int32 HitSFXCount = 0;
 	int32 CameraShakeRequestCount = 0;
+#endif
 }
+
+// Gate
 
 bool FCombatFeedbackProfiling::ShouldSkipEnemyCombatFeedback(const AActor* InOwnerActor)
 {
@@ -45,10 +50,25 @@ bool FCombatFeedbackProfiling::ShouldSkipEnemyCombatFeedback(const AActor* InOwn
 #endif
 }
 
-void FCombatFeedbackProfiling::RecordActionFeedbackRequest() { ++ActionFeedbackRequestCount; }
-void FCombatFeedbackProfiling::RecordActionFeedbackSkipped() { ++ActionFeedbackSkippedCount; }
+// Action Counter
+
+void FCombatFeedbackProfiling::RecordActionFeedbackRequest()
+{
+#if !UE_BUILD_SHIPPING
+	++ActionFeedbackRequestCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordActionFeedbackSkipped()
+{
+#if !UE_BUILD_SHIPPING
+	++ActionFeedbackSkippedCount;
+#endif
+}
+
 void FCombatFeedbackProfiling::RecordActionTrail(bool bActive)
 {
+#if !UE_BUILD_SHIPPING
 	if (bActive)
 	{
 		++ActionTrailCount;
@@ -56,23 +76,96 @@ void FCombatFeedbackProfiling::RecordActionTrail(bool bActive)
 	}
 
 	++ActionTrailClearCount;
+#endif
 }
-void FCombatFeedbackProfiling::RecordActionVFX() { ++ActionVFXCount; }
-void FCombatFeedbackProfiling::RecordActionSFX() { ++ActionSFXCount; }
 
-void FCombatFeedbackProfiling::RecordReactionFeedbackRequest() { ++ReactionFeedbackRequestCount; }
-void FCombatFeedbackProfiling::RecordReactionFeedbackSkipped() { ++ReactionFeedbackSkippedCount; }
-void FCombatFeedbackProfiling::RecordReactionVFX() { ++ReactionVFXCount; }
-void FCombatFeedbackProfiling::RecordReactionSFX() { ++ReactionSFXCount; }
+void FCombatFeedbackProfiling::RecordActionVFX()
+{
+#if !UE_BUILD_SHIPPING
+	++ActionVFXCount;
+#endif
+}
 
-void FCombatFeedbackProfiling::RecordHitFeedbackRequest() { ++HitFeedbackRequestCount; }
-void FCombatFeedbackProfiling::RecordHitFeedbackPresentationSkipped() { ++HitFeedbackPresentationSkippedCount; }
-void FCombatFeedbackProfiling::RecordHitVFX() { ++HitVFXCount; }
-void FCombatFeedbackProfiling::RecordHitSFX() { ++HitSFXCount; }
-void FCombatFeedbackProfiling::RecordCameraShakeRequest() { ++CameraShakeRequestCount; }
+void FCombatFeedbackProfiling::RecordActionSFX()
+{
+#if !UE_BUILD_SHIPPING
+	++ActionSFXCount;
+#endif
+}
+
+// Reaction Counter
+
+void FCombatFeedbackProfiling::RecordReactionFeedbackRequest()
+{
+#if !UE_BUILD_SHIPPING
+	++ReactionFeedbackRequestCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordReactionFeedbackSkipped()
+{
+#if !UE_BUILD_SHIPPING
+	++ReactionFeedbackSkippedCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordReactionVFX()
+{
+#if !UE_BUILD_SHIPPING
+	++ReactionVFXCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordReactionSFX()
+{
+#if !UE_BUILD_SHIPPING
+	++ReactionSFXCount;
+#endif
+}
+
+// Hit Counter
+
+void FCombatFeedbackProfiling::RecordHitFeedbackRequest()
+{
+#if !UE_BUILD_SHIPPING
+	++HitFeedbackRequestCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordHitFeedbackPresentationSkipped()
+{
+#if !UE_BUILD_SHIPPING
+	++HitFeedbackPresentationSkippedCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordHitVFX()
+{
+#if !UE_BUILD_SHIPPING
+	++HitVFXCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordHitSFX()
+{
+#if !UE_BUILD_SHIPPING
+	++HitSFXCount;
+#endif
+}
+
+void FCombatFeedbackProfiling::RecordCameraShakeRequest()
+{
+#if !UE_BUILD_SHIPPING
+	++CameraShakeRequestCount;
+#endif
+}
+
+// Flush
 
 void FCombatFeedbackProfiling::FlushToCsv()
 {
+#if !UE_BUILD_SHIPPING
+	// Action Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionFeedback_Request_FlushCount, ActionFeedbackRequestCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionFeedback_Skipped_FlushCount, ActionFeedbackSkippedCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionFeedback_Trail_FlushCount, ActionTrailCount, ECsvCustomStatOp::Accumulate);
@@ -80,17 +173,20 @@ void FCombatFeedbackProfiling::FlushToCsv()
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionFeedback_VFX_FlushCount, ActionVFXCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ActionFeedback_SFX_FlushCount, ActionSFXCount, ECsvCustomStatOp::Accumulate);
 
+	// Reaction Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ReactionFeedback_Request_FlushCount, ReactionFeedbackRequestCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ReactionFeedback_Skipped_FlushCount, ReactionFeedbackSkippedCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ReactionFeedback_VFX_FlushCount, ReactionVFXCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_ReactionFeedback_SFX_FlushCount, ReactionSFXCount, ECsvCustomStatOp::Accumulate);
 
+	// Hit Counter
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitFeedback_Request_FlushCount, HitFeedbackRequestCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitFeedback_PresentationSkipped_FlushCount, HitFeedbackPresentationSkippedCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitFeedback_VFX_FlushCount, HitVFXCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitFeedback_SFX_FlushCount, HitSFXCount, ECsvCustomStatOp::Accumulate);
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_HitFeedback_CameraShakeRequest_FlushCount, CameraShakeRequestCount, ECsvCustomStatOp::Accumulate);
 
+	// Action Counter
 	ActionFeedbackRequestCount = 0;
 	ActionFeedbackSkippedCount = 0;
 	ActionTrailCount = 0;
@@ -98,14 +194,17 @@ void FCombatFeedbackProfiling::FlushToCsv()
 	ActionVFXCount = 0;
 	ActionSFXCount = 0;
 
+	// Reaction Counter
 	ReactionFeedbackRequestCount = 0;
 	ReactionFeedbackSkippedCount = 0;
 	ReactionVFXCount = 0;
 	ReactionSFXCount = 0;
 
+	// Hit Counter
 	HitFeedbackRequestCount = 0;
 	HitFeedbackPresentationSkippedCount = 0;
 	HitVFXCount = 0;
 	HitSFXCount = 0;
 	CameraShakeRequestCount = 0;
+#endif
 }

--- a/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.cpp
@@ -7,11 +7,13 @@
 
 namespace
 {
+#if !UE_BUILD_SHIPPING
 	TAutoConsoleVariable<int32> CVarDisableEnemyCombatFeedback(
 		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyCombatFeedback"),
 		0,
 		TEXT("Disable Enemy combat feedback presentation for runtime LOD profiling. 0: play feedback, 1: skip Enemy feedback presentation."),
 		ECVF_Default);
+#endif
 
 	int32 ActionFeedbackRequestCount = 0;
 	int32 ActionFeedbackSkippedCount = 0;
@@ -34,9 +36,13 @@ namespace
 
 bool FCombatFeedbackProfiling::ShouldSkipEnemyCombatFeedback(const AActor* InOwnerActor)
 {
+#if !UE_BUILD_SHIPPING
 	if (CVarDisableEnemyCombatFeedback.GetValueOnGameThread() == 0) return false;
 
 	return IsValid(InOwnerActor) && InOwnerActor->IsA<ACEnemy>();
+#else
+	return false;
+#endif
 }
 
 void FCombatFeedbackProfiling::RecordActionFeedbackRequest() { ++ActionFeedbackRequestCount; }

--- a/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.h
@@ -5,24 +5,29 @@
 class FCombatFeedbackProfiling
 {
 public:
+	// Gate
 	static bool ShouldSkipEnemyCombatFeedback(const class AActor* InOwnerActor);
 
+	// Action Counter
 	static void RecordActionFeedbackRequest();
 	static void RecordActionFeedbackSkipped();
 	static void RecordActionTrail(bool bActive);
 	static void RecordActionVFX();
 	static void RecordActionSFX();
 
+	// Reaction Counter
 	static void RecordReactionFeedbackRequest();
 	static void RecordReactionFeedbackSkipped();
 	static void RecordReactionVFX();
 	static void RecordReactionSFX();
 
+	// Hit Counter
 	static void RecordHitFeedbackRequest();
 	static void RecordHitFeedbackPresentationSkipped();
 	static void RecordHitVFX();
 	static void RecordHitSFX();
 	static void RecordCameraShakeRequest();
 
+	// Flush
 	static void FlushToCsv();
 };

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -6,6 +6,7 @@
 #include "AIController.h"
 
 #include "Controller/CAIController.h"
+#include "Core/Debug/FCombatEngageDebug.h"
 #include "Core/Profiling/CCombatCollisionProfilingCounters.h"
 #include "Core/Profiling/CCombatFeedbackProfiling.h"
 
@@ -18,20 +19,6 @@ namespace
 		0.0f,
 		TEXT("Delays the first CombatEngage assignment rebuild until request candidates are warmed up. 0: disabled."),
 		ECVF_Default);
-
-#if !UE_BUILD_SHIPPING
-	TAutoConsoleVariable<int32> CVarEngageAssignmentAudit(
-		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentAudit"),
-		0,
-		TEXT("Print minimal CombatEngage assignment warmup audit logs. 0: disabled, 1: enabled."),
-		ECVF_Default);
-
-	TAutoConsoleVariable<int32> CVarEngageAssignmentVerboseAudit(
-		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentVerboseAudit"),
-		0,
-		TEXT("Print detailed CombatEngage assignment candidate logs. 0: disabled, 1: enabled."),
-		ECVF_Default);
-#endif
 
 	TAutoConsoleVariable<int32> CVarEngageAssignmentEngageCap(
 		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentEngageCap"),
@@ -58,24 +45,6 @@ namespace
 	int32 GetEngageAssignmentAlertCap()
 	{
 		return FMath::Max(0, CVarEngageAssignmentAlertCap.GetValueOnGameThread());
-	}
-
-	bool ShouldPrintEngageAssignmentAudit()
-	{
-#if !UE_BUILD_SHIPPING
-		return CVarEngageAssignmentAudit.GetValueOnGameThread() != 0;
-#else
-		return false;
-#endif
-	}
-
-	bool ShouldPrintEngageAssignmentVerboseAudit()
-	{
-#if !UE_BUILD_SHIPPING
-		return CVarEngageAssignmentVerboseAudit.GetValueOnGameThread() != 0;
-#else
-		return false;
-#endif
 	}
 }
 
@@ -150,10 +119,7 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 	// Delay for Warmup
 	if (ShouldDelayAssignmentForWarmup())
 	{
-		if (ShouldPrintEngageAssignmentAudit())
-		{
-			PrintAssignmentWarmupDelay(AssignmentRebuildId);
-		}
+		FCombatEngageDebug::RecordEngageAssignmentWarmupDelayedForAudit(AssignmentRebuildId, RequestContainer.Num(), GetAssignmentWarmupElapsedTime(), GetEngageAssignmentWarmupTime());
 
 		return;
 	}
@@ -181,9 +147,9 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 	rebuildDebugState.RequestSnapshotCount = requestSnapshot.Num();
 	rebuildDebugState.RequestBucketCount = requestBucket.Num();
 
-	if (ShouldPrintEngageAssignmentVerboseAudit())
+	if (FCombatEngageDebug::ShouldAuditEngageAssignmentVerbose())
 	{
-		PrintEngageRequestSnapshot(AssignmentRebuildId, requestSnapshot, requestBucket);
+		FCombatEngageDebug::RecordEngageRequestSnapshotForAudit(AssignmentRebuildId, requestSnapshot, requestBucket);
 	}
 
 	PreserveExistingEngageAssignments(nextAssignments, slotState, rebuildDebugState);
@@ -191,9 +157,9 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 	PreserveExistingAlertAssignments(nextAssignments, slotState, rebuildDebugState);
 	ApplyFreshRequestAssignments(requestBucket, nextAssignments, slotState, rebuildDebugState);
 
-	if (ShouldPrintEngageAssignmentAudit() && (bCompletedWarmupThisRebuild || AssignmentRebuildId == 1))
+	if (FCombatEngageDebug::ShouldAuditEngageAssignment() && (bCompletedWarmupThisRebuild || AssignmentRebuildId == 1))
 	{
-		PrintEngageAssignmentRebuildSummary(AssignmentRebuildId, rebuildDebugState, nextAssignments);
+		FCombatEngageDebug::RecordEngageAssignmentRebuildSummaryForAudit(AssignmentRebuildId, rebuildDebugState, nextAssignments, GetEngageAssignmentEngageCap(), GetEngageAssignmentAlertCap());
 	}
 
 	AssignmentContainer = MoveTemp(nextAssignments);
@@ -288,9 +254,14 @@ void UCWorldSubsystem_CombatEngage::PreserveExistingEngageAssignments(TMap<ACAIC
 		++InOutDebugState.PreservedEngageCount;
 
 		const FEngageAssignmentSlotState& targetSlotState = InOutSlotState.FindChecked(previousAssignment.TargetActor);
-		if (ShouldPrintEngageAssignmentVerboseAudit())
+		if (FCombatEngageDebug::ShouldAuditEngageAssignmentVerbose())
 		{
-			PrintPreservedAssignment(aiController, previousAssignment, targetSlotState);
+			const float* lastRequestTime = LastRequestTimeContainer.Find(aiController);
+			const UWorld* world = GetWorld();
+			const float currentTime = IsValid(world) ? world->GetTimeSeconds() : 0.f;
+			const float leaseAge = lastRequestTime ? currentTime - *lastRequestTime : -1.f;
+			const float leaseRemaining = lastRequestTime ? FMath::Max(0.f, AssignmentLeaseDuration - leaseAge) : 0.f;
+			FCombatEngageDebug::RecordEngageAssignmentPreservedForAudit(aiController, previousAssignment, targetSlotState, leaseAge, leaseRemaining, GetEngageAssignmentEngageCap(), GetEngageAssignmentAlertCap());
 		}
 	}
 }
@@ -330,9 +301,9 @@ void UCWorldSubsystem_CombatEngage::PromoteExistingAlertAssignments(const TMap<A
 			++InOutDebugState.PromotedCount;
 
 			const FEngageAssignmentSlotState& targetSlotState = InOutSlotState.FindChecked(targetActor);
-			if (ShouldPrintEngageAssignmentVerboseAudit())
+			if (FCombatEngageDebug::ShouldAuditEngageAssignmentVerbose())
 			{
-				PrintPromotedEngageAssignment(requestContexts[i], targetSlotState);
+				FCombatEngageDebug::RecordEngageAssignmentPromotedForAudit(requestContexts[i], targetSlotState, GetEngageAssignmentEngageCap(), GetEngageAssignmentAlertCap());
 			}
 		}
 	}
@@ -359,9 +330,14 @@ void UCWorldSubsystem_CombatEngage::PreserveExistingAlertAssignments(TMap<ACAICo
 		++InOutDebugState.PreservedAlertCount;
 
 		const FEngageAssignmentSlotState& targetSlotState = InOutSlotState.FindChecked(previousAssignment.TargetActor);
-		if (ShouldPrintEngageAssignmentVerboseAudit())
+		if (FCombatEngageDebug::ShouldAuditEngageAssignmentVerbose())
 		{
-			PrintPreservedAssignment(aiController, previousAssignment, targetSlotState);
+			const float* lastRequestTime = LastRequestTimeContainer.Find(aiController);
+			const UWorld* world = GetWorld();
+			const float currentTime = IsValid(world) ? world->GetTimeSeconds() : 0.f;
+			const float leaseAge = lastRequestTime ? currentTime - *lastRequestTime : -1.f;
+			const float leaseRemaining = lastRequestTime ? FMath::Max(0.f, AssignmentLeaseDuration - leaseAge) : 0.f;
+			FCombatEngageDebug::RecordEngageAssignmentPreservedForAudit(aiController, previousAssignment, targetSlotState, leaseAge, leaseRemaining, GetEngageAssignmentEngageCap(), GetEngageAssignmentAlertCap());
 		}
 	}
 }
@@ -405,9 +381,9 @@ void UCWorldSubsystem_CombatEngage::ApplyFreshRequestAssignments(const TMap<AAct
 			++InOutDebugState.FreshAppliedCount;
 
 			const FEngageAssignmentSlotState& updatedSlotState = InOutSlotState.FindChecked(targetActor);
-			if (ShouldPrintEngageAssignmentVerboseAudit())
+			if (FCombatEngageDebug::ShouldAuditEngageAssignmentVerbose())
 			{
-				PrintAppliedFreshEngageAssignment(requestContexts[i], i, freshAssignment.CombatRole, updatedSlotState);
+				FCombatEngageDebug::RecordFreshEngageAssignmentAppliedForAudit(requestContexts[i], i, freshAssignment.CombatRole, updatedSlotState, GetEngageAssignmentEngageCap(), GetEngageAssignmentAlertCap());
 			}
 		}
 	}
@@ -462,162 +438,4 @@ void UCWorldSubsystem_CombatEngage::ClearEngageRuntimeState()
 	RequestContainer.Reset();
 	LastRequestTimeContainer.Reset();
 	AssignmentContainer.Reset();
-}
-
-// Debug
-
-void UCWorldSubsystem_CombatEngage::PrintAppliedFreshEngageAssignment(const FEngageRequestContext& InRequestContext, const int& InIndex, const ECombatRole& InCombatRole, const FEngageAssignmentSlotState& InSlotState) const
-{
-	if (!ShouldPrintEngageAssignmentVerboseAudit()) return;
-
-	const APawn* controlledPawn = IsValid(InRequestContext.RequestController) ? InRequestContext.RequestController->GetPawn() : nullptr;
-
-	FLog::Log(TEXT("==== AppliedFreshEngageAssignment ===="));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("AIController"), *GetNameSafe(InRequestContext.RequestController)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("ControlledPawn"), *GetNameSafe(controlledPawn)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("TargetActor"), *GetNameSafe(InRequestContext.TargetActor)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("Priority"), InRequestContext.TargetPriority));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("Index"), InIndex));
-	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("DistanceToTarget"), InRequestContext.DistanceToTarget));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("CombatRole"), *UEnum::GetValueAsString(InCombatRole)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d / %d"), TEXT("EngageSlot"), InSlotState.EngageCount, GetEngageAssignmentEngageCap()));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d / %d"), TEXT("AlertSlot"), InSlotState.AlertCount, GetEngageAssignmentAlertCap()));
-	FLog::Log(TEXT("===================================="));
-}
-
-void UCWorldSubsystem_CombatEngage::PrintPromotedEngageAssignment(const FEngageRequestContext& InRequestContext, const FEngageAssignmentSlotState& InSlotState) const
-{
-	if (!ShouldPrintEngageAssignmentVerboseAudit()) return;
-
-	const APawn* controlledPawn = IsValid(InRequestContext.RequestController) ? InRequestContext.RequestController->GetPawn() : nullptr;
-
-	FLog::Log(TEXT("==== PromotedEngageAssignment ===="));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("AIController"), *GetNameSafe(InRequestContext.RequestController)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("ControlledPawn"), *GetNameSafe(controlledPawn)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("TargetActor"), *GetNameSafe(InRequestContext.TargetActor)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("Priority"), InRequestContext.TargetPriority));
-	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("DistanceToTarget"), InRequestContext.DistanceToTarget));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("PreviousRole"), *UEnum::GetValueAsString(ECombatRole::Alert)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("CombatRole"), *UEnum::GetValueAsString(ECombatRole::Engage)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d / %d"), TEXT("EngageSlot"), InSlotState.EngageCount, GetEngageAssignmentEngageCap()));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d / %d"), TEXT("AlertSlot"), InSlotState.AlertCount, GetEngageAssignmentAlertCap()));
-	FLog::Log(TEXT("=================================="));
-}
-
-void UCWorldSubsystem_CombatEngage::PrintPreservedAssignment(const ACAIController* InCAIController, const FEngageAssignmentContext& InAssignment, const FEngageAssignmentSlotState& InSlotState) const
-{
-	if (!ShouldPrintEngageAssignmentVerboseAudit()) return;
-
-	const APawn* controlledPawn = IsValid(InCAIController) ? InCAIController->GetPawn() : nullptr;
-	const float* lastRequestTime = LastRequestTimeContainer.Find(InCAIController);
-
-	const UWorld* world = GetWorld();
-	const float currentTime = IsValid(world) ? world->GetTimeSeconds() : 0.f;
-	const float leaseAge = lastRequestTime ? currentTime - *lastRequestTime : -1.f;
-	const float leaseRemaining = lastRequestTime ? FMath::Max(0.f, AssignmentLeaseDuration - leaseAge) : 0.f;
-
-	FLog::Log(TEXT("==== PreservedAssignment ===="));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("AIController"), *GetNameSafe(InCAIController)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("ControlledPawn"), *GetNameSafe(controlledPawn)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("TargetActor"), *GetNameSafe(InAssignment.TargetActor)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("CombatRole"), *UEnum::GetValueAsString(InAssignment.CombatRole)));
-	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("LeaseAge"), leaseAge));
-	FLog::Log(FString::Printf(TEXT("%-20s: %.3f"), TEXT("LeaseRemaining"), leaseRemaining));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d / %d"), TEXT("EngageSlot"), InSlotState.EngageCount, GetEngageAssignmentEngageCap()));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d / %d"), TEXT("AlertSlot"), InSlotState.AlertCount, GetEngageAssignmentAlertCap()));
-	FLog::Log(TEXT("============================="));
-}
-
-void UCWorldSubsystem_CombatEngage::PrintAssignmentWarmupDelay(const int& InRebuildId) const
-{
-	if (!ShouldPrintEngageAssignmentAudit()) return;
-
-	FLog::Log(FString::Printf(
-		TEXT("[EngageAssignmentWarmupDelay] RebuildId=%d | RequestCount=%d | WarmupElapsed=%.3f | WarmupTime=%.3f"),
-		InRebuildId,
-		RequestContainer.Num(),
-		GetAssignmentWarmupElapsedTime(),
-		GetEngageAssignmentWarmupTime()));
-}
-
-void UCWorldSubsystem_CombatEngage::PrintEngageRequestSnapshot(const int& InRebuildId, const TMap<ACAIController*, FEngageRequestContext>& InRequestSnapshot, const TMap<AActor*, TArray<FEngageRequestContext>>& InRequestBucket) const
-{
-	if (!ShouldPrintEngageAssignmentVerboseAudit()) return;
-
-	FLog::Log(TEXT("==== EngageRequestSnapshot ===="));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("RebuildId"), InRebuildId));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("RequestCount"), InRequestSnapshot.Num()));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("TargetBucketCount"), InRequestBucket.Num()));
-
-	for (const TPair<AActor*, TArray<FEngageRequestContext>>& pair : InRequestBucket)
-	{
-		AActor* targetActor = pair.Key;
-		TArray<FEngageRequestContext> requestContexts = pair.Value;
-		SortRequestContexts(requestContexts);
-
-		FLog::Log(FString::Printf(TEXT("%-20s: %s"), TEXT("TargetActor"), *GetNameSafe(targetActor)));
-		FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("CandidateCount"), requestContexts.Num()));
-
-		for (int32 i = 0; i < requestContexts.Num(); ++i)
-		{
-			const FEngageRequestContext& requestContext = requestContexts[i];
-			const APawn* controlledPawn = IsValid(requestContext.RequestController) ? requestContext.RequestController->GetPawn() : nullptr;
-
-			FLog::Log(FString::Printf(
-				TEXT("  [%02d] Controller=%s | Pawn=%s | Priority=%d | WasEngaged=%s | Distance=%.3f"),
-				i,
-				*GetNameSafe(requestContext.RequestController),
-				*GetNameSafe(controlledPawn),
-				requestContext.TargetPriority,
-				requestContext.bWasEngaged ? TEXT("true") : TEXT("false"),
-				requestContext.DistanceToTarget));
-		}
-	}
-
-	FLog::Log(TEXT("==============================="));
-}
-
-void UCWorldSubsystem_CombatEngage::PrintEngageAssignmentRebuildSummary(const int& InRebuildId, const FEngageAssignmentRebuildDebugState& InDebugState, const TMap<ACAIController*, FEngageAssignmentContext>& InAssignments) const
-{
-	if (!ShouldPrintEngageAssignmentAudit()) return;
-
-	int32 engageCount = 0;
-	int32 alertCount = 0;
-	int32 noneCount = 0;
-
-	for (const TPair<ACAIController*, FEngageAssignmentContext>& pair : InAssignments)
-	{
-		switch (pair.Value.CombatRole)
-		{
-		case ECombatRole::Engage:
-			++engageCount;
-			break;
-
-		case ECombatRole::Alert:
-			++alertCount;
-			break;
-
-		case ECombatRole::None:
-		default:
-			++noneCount;
-			break;
-		}
-	}
-
-	FLog::Log(TEXT("==== EngageAssignmentRebuildSummary ===="));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("RebuildId"), InRebuildId));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("EngageCap"), GetEngageAssignmentEngageCap()));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("AlertCap"), GetEngageAssignmentAlertCap()));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("RequestSnapshot"), InDebugState.RequestSnapshotCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("TargetBuckets"), InDebugState.RequestBucketCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("WarmupRequest"), InDebugState.WarmupRequestCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("FreshApplied"), InDebugState.FreshAppliedCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("Promoted"), InDebugState.PromotedCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("PreservedEngage"), InDebugState.PreservedEngageCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("PreservedAlert"), InDebugState.PreservedAlertCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("FinalEngage"), engageCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("FinalAlert"), alertCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("FinalNone"), noneCount));
-	FLog::Log(FString::Printf(TEXT("%-20s: %d"), TEXT("FinalTotal"), InAssignments.Num()));
-	FLog::Log(TEXT("========================================"));
 }

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -23,13 +23,13 @@ namespace
 	TAutoConsoleVariable<int32> CVarEngageAssignmentEngageCap(
 		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentEngageCap"),
 		2,
-		TEXT("Controls max Engage assignees per target for AI Runtime LOD profiling. Default: 2."),
+		TEXT("Controls max Engage assignees per target for AI Runtime LOD assignment. Default: 2."),
 		ECVF_Default);
 
 	TAutoConsoleVariable<int32> CVarEngageAssignmentAlertCap(
 		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentAlertCap"),
 		6,
-		TEXT("Controls max Alert assignees per target for AI Runtime LOD profiling. Default: 6."),
+		TEXT("Controls max Alert assignees per target for AI Runtime LOD assignment. Default: 6."),
 		ECVF_Default);
 
 	float GetEngageAssignmentWarmupTime()

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
@@ -5,23 +5,6 @@
 #include "Type/CWorldSubSystemStructure.h"
 #include "CWorldSubsystem_CombatEngage.generated.h"
 
-struct FEngageAssignmentSlotState
-{
-	int32 EngageCount = 0;
-	int32 AlertCount = 0;
-};
-
-struct FEngageAssignmentRebuildDebugState
-{
-	int32 RequestSnapshotCount = 0;
-	int32 RequestBucketCount = 0;
-	int32 WarmupRequestCount = 0;
-	int32 FreshAppliedCount = 0;
-	int32 PromotedCount = 0;
-	int32 PreservedEngageCount = 0;
-	int32 PreservedAlertCount = 0;
-};
-
 UCLASS()
 class PORTFOLIO_API UCWorldSubsystem_CombatEngage : public UTickableWorldSubsystem
 {
@@ -99,13 +82,4 @@ private:
 private:
 	// Runtime State
 	void ClearEngageRuntimeState();
-
-private:
-	// Debug
-	void PrintAppliedFreshEngageAssignment(const FEngageRequestContext& InRequestContext, const int& InIndex, const ECombatRole& InCombatRole, const FEngageAssignmentSlotState& InSlotState) const;
-	void PrintPromotedEngageAssignment(const FEngageRequestContext& InRequestContext, const FEngageAssignmentSlotState& InSlotState) const;
-	void PrintPreservedAssignment(const ACAIController* InCAIController, const FEngageAssignmentContext& InAssignment, const FEngageAssignmentSlotState& InSlotState) const;
-	void PrintAssignmentWarmupDelay(const int& InRebuildId) const;
-	void PrintEngageRequestSnapshot(const int& InRebuildId, const TMap<class ACAIController*, FEngageRequestContext>& InRequestSnapshot, const TMap<class AActor*, TArray<FEngageRequestContext>>& InRequestBucket) const;
-	void PrintEngageAssignmentRebuildSummary(const int& InRebuildId, const FEngageAssignmentRebuildDebugState& InDebugState, const TMap<class ACAIController*, FEngageAssignmentContext>& InAssignments) const;
 };

--- a/Source/Portfolio/Type/CAIStructure.h
+++ b/Source/Portfolio/Type/CAIStructure.h
@@ -31,6 +31,98 @@ enum class EContextBuildResult : uint8
     Error
 };
 
+struct FPerceptionCandidateAuditState
+{
+    bool bEnabled = false;
+
+    float RuntimeStartTime = 0.f;
+    uint64 RuntimeStartFrame = 0;
+
+    float FirstRawPerceptionTime = -1.f;
+    uint64 FirstRawPerceptionFrame = 0;
+
+    float FirstValidTargetTime = -1.f;
+    uint64 FirstValidTargetFrame = 0;
+
+    int32 RawPerceptionEventCount = 0;
+    int32 MaxTargetDataMapSize = 0;
+
+    TSet<TWeakObjectPtr<class AActor>> RawPerceptionActors;
+    TSet<TWeakObjectPtr<class AActor>> ValidTargetProviderActors;
+    TSet<TWeakObjectPtr<class AActor>> InvalidTargetProviderActors;
+
+    void Reset()
+    {
+        bEnabled = false;
+
+        RuntimeStartTime = 0.f;
+        RuntimeStartFrame = 0;
+
+        FirstRawPerceptionTime = -1.f;
+        FirstRawPerceptionFrame = 0;
+
+        FirstValidTargetTime = -1.f;
+        FirstValidTargetFrame = 0;
+
+        RawPerceptionEventCount = 0;
+        MaxTargetDataMapSize = 0;
+
+        RawPerceptionActors.Reset();
+        ValidTargetProviderActors.Reset();
+        InvalidTargetProviderActors.Reset();
+    }
+};
+
+struct FBlackboardEngageLatencyAuditState
+{
+    bool bEnabled = false;
+
+    float RuntimeStartTime = 0.f;
+    uint64 RuntimeStartFrame = 0;
+
+    float FirstPerceptionContextTime = -1.f;
+    uint64 FirstPerceptionContextFrame = 0;
+
+    float FirstBlackboardTargetTime = -1.f;
+    uint64 FirstBlackboardTargetFrame = 0;
+
+    float FirstEngageRequestTime = -1.f;
+    uint64 FirstEngageRequestFrame = 0;
+
+    float FirstEngageAssignmentTime = -1.f;
+    uint64 FirstEngageAssignmentFrame = 0;
+
+    TWeakObjectPtr<class AActor> FirstPerceptionTargetActor;
+    TWeakObjectPtr<class AActor> FirstBlackboardTargetActor;
+    TWeakObjectPtr<class AActor> FirstEngageRequestTargetActor;
+    TWeakObjectPtr<class AActor> FirstEngageAssignmentTargetActor;
+
+    void Reset()
+    {
+        bEnabled = false;
+
+        RuntimeStartTime = 0.f;
+        RuntimeStartFrame = 0;
+
+        FirstPerceptionContextTime = -1.f;
+        FirstPerceptionContextFrame = 0;
+
+        FirstBlackboardTargetTime = -1.f;
+        FirstBlackboardTargetFrame = 0;
+
+        FirstEngageRequestTime = -1.f;
+        FirstEngageRequestFrame = 0;
+
+        FirstEngageAssignmentTime = -1.f;
+        FirstEngageAssignmentFrame = 0;
+
+        FirstPerceptionTargetActor.Reset();
+        FirstBlackboardTargetActor.Reset();
+        FirstEngageRequestTargetActor.Reset();
+        FirstEngageAssignmentTargetActor.Reset();
+    }
+};
+
 USTRUCT(BlueprintType)
 struct FTargetData
 {

--- a/Source/Portfolio/Type/CWorldSubSystemStructure.h
+++ b/Source/Portfolio/Type/CWorldSubSystemStructure.h
@@ -75,6 +75,23 @@ public:
 	}
 };
 
+struct FEngageAssignmentSlotState
+{
+	int32 EngageCount = 0;
+	int32 AlertCount = 0;
+};
+
+struct FEngageAssignmentRebuildDebugState
+{
+	int32 RequestSnapshotCount = 0;
+	int32 RequestBucketCount = 0;
+	int32 WarmupRequestCount = 0;
+	int32 FreshAppliedCount = 0;
+	int32 PromotedCount = 0;
+	int32 PreservedEngageCount = 0;
+	int32 PreservedAlertCount = 0;
+};
+
 USTRUCT(BlueprintType)
 struct FHitStopRequest
 {


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P43: CVar Ownership Policy**

## 날짜

**2026.07.22**

## 상태

- [x] Debug / Diagnostic CVar ownership 재점검
- [x] Profiling audit / CSV counter CVar ownership 분리
- [x] RuntimeLOD policy / tuning CVar 유지 기준 정리
- [x] `CSV_CUSTOM_STAT_GLOBAL` 직접 호출을 `Core/Profiling` helper로 이동
- [x] `CSV_SCOPED_TIMING_STAT_GLOBAL`은 측정 scope 본문 유지
- [x] RuntimeLOD policy의 profiling audit gate 노출 제거
- [x] CVar ownership 최종 기준 문서화
- [x] `PortfolioEditor Win64 Development` build 통과

## 브랜치

- `refactor/cvar-ownership-policy`

## 요약

이번 PR은 P42 `Debug Log Policy v1` 이후 남아 있던 CVar ownership 경계를 정리한다.

P42에서 debug log / diagnostic helper 분리는 완료했지만, 일부 profiling gate, CSV counter, RuntimeLOD policy CVar의 책임 경계가 아직 섞여 있었다. 이번 PR에서는 CVar를 다음 기준으로 재분류했다.

```text
Core/Debug
-> 사람이 읽는 Output Log / diagnostic text / debug dump CVar 소유

Core/Profiling
-> profiling audit gate / CSV counter / profiling behavior gate 소유

AI/RuntimeLOD 또는 owner system
-> 실제 gameplay policy / tuning CVar 소유
```

이 기준에 따라 debug 출력 CVar, profiling audit CVar, RuntimeLOD policy/tuning CVar를 분리하고, CSV counter 직접 호출도 profiling helper 내부로 모았다.

## 주요 변경

```text
1. AI audit / debug CVar gate 정리
   - AI perception audit summary 출력 helper 분리
   - AI combat BT / CanMove decorator audit gate 정리
   - CombatEngage assignment audit output helper 분리

2. Profiling behavior gate CVar 분리
   - DisableEnemyPerception
   - DisableEnemyHitProcessing
   - DisableEnemyWeaponActor
   - DisableEnemyCombatFeedback
   - StatePolicyAudit
   - AnimationRefreshAudit

3. CSV counter ownership 정리
   - animation refresh counter를 CAIAnimationProfiling으로 이동
   - BT service / interval preset counter를 CAIBehaviorTreeProfiling으로 이동
   - Core/Profiling 밖 CSV_CUSTOM_STAT_GLOBAL 직접 호출 제거

4. RuntimeLOD policy 경계 정리
   - StatePolicyMode는 policy source 선택만 담당
   - StatePolicyAudit은 state tier CSV counter만 담당
   - FAIAnimationRuntimeLODPolicy에서 profiling audit gate 노출 제거

5. 문서화
   - N26 ownership inventory 정정
   - N27 CVar ownership final rule 추가
```

## 최종 CVar ownership 기준

```text
Debug / Diagnostic output CVar
-> Core/Debug helper

Debug Dump CVar
-> Core/Debug helper

Profiling audit / CSV counter CVar
-> Core/Profiling helper

Runtime policy / tuning CVar
-> owning policy/system cpp
```

혼합 CVar는 금지한다.

```text
StatePolicyMode
-> RuntimeLOD policy source만 선택

StatePolicyAudit
-> state tier CSV profiling counter만 제어
```

## CSV macro 기준

```text
CSV_CUSTOM_STAT_GLOBAL
-> event / counter 기록
-> 직접 호출은 Core/Profiling helper 구현부에만 둔다.

CSV_SCOPED_TIMING_STAT_GLOBAL
-> RAII scope timing 계측
-> 측정 범위가 중요하므로 측정 대상 scope 본문에 둔다.
```

## 주요 CVar

Core/Debug:

```text
Portfolio.Debug.*
Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit
Portfolio.AI.RuntimeLOD.BlackboardEngageLatencyAudit
Portfolio.AI.RuntimeLOD.CanMoveDecoratorAudit
Portfolio.AI.RuntimeLOD.EngageAssignmentAudit
Portfolio.AI.RuntimeLOD.EngageAssignmentVerboseAudit
```

Core/Profiling:

```text
Portfolio.AI.RuntimeLOD.AnimationRefreshAudit
Portfolio.AI.RuntimeLOD.StatePolicyAudit
Portfolio.AI.RuntimeLOD.DisableEnemyPerception
Portfolio.AI.RuntimeLOD.DisableEnemyHitProcessing
Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor
Portfolio.AI.RuntimeLOD.DisableEnemyCombatFeedback
```

Runtime policy / tuning owner 유지:

```text
Portfolio.AI.RuntimeLOD.StatePolicyMode
Portfolio.AI.RuntimeLOD.EnemyMovementMode
Portfolio.AI.RuntimeLOD.EnemyAnimationMode
Portfolio.AI.RuntimeLOD.EnemyAnimationReducedRefreshInterval
Portfolio.AI.RuntimeLOD.BTUpdateIntervalMode
Portfolio.AI.RuntimeLOD.EngageAssignmentWarmupTime
Portfolio.AI.RuntimeLOD.EngageAssignmentEngageCap
Portfolio.AI.RuntimeLOD.EngageAssignmentAlertCap
```

## 변경 파일 범위

```text
Docs/04_Pull_Request/00_Pull_Request_Index.md
Docs/04_Pull_Request/P43_UE5_Portfolio_Pull_Request.md
Docs/06_notes/N26_Diagnostic_Log_Full_Audit_Inventory_Note.md
Docs/06_notes/N27_Debug_Profiling_CVar_Ownership_Final_Note.md

Source/Portfolio/Core/Debug/*
Source/Portfolio/Core/Profiling/*
Source/Portfolio/AI/RuntimeLOD/*
Source/Portfolio/AI/BehaviorTree/*
Source/Portfolio/Character/*
Source/Portfolio/System/Combat/*
```

## 검증

### Build

```text
PortfolioEditor Win64 Development
Result: Pass
```

### Static check

```text
Core/Debug 밖 직접 출력 호출
Result: 0

Core/Profiling 밖 CSV_CUSTOM_STAT_GLOBAL 직접 호출
Result: 0

Core/Profiling 밖 남은 CSV_ 호출
Result: CSV_SCOPED_TIMING_STAT_GLOBAL only

Core/Debug / Core/Profiling 밖 TAutoConsoleVariable
Result: RuntimeLOD policy / tuning CVar만 유지
```

### Remaining Direct Scoped Timing

```text
CWorldSubsystem_CombatEngage
-> PortfolioAI_CombatEngage_Tick
-> PortfolioAI_CombatEngage_RebuildAssignments

BT services
-> PortfolioAI_BT_UpdateAIContext
-> PortfolioAI_BT_UpdateAIIntentState
-> PortfolioAI_BT_UpdateEngageContext
-> PortfolioAI_BT_UpdateInvestigateContext
```

위 항목은 `CSV_SCOPED_TIMING_STAT_GLOBAL`이라 helper로 이동하지 않고 측정 scope 본문에 유지한다.

## 후속 작업

이번 PR에서 처리하지 않는 항목:

```text
EBTServiceIntervalPreset 위치
-> 구조체 나누기 / 헤더 배치 규칙에서 처리

combat profiling API suffix 통일
-> 네이밍 / 매개변수 작명 규칙에서 처리

Debug helper 섹션명 전체 통일
-> TODO / 주석 및 섹션 정리에서 처리

CEnemy RuntimeLOD CVar 이동
-> 데이터 에셋 분리 또는 RuntimeLOD config 구조 정리에서 처리
```
