### PR TITLE
P44: 주석 / 섹션 정리 정책

### DIFF
--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -157,12 +157,12 @@
 
 ### 5) 불필요한 설명 주석 제거
 
-- [ ] `CPlayer.cpp` 생성자 init 주석 중 코드 반복 설명 제거
-- [ ] `CEnemy.cpp` 생성자 init 주석 중 코드 반복 설명 제거
-- [ ] `CWeaponComponent.cpp` spawn 단계 번호 주석을 압축 또는 제거
-- [ ] `CBTServiceIntervalHelper.cpp`의 단순 return 설명 주석 제거
-- [ ] `CCombatSignalStructure.h`의 필드명 반복 UPROPERTY 주석 정리
-- [ ] `CWeaponStructure.h`의 `[NOTE] Temp`, 개인 체크리스트성 주석, 단순 단계 주석 정리
+- [x] `CPlayer.cpp` 생성자 init 주석 중 코드 반복 설명 제거
+- [x] `CEnemy.cpp` 생성자 init 주석 중 코드 반복 설명 제거
+- [x] `CWeaponComponent.cpp` spawn 단계 번호 주석을 압축 또는 제거
+- [x] `CBTServiceIntervalHelper.cpp`의 단순 return 설명 주석 제거
+- [x] `CCombatSignalStructure.h`의 필드명 반복 UPROPERTY 주석 정리
+- [x] `CWeaponStructure.h`의 `[NOTE] Temp`, 개인 체크리스트성 주석, 단순 단계 주석 정리
 
 ### 6) API / inline role comment 유효성 검토
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -173,10 +173,10 @@
 
 ### 7) 잔존 trace 확인
 
-- [ ] commented-out `UE_LOG` 잔존 여부 확인
-- [ ] commented-out `DrawDebug` 잔존 여부 확인
-- [ ] commented-out `GEngine` 잔존 여부 확인
-- [ ] 임시 debug trace성 주석 잔존 여부 확인
+- [x] commented-out `UE_LOG` 잔존 여부 확인
+- [x] commented-out `DrawDebug` 잔존 여부 확인
+- [x] commented-out `GEngine` 잔존 여부 확인
+- [x] 임시 debug trace성 주석 잔존 여부 확인
 
 ---
 
@@ -224,13 +224,13 @@ UPROPERTY / Editor 노출 정리:
 
 ## 7. 완료 기준
 
-- [ ] 전수조사 후보가 이번 브랜치 범위 / 후속 범위로 분류되어 있다
-- [ ] 오타와 stale comment가 코드 상태와 충돌하지 않는다
-- [ ] TODO는 구현 필요 여부와 후속 카테고리를 추적할 수 있다
-- [ ] 섹션 주석은 같은 파일 안에서 일관된 양식을 가진다
-- [ ] 단순히 코드 내용을 반복하는 주석이 줄어 있다
-- [ ] commented-out temporary trace가 남아 있지 않음을 확인했다
-- [ ] 코드 동작 변경 없이 diff가 주석 / 문자열 / 문서 중심으로 제한되어 있다
+- [x] 전수조사 후보가 이번 브랜치 범위 / 후속 범위로 분류되어 있다
+- [x] 오타와 stale comment가 코드 상태와 충돌하지 않는다
+- [x] TODO는 구현 필요 여부와 후속 카테고리를 추적할 수 있다
+- [x] 섹션 주석은 같은 파일 안에서 일관된 양식을 가진다
+- [x] 단순히 코드 내용을 반복하는 주석이 줄어 있다
+- [x] commented-out temporary trace가 남아 있지 않음을 확인했다
+- [x] 코드 동작 변경 없이 diff가 주석 / 문자열 / 문서 중심으로 제한되어 있다
 
 ---
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -1,0 +1,286 @@
+# UE5 Portfolio - Work List
+
+## 제목
+
+**W05: comment / section cleanup 작업 계획**
+
+## 날짜
+
+**2026.07.22**
+
+## 상태
+
+- [ ] **진행중**
+
+---
+
+## 브랜치
+
+- `refactor/comment-section-cleanup`
+
+---
+
+## 1. 작업 목표
+
+이번 작업은 코드 동작을 바꾸지 않고, 주석 / TODO / 섹션 구분 / 설명 문자열의 신뢰도를 정리한다.
+
+목표는 리뷰어가 코드를 읽을 때 임시 trace, stale comment, 오타, 중복 설명 때문에 현재 구현 상태를 잘못 판단하지 않도록 만드는 것이다.
+
+```text
+핵심 목표
+1. stale / 오타 / 잘못된 주석 정리
+2. commented-out / temporary trace 잔존 여부 확인
+3. TODO를 후속 작업 범주로 분류
+4. 섹션 주석 양식 정리
+5. 불필요한 설명 주석 제거
+6. 작업 중 발견된 작은 보완 후보 기록
+```
+
+---
+
+## 2. 작업 개요
+
+이번 브랜치는 코드 품질 정리 중에서도 가벼운 문맥 정합성 정리에 한정한다.
+
+```yaml
+포함 범위:
+- 오타 / 잘못된 단어 수정
+- CVar help text와 실제 역할 정합성 수정
+- 의미 없는 빈 TODO 제거 또는 후속 범주 명시
+- 섹션 주석 스타일 정리
+- 코드가 그대로 설명되는 중복 주석 제거
+- commented-out debug trace 잔존 여부 확인
+
+제외 범위:
+- API rename
+- USTRUCT / header 구조 이동
+- DataAsset 분리 구현
+- runtime behavior 변경
+- DeadFlag / loop / spawn policy 구현
+- RuntimeLOD CVar 위치 이동
+```
+
+---
+
+## 3. 구조 / 비용 / 위험 검토
+
+```yaml
+구조 타당성:
+- 코드 동작을 바꾸지 않는 품질 정리이므로 PR 단위로 독립 검토 가능
+- TODO 분류는 이후 작업 카테고리와 연결되므로 장기 관리에 도움됨
+- 섹션 주석 정리는 현재 debug / profiling helper 정리 흐름과 맞음
+
+구현 비용:
+- 대부분 주석 / 문자열 수정
+- 일부 파일은 주석 양식만 수정
+- Type 헤더 주석 정리는 양이 많을 수 있으므로 별도 커밋으로 분리 가능
+
+위험:
+- CVar help text 변경은 사용자-facing console help 문구가 바뀜
+- API 이름, enum 이름, asset reference는 건드리지 않아야 함
+- TODO를 삭제할 때 후속 작업 추적성이 사라지지 않도록 범주를 남겨야 함
+```
+
+---
+
+## 4. 결정 항목
+
+현재 사용자 결정이 필요한 항목은 없다.
+
+다만 다음 항목은 이번 브랜치에서 구현하지 않고 후속 카테고리로 넘긴다.
+
+```yaml
+후속 처리:
+- API rename: 네이밍 / 매개변수 작명 규칙
+- Type 이동: 구조체 나누기 / 헤더 배치 규칙
+- DataAsset 이동: 데이터 에셋 분리
+- DeadFlag 동작 변경: 별도 gameplay correctness 작업
+- RuntimeLOD CVar 위치 이동: RuntimeLOD config / policy 구조 정리
+```
+
+---
+
+## 5. 이번 작업 범위
+
+### 1) 오타 / 표현 정리
+
+- [x] `Acitve API`를 `Active API`로 수정
+- [x] `Delgate`를 `Delegate`로 수정
+- [x] `Flag Toogle`을 `Flag Toggle`로 수정하거나 불필요하면 제거
+- [x] `Deffered Spawn`을 `Deferred Spawn`으로 수정
+- [x] `Seperate`를 `Separate`로 수정
+- [x] `Stemina`를 `Stamina`로 수정
+- [x] `BroadCast`를 `Broadcast`로 수정
+- [x] `Injection Datas`를 `Injected Animation Data`로 수정
+- [x] `FallBack`을 `Fallback`으로 수정하거나 불필요하면 제거
+- [x] CVar 설명 문자열의 일반 명사 `Enemy` 표기를 `enemy` 또는 `ACEnemy` 기준으로 정리
+
+### 2) stale / 잘못된 설명 정리
+
+- [ ] `FCombatEngageDebug` CVar 설명을 warmup 한정 표현에서 warmup / rebuild summary 기준으로 수정
+- [ ] `FCombatFeedbackDebug` CVar 설명을 실제 request / channel / presentation / dispatch 역할에 맞게 수정
+- [ ] `FAIPerceptionDebug` CVar 설명의 candidate / latency / Blackboard / Engage 표현을 실제 출력 기준으로 수정
+- [ ] `CAIPerceptionProfiling` CVar 설명의 `Enemy` 표기를 정리
+- [ ] `CCombatCollisionProfiling` CVar 설명의 enemy / weapon actor 표현을 정리
+- [ ] `CCombatFeedbackProfiling` CVar 설명의 `Enemy` 표기를 정리
+- [ ] `CAIStateRuntimeLODPolicy`의 `Runtime LOD` / `RuntimeLOD` 표현을 문맥별로 통일
+- [ ] `CActionFeedbackComponent`의 `Architect Miss` 표현을 실제 의미가 드러나는 문구로 수정
+
+### 3) TODO 분류
+
+- [ ] `CAIController` perception config DataAsset 후보 TODO 분류
+- [ ] `CPlayer` / `CEnemy` DeadFlag early return TODO 분류
+- [ ] `CActionFeedbackComponent` / `CReactionFeedbackComponent` loop support TODO 분류
+- [ ] `CWeaponComponent` deferred spawn TODO 분류
+- [ ] `CActionComponent` / `CReactionComponent` DataAsset build TODO 분류
+- [ ] `CCombatSignalSourceComponent` DamageSpecContainer DataAsset migration TODO 분류
+- [ ] `CHealthComponent` ResourceComponent extension / delegate broadcast TODO 분류
+- [ ] `CWeaponStructure` feedback / action execution context / 미분류 TODO 정리
+
+### 4) 섹션 주석 양식 정리
+
+- [ ] `CWeaponActor.h`의 `// ===`, `/* === */`, 중복 `AnimNotify Events` 섹션 정리
+- [ ] `CAIController.h`의 `/* --- Asset --- */`와 `// Lifecycle` 스타일 혼용 정리
+- [ ] `CAnimInstance.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
+- [ ] `CEnemy.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
+- [ ] `CMovementComponent.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
+- [ ] `Core/Debug` / `Core/Profiling` helper 섹션명은 필요 시 최소 보정
+
+### 5) 불필요한 설명 주석 제거
+
+- [ ] `CPlayer.cpp` 생성자 init 주석 중 코드 반복 설명 제거
+- [ ] `CEnemy.cpp` 생성자 init 주석 중 코드 반복 설명 제거
+- [ ] `CWeaponComponent.cpp` spawn 단계 번호 주석을 압축 또는 제거
+- [ ] `CBTServiceIntervalHelper.cpp`의 단순 return 설명 주석 제거
+- [ ] `CCombatSignalStructure.h`의 필드명 반복 UPROPERTY 주석 정리
+- [ ] `CWeaponStructure.h`의 `[NOTE] Temp`, 개인 체크리스트성 주석, 단순 단계 주석 정리
+
+### 6) API / inline role comment 유효성 검토
+
+- [x] `Incoming API`, `Active API`, `Getter`, `Setter` 같은 inline role comment가 실제 책임을 설명하는지 확인
+- [x] 의미가 코드명과 중복되면 제거
+- [x] 의미가 불명확하면 실제 역할 기준으로 수정
+- [x] public API rename이 필요한 수준이면 이번 브랜치에서 수정하지 않고 네이밍 작업으로 분리
+
+### 7) 잔존 trace 확인
+
+- [ ] commented-out `UE_LOG` 잔존 여부 확인
+- [ ] commented-out `DrawDebug` 잔존 여부 확인
+- [ ] commented-out `GEngine` 잔존 여부 확인
+- [ ] 임시 debug trace성 주석 잔존 여부 확인
+
+---
+
+## 6. 제외 범위 / 후속 작업 범위
+
+이번 브랜치에서 발견하더라도 다음 범위는 수정하지 않는다.
+
+```yaml
+네이밍 / 매개변수 작명 규칙:
+- FObservableOverlayDebug / FExecutionOrchestratorDebug의 Handlings 계열 API 이름
+- combat profiling API suffix 통일
+- 책임명이 어색한 public API rename
+
+구조체 나누기 / 헤더 배치 규칙:
+- EBTServiceIntervalPreset 위치 이동
+- CWeaponStructure large type 분리
+- shared type / module-local type 재배치
+
+데이터 에셋 분리:
+- Action / Reaction data map build 이동
+- DamageSpecContainer DataAsset migration
+- AI perception config DataAsset migration
+
+상수 제거 / RuntimeLOD 구조 정리:
+- CEnemy RuntimeLOD CVar 위치 이동
+- RuntimeLOD policy/config 재구성
+
+기능 수정:
+- DeadFlag early return 동작 변경
+- feedback loop support 구현
+- deferred spawn 정책 구현
+```
+
+---
+
+## 7. 완료 기준
+
+- [ ] 전수조사 후보가 이번 브랜치 범위 / 후속 범위로 분류되어 있다
+- [ ] 오타와 stale comment가 코드 상태와 충돌하지 않는다
+- [ ] TODO는 구현 필요 여부와 후속 카테고리를 추적할 수 있다
+- [ ] 섹션 주석은 같은 파일 안에서 일관된 양식을 가진다
+- [ ] 단순히 코드 내용을 반복하는 주석이 줄어 있다
+- [ ] commented-out temporary trace가 남아 있지 않음을 확인했다
+- [ ] 코드 동작 변경 없이 diff가 주석 / 문자열 / 문서 중심으로 제한되어 있다
+
+---
+
+## 8. 필수 문서 / 산출 대상
+
+```yaml
+Work List:
+- Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+- Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+
+후속 PR 문서:
+- Docs/04_Pull_Request/P##_UE5_Portfolio_Pull_Request.md
+```
+
+---
+
+## 9. 검증 기준
+
+```yaml
+정적 확인:
+- rg로 TODO / 오타 / temporary trace 잔존 여부 확인
+- git diff에서 기능 코드 변경 여부 확인
+- git diff --check 통과
+
+빌드:
+- 주석 / 문자열만 변경한 경우 빌드는 선택
+- header comment 정리 중 preprocessor / macro 주변을 건드린 경우 PortfolioEditor Development 빌드 권장
+
+리뷰:
+- 후속 작업으로 넘긴 항목이 삭제되지 않고 추적 가능한지 확인
+- 문서와 코드 주석의 작업 범주가 충돌하지 않는지 확인
+```
+
+---
+
+## 10. 진행 중 변경 관리 기준
+
+- 동작 변경이 필요해 보이면 이번 브랜치에서 수정하지 않고 후속 후보로 기록한다.
+- public API rename이 필요해 보이면 네이밍 작업으로 분리한다.
+- USTRUCT / UPROPERTY / Blueprint exposure와 관련된 이름 변경은 이번 브랜치에서 하지 않는다.
+- TODO 삭제는 구현 완료가 명확하거나 다른 문서 / 후속 범주로 추적 가능할 때만 허용한다.
+- 섹션 주석은 파일별 기존 스타일을 우선하되, 같은 파일 안에서는 혼용을 줄인다.
+
+---
+
+## 11. PR 가능 조건
+
+```yaml
+PR 가능:
+- 이번 문서의 체크리스트가 완료 또는 후속 범위로 명확히 분류됨
+- diff가 주석 / 문자열 / 문서 중심임
+- git diff --check 통과
+- 필요 시 PortfolioEditor Development 빌드 통과
+
+PR 보류:
+- 기능 동작 변경이 섞임
+- asset reference 위험이 있는 rename이 섞임
+- TODO를 삭제했지만 후속 추적 경로가 사라짐
+- header / macro 주변 수정 후 빌드를 확인하지 못함
+```
+
+---
+
+## 12. Backlog 후보
+
+- `refactor/naming-typo-api-cleanup`: API / 매개변수 / suffix 네이밍 통일
+- `refactor/type-header-helper-boundary`: Type 헤더 분리와 helper boundary 정리
+- `refactor/tuning-constants-cleanup`: 상수 / CVar / DataAsset 후보 정리
+- `refactor/api-const-consistency`: read-only API const 정합성 정리
+- `refactor/runtime-lod-config-policy`: RuntimeLOD CVar / policy / config 위치 재검토
+
+---

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -128,14 +128,14 @@
 
 ### 3) TODO 분류
 
-- [ ] `CAIController` perception config DataAsset 후보 TODO 분류
-- [ ] `CPlayer` / `CEnemy` DeadFlag early return TODO 분류
-- [ ] `CActionFeedbackComponent` / `CReactionFeedbackComponent` loop support TODO 분류
-- [ ] `CWeaponComponent` deferred spawn TODO 분류
-- [ ] `CActionComponent` / `CReactionComponent` DataAsset build TODO 분류
-- [ ] `CCombatSignalSourceComponent` DamageSpecContainer DataAsset migration TODO 분류
-- [ ] `CHealthComponent` ResourceComponent extension / delegate broadcast TODO 분류
-- [ ] `CWeaponStructure` feedback / action execution context / 미분류 TODO 정리
+- [x] `CAIController` perception config DataAsset 후보 TODO 분류
+- [x] `CPlayer` / `CEnemy` DeadFlag early return TODO 분류
+- [x] `CActionFeedbackComponent` / `CReactionFeedbackComponent` loop support TODO 분류
+- [x] `CWeaponComponent` deferred spawn TODO 분류
+- [x] `CActionComponent` / `CReactionComponent` DataAsset build TODO 분류
+- [x] `CCombatSignalSourceComponent` DamageSpecContainer DataAsset migration TODO 분류
+- [x] `CHealthComponent` ResourceComponent extension / delegate broadcast TODO 분류
+- [x] `CWeaponStructure` feedback / action execution context / 미분류 TODO 정리
 
 ### 4) 섹션 주석 양식 정리
 
@@ -190,6 +190,8 @@
 - Action / Reaction data map build 이동
 - DamageSpecContainer DataAsset migration
 - AI perception config DataAsset migration
+- feedback data type 이동
+- Health / ResourceComponent 확장
 
 상수 제거 / RuntimeLOD 구조 정리:
 - CEnemy RuntimeLOD CVar 위치 이동
@@ -199,6 +201,9 @@
 - DeadFlag early return 동작 변경
 - feedback loop support 구현
 - deferred spawn 정책 구현
+- AI combo branch의 action index 사용 정책
+- CombatEngage coordinator naming / responsibility 재검토
+- combat result UI feedback 추가 여부
 ```
 
 ---

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -498,3 +498,40 @@ void UCWeaponComponent::ClearWeaponRuntime()
 // UINTERFACE wrapper keeps the UObject and interface pointer together.
 FObservableTargetRef targetRef;
 ```
+
+---
+
+## 14. P3 Final Decision
+
+P3 항목은 이번 브랜치에서 코드 수정하지 않고, 유지 또는 후속 작업으로 이관한다.
+
+### 1) Type / Data 주석
+
+`CAIStructure.h`, `CWeaponStructure.h`에 남은 Type / Data 의미 주석은 현재 브랜치에서 추가 정리하지 않는다.
+
+판단:
+- enum의 `None`, `All`, `Max` 설명은 sentinel / wildcard 의미를 설명하므로 유지한다.
+- `FDamageAmount`의 damage 단계 설명은 `RequestedDamage`, `MitigatedDamage`, `FinalTakenDamage`, `CommittedDamage`의 파이프라인 의미를 구분하므로 유지한다.
+- `FAIContext`의 field group 주석과 `FOverlapContext`의 actor/component alias 주석은 구조체 분리 / 헤더 배치 규칙 작업에서 다시 판단한다.
+
+후속 범위:
+- 구조체 나누기 / 헤더 배치 규칙
+- 네이밍 / 매개변수 작명 규칙
+- UPROPERTY Category 정리
+
+### 2) TODO 유지 판단
+
+남은 TODO 6개는 코드 위치에 정책 후속 작업을 표시해야 하므로 유지한다.
+
+유지 목록:
+- `CPlayer.cpp`: `TODO(Gameplay)` Dead actor TakeDamage route 정책
+- `CEnemy.cpp`: `TODO(Gameplay)` Dead actor TakeDamage route 정책
+- `CCombatSignalTargetComponent.cpp`: `TODO(CombatPolicy)` target-side defensive gates
+- `CCombatSignalTargetComponent.cpp`: `TODO(CombatPolicy)` mitigation policy
+- `CCombatSignalTargetComponent.cpp`: `TODO(CombatPolicy)` final damage policy
+- `CCombatSignalTargetComponent.cpp`: `TODO(CombatPolicy)` resource commit order
+
+판단:
+- TODO가 실제 구현 위치와 직접 연결되어 있다.
+- 문서로만 옮기면 정책을 구현할 때 놓칠 가능성이 크다.
+- 이번 브랜치의 주석 규칙상 허용되는 code-local TODO로 본다.

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -48,6 +48,7 @@
 - CVar help text와 실제 역할 정합성 수정
 - 의미 없는 빈 TODO 제거 또는 후속 범주 명시
 - 섹션 주석 스타일 정리
+- UPROPERTY 변수 구간 섹션 주석 정리
 - 코드가 그대로 설명되는 중복 주석 제거
 - commented-out debug trace 잔존 여부 확인
 
@@ -55,6 +56,7 @@
 - API rename
 - USTRUCT / header 구조 이동
 - DataAsset 분리 구현
+- UPROPERTY Category 재설계
 - runtime behavior 변경
 - DeadFlag / loop / spawn policy 구현
 - RuntimeLOD CVar 위치 이동
@@ -69,6 +71,7 @@
 - 코드 동작을 바꾸지 않는 품질 정리이므로 PR 단위로 독립 검토 가능
 - TODO 분류는 이후 작업 카테고리와 연결되므로 장기 관리에 도움됨
 - 섹션 주석 정리는 현재 debug / profiling helper 정리 흐름과 맞음
+- UPROPERTY 변수 구간은 섹션 주석보다 Category 기준으로 관리하는 편이 에디터 노출 의도와 맞음
 
 구현 비용:
 - 대부분 주석 / 문자열 수정
@@ -94,6 +97,7 @@
 - API rename: 네이밍 / 매개변수 작명 규칙
 - Type 이동: 구조체 나누기 / 헤더 배치 규칙
 - DataAsset 이동: 데이터 에셋 분리
+- UPROPERTY Category 정리: 별도 category naming / editor exposure 정리
 - DeadFlag 동작 변경: 별도 gameplay correctness 작업
 - RuntimeLOD CVar 위치 이동: RuntimeLOD config / policy 구조 정리
 ```
@@ -139,12 +143,17 @@
 
 ### 4) 섹션 주석 양식 정리
 
-- [ ] `CWeaponActor.h`의 `// ===`, `/* === */`, 중복 `AnimNotify Events` 섹션 정리
-- [ ] `CAIController.h`의 `/* --- Asset --- */`와 `// Lifecycle` 스타일 혼용 정리
-- [ ] `CAnimInstance.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
-- [ ] `CEnemy.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
-- [ ] `CMovementComponent.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
-- [ ] `Core/Debug` / `Core/Profiling` helper 섹션명은 필요 시 최소 보정
+- [x] 변수 / `UPROPERTY` 구간은 섹션 주석 대신 Category / 변수명 / struct 이름 기준으로 관리
+- [x] `CWeaponActor.h`의 `// ===`, `/* === */`, 중복 `AnimNotify Events` 섹션 정리
+- [x] `CAIController.h`의 `/* --- Asset --- */`와 `// Lifecycle` 스타일 혼용 정리
+- [x] `CAnimInstance.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
+- [x] `CEnemy.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
+- [x] `CMovementComponent.h`의 RuntimeLOD 번호 주석을 의미 기반 섹션으로 정리
+- [x] `CWeaponComponent.h` / `CStateComponent.h` / `CHealthComponent.h` 변수 섹션 주석 정리
+- [x] `CActionComponent.h` / `CReactionComponent.h` 변수 섹션 주석 정리
+- [x] `CPlayerFeedbackComponent.h` / `CHitFeedbackComponent.h` 변수 섹션 주석 정리
+- [x] `CCombatSignalSourceComponent.h` / `CCombatSignalTargetComponent.h` 변수 섹션 주석 정리
+- [x] `Core/Debug` / `Core/Profiling` helper 섹션명은 필요 시 최소 보정
 
 ### 5) 불필요한 설명 주석 제거
 
@@ -192,6 +201,11 @@
 - AI perception config DataAsset migration
 - feedback data type 이동
 - Health / ResourceComponent 확장
+
+UPROPERTY / Editor 노출 정리:
+- UPROPERTY Category naming 통일
+- 변수 구간 분류는 Category 기준으로 재검토
+- Category 변경에 따른 에디터 표시 / asset 영향 확인
 
 상수 제거 / RuntimeLOD 구조 정리:
 - CEnemy RuntimeLOD CVar 위치 이동
@@ -258,7 +272,8 @@ Work List:
 - public API rename이 필요해 보이면 네이밍 작업으로 분리한다.
 - USTRUCT / UPROPERTY / Blueprint exposure와 관련된 이름 변경은 이번 브랜치에서 하지 않는다.
 - TODO 삭제는 구현 완료가 명확하거나 다른 문서 / 후속 범주로 추적 가능할 때만 허용한다.
-- 섹션 주석은 파일별 기존 스타일을 우선하되, 같은 파일 안에서는 혼용을 줄인다.
+- 함수 구간 섹션 주석은 파일별 기존 스타일을 우선하되, 같은 파일 안에서는 혼용을 줄인다.
+- 변수 / UPROPERTY 구간은 섹션 주석을 줄이고 Category / 변수명 / struct 이름으로 의미를 표현한다.
 
 ---
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -117,14 +117,14 @@
 
 ### 2) stale / 잘못된 설명 정리
 
-- [ ] `FCombatEngageDebug` CVar 설명을 warmup 한정 표현에서 warmup / rebuild summary 기준으로 수정
-- [ ] `FCombatFeedbackDebug` CVar 설명을 실제 request / channel / presentation / dispatch 역할에 맞게 수정
-- [ ] `FAIPerceptionDebug` CVar 설명의 candidate / latency / Blackboard / Engage 표현을 실제 출력 기준으로 수정
-- [ ] `CAIPerceptionProfiling` CVar 설명의 `Enemy` 표기를 정리
-- [ ] `CCombatCollisionProfiling` CVar 설명의 enemy / weapon actor 표현을 정리
-- [ ] `CCombatFeedbackProfiling` CVar 설명의 `Enemy` 표기를 정리
-- [ ] `CAIStateRuntimeLODPolicy`의 `Runtime LOD` / `RuntimeLOD` 표현을 문맥별로 통일
-- [ ] `CActionFeedbackComponent`의 `Architect Miss` 표현을 실제 의미가 드러나는 문구로 수정
+- [x] `FCombatEngageDebug` CVar 설명을 warmup 한정 표현에서 warmup / rebuild summary 기준으로 수정
+- [x] `FCombatFeedbackDebug` CVar 설명을 실제 request / channel / presentation / dispatch 역할에 맞게 수정
+- [x] `FAIPerceptionDebug` CVar 설명의 candidate / latency / Blackboard / Engage 표현을 실제 출력 기준으로 수정
+- [x] `CAIPerceptionProfiling` CVar 설명의 `Enemy` 표기를 정리
+- [x] `CCombatCollisionProfiling` CVar 설명의 enemy / weapon actor 표현을 정리
+- [x] `CCombatFeedbackProfiling` CVar 설명의 `Enemy` 표기를 정리
+- [x] `CAIStateRuntimeLODPolicy`의 `Runtime LOD` / `RuntimeLOD` 표현을 문맥별로 통일
+- [x] `CActionFeedbackComponent`의 `Architect Miss` 표현을 실제 의미가 드러나는 문구로 수정
 
 ### 3) TODO 분류
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -304,3 +304,197 @@ PR 보류:
 - `refactor/runtime-lod-config-policy`: RuntimeLOD CVar / policy / config 위치 재검토
 
 ---
+## 13. Comment Usage Rules
+
+이번 브랜치 이후 주석은 "코드가 직접 말하지 못하는 이유 / 정책 / 예외 / 구역"만 남긴다.
+단순히 코드 동작을 반복하는 주석, 임시 trace, stale 상태 설명, 장식성 banner는 제거 대상이다.
+
+### 1) Engine / Template Header
+
+UE 템플릿 copyright 주석은 유지한다.
+그 외 파일 상단 설명 주석은 별도 필요가 없으면 추가하지 않는다.
+
+```cpp
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "Portfolio.h"
+```
+
+### 2) Debug Helper
+
+Debug helper는 API 구역을 구분하기 위한 짧은 명사구 섹션만 허용한다.
+출력 정책은 함수명, CVar, helper 구조로 표현하고 본문 설명 주석은 최소화한다.
+
+```cpp
+// Gate
+
+bool FCombatSignalDebug::ShouldAuditCombatSignal()
+{
+	return CVarCombatSignalAudit.GetValueOnGameThread() != 0;
+}
+
+// Source Diagnostic Hook
+
+void FCombatSignalDebug::RecordSourceRejectedForAudit(...)
+{
+	if (!ShouldAuditCombatSignal()) return;
+}
+```
+
+### 3) Profiling Helper
+
+Profiling helper는 gate / audit / counter / CSV 구역 구분에 사용한다.
+counter 종류가 여러 개면 구체적인 counter 이름을 섹션명으로 쓴다.
+
+```cpp
+// Gate
+
+bool CAIAnimationProfiling::ShouldAuditAnimationRefresh()
+{
+	return CVarAnimationRefreshAudit.GetValueOnGameThread() != 0;
+}
+
+// Counter
+
+void CAIAnimationProfiling::RecordAnimationRefreshExecuted()
+{
+	CSV_CUSTOM_STAT_GLOBAL(AnimationRefreshExecuted, 1, ECsvCustomStatOp::Accumulate);
+}
+```
+
+### 4) Header API Section
+
+헤더 선언부는 함수 그룹을 읽기 쉽게 나눌 때만 섹션 주석을 둔다.
+섹션명은 `Lifecycle`, `Component Reference`, `Query`, `Mutation`, `Runtime State`, `Notify Routing`처럼 짧은 명사구를 사용한다.
+`API`, `Current`, `Used`, `Temp` 같은 상태성 표현은 사용하지 않는다.
+
+```cpp
+public:
+	// Lifecycle
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+public:
+	// Query
+	bool IsActive() const;
+	EActionType GetActiveActionType() const;
+
+private:
+	// Runtime State
+	void ClearActionRuntimeState();
+```
+
+### 5) Implementation Section
+
+cpp 구현부는 함수 그룹을 나눌 때만 섹션 주석을 둔다.
+가능하면 헤더의 섹션명과 같은 용어를 사용한다.
+함수 1개짜리 작은 그룹은 보통 섹션 주석을 두지 않는다.
+
+```cpp
+// Runtime Lifecycle
+
+void UCActionComponent::InitializeActionRuntime()
+{
+	BuildActionRuntimeMaps();
+}
+
+void UCActionComponent::UninitializeActionRuntime()
+{
+	ClearActionRuntimeMaps();
+}
+
+// Notify Routing
+
+void UCActionComponent::HandleActionNotify(...)
+{
+}
+```
+
+### 6) Algorithm / Step
+
+순서나 우선순위가 의미 있는 fallback, priority matching, state decision에만 단계 주석을 사용한다.
+번호는 실제 실행 순서나 우선순위를 나타낼 때만 쓴다.
+장식성 separator 또는 block banner는 사용하지 않는다.
+
+```cpp
+AController* ResolveInstigatorController(AActor* InAttacker, AActor* InDamageCauser)
+{
+	// 1) Prefer attacker-provided instigator.
+	if (AController* controller = InAttacker->GetInstigatorController())
+		return controller;
+
+	// 2) Fall back to the attacker pawn controller.
+	if (APawn* pawn = Cast<APawn>(InAttacker))
+		return pawn->GetController();
+
+	return nullptr;
+}
+```
+
+### 7) Policy / Exception Reason
+
+본문 주석은 기본적으로 "왜 이렇게 해야 하는지"를 설명할 때만 사용한다.
+`[NOTE]`, `[Policy]` 같은 태그는 기본적으로 쓰지 않고, 한 줄 문장으로 작성한다.
+2줄 이상 길어지면 함수 분리 또는 문서화를 먼저 검토한다.
+
+```cpp
+bool UCReactionOrchestratorComponent::CanAcceptReactionRequest(...)
+{
+	// DeadReaction may be requested after health and dead state have already been committed.
+	if (RejectReason == EReactionRequestRejectReason::DeadState)
+		return true;
+
+	return false;
+}
+```
+
+### 8) Type / Data Meaning
+
+enum sentinel / wildcard처럼 이름만으로 의미가 부족한 값은 짧은 inline 주석을 허용한다.
+field 의미 설명은 이름으로 표현하기 어려울 때만 허용한다.
+payload 설명이 길어지면 struct 이름, 필드명, 문서로 이동한다.
+UPROPERTY 바로 위에 변수 그룹처럼 보이는 섹션 주석은 지양한다.
+
+```cpp
+UENUM(BlueprintType)
+enum class EWeaponType : uint8
+{
+	None = 0,	// Invalid, unset
+	Sword,
+
+	All,		// Wildcard
+	Max,		// Sentinel
+};
+```
+
+```cpp
+USTRUCT(BlueprintType)
+struct FDamageAmount
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Transient)
+	float RequestedDamage = 0.f; // Raw incoming damage before mitigation.
+
+	UPROPERTY(Transient)
+	float FinalTakenDamage = 0.f; // Damage after target-side final rules.
+};
+```
+
+### 9) Sparse / One-off
+
+주석이 한두 개만 있는 파일은 기본적으로 제거 후보로 본다.
+단, 코드만으로 드러나지 않는 엔진 제약, interface wrapper, lifecycle 예외 같은 이유 설명은 유지할 수 있다.
+
+```cpp
+// Avoid if this is the only comment and it only repeats the function name.
+void UCWeaponComponent::ClearWeaponRuntime()
+{
+}
+```
+
+```cpp
+// UINTERFACE wrapper keeps the UObject and interface pointer together.
+FObservableTargetRef targetRef;
+```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -34,12 +34,13 @@
 12. feature/ai-enemy-actor-tick-profiling
 13. feature/ai-state-based-runtime-lod
 14. refactor/debug-log-policy-v1
-15. refactor/todo-status-cleanup
-16. refactor/naming-typo-api-cleanup
-17. refactor/api-const-consistency
-18. refactor/tuning-constants-cleanup
-19. refactor/type-header-helper-boundary
-20. docs/pr-record-format-sweep
+15. refactor/comment-section-cleanup
+16. refactor/todo-status-cleanup
+17. refactor/naming-typo-api-cleanup
+18. refactor/api-const-consistency
+19. refactor/tuning-constants-cleanup
+20. refactor/type-header-helper-boundary
+21. docs/pr-record-format-sweep
 
 별도 후순위:
 - refactor/enhanced-input-migration
@@ -100,6 +101,7 @@ W05 묶음은 다음 조건을 만족하면 코드 품질 1차 정리가 완료�
 ```yaml
 Work List / Notes
 - Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+- Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
 - Docs/01_Work_List/00_Work_List_Index.md
 - Docs/06_notes/N08_Code_Quality_Cleanup_Plan_Note.md
 ```

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -6,7 +6,7 @@
 
 | ID | 제목 | 파일 | 브랜치 | GitHub PR | 관련 문서 |
 | --- | --- | --- | --- | --- | --- |
-| P44 | Comment / Section Cleanup Policy | `P44_UE5_Portfolio_Pull_Request.md` | `refactor/comment-section-cleanup` |  | W05 |
+| P44 | 주석 / 섹션 정리 정책 | `P44_UE5_Portfolio_Pull_Request.md` | `refactor/comment-section-cleanup` | #99 | W05 |
 | P42 | Debug Log Policy v1 | `P42_UE5_Portfolio_Pull_Request.md` | `refactor/debug-log-policy-v1` |  | W05, N22, N23, N24, N25, N26 |
 | P43 | CVar Ownership Policy | `P43_UE5_Portfolio_Pull_Request.md` | `refactor/cvar-ownership-policy` |  | W05, N23, N26, N27 |
 | P01 | Character / Camera Core | `P01_UE5_Portfolio_Pull_Request.md` | `feature/character-camera-core` |  | D02 |

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -6,6 +6,7 @@
 
 | ID | 제목 | 파일 | 브랜치 | GitHub PR | 관련 문서 |
 | --- | --- | --- | --- | --- | --- |
+| P44 | Comment / Section Cleanup Policy | `P44_UE5_Portfolio_Pull_Request.md` | `refactor/comment-section-cleanup` |  | W05 |
 | P42 | Debug Log Policy v1 | `P42_UE5_Portfolio_Pull_Request.md` | `refactor/debug-log-policy-v1` |  | W05, N22, N23, N24, N25, N26 |
 | P43 | CVar Ownership Policy | `P43_UE5_Portfolio_Pull_Request.md` | `refactor/cvar-ownership-policy` |  | W05, N23, N26, N27 |
 | P01 | Character / Camera Core | `P01_UE5_Portfolio_Pull_Request.md` | `feature/character-camera-core` |  | D02 |

--- a/Docs/04_Pull_Request/P44_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P44_UE5_Portfolio_Pull_Request.md
@@ -2,7 +2,7 @@
 
 ## 제목
 
-**P44: Comment / Section Cleanup Policy**
+**P44: 주석 / 섹션 정리 정책**
 
 ## 날짜
 
@@ -343,16 +343,30 @@ Gameplay / CombatPolicy TODO 구현
 -> mitigation / final damage / resource commit order
 ```
 
+## 관련 문서
+
+```text
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+-> 이번 브랜치의 작업 범위, 주석 사용 규칙, 유지 TODO 판단을 기록한다.
+
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+-> W05 코드 품질 작업 흐름에서 이번 브랜치 위치를 관리한다.
+
+Docs/04_Pull_Request/00_Pull_Request_Index.md
+-> P44 문서와 GitHub PR 번호를 연결한다.
+```
+
 ## PR 설명 초안
 
 ```md
 ## Summary
 
-- comment / section cleanup 작업 계획과 주석 사용 규칙을 문서화
-- stale / 오타 / 잘못된 주석, 태그형 주석, 장식성 banner, 코드 반복 설명 주석 정리
+- 주석 / 섹션 정리 작업 계획과 주석 사용 규칙을 문서화
+- stale comment, 오타, 잘못된 설명, 태그형 주석, 장식성 banner, 코드 반복 설명 주석 정리
 - header / cpp section comment를 짧은 책임명 중심으로 정리
 - code-local TODO 6개를 Gameplay / CombatPolicy 후속 작업으로 유지 판단
-- Type / Data 주석 중 구조체/헤더 배치 작업으로 넘길 항목을 P3 final decision으로 기록
+- Type / Data 주석 중 구조체 / 헤더 배치 작업으로 넘길 항목을 P3 final decision으로 기록
+- PR 문서에 관련 문서 섹션과 GitHub PR 번호 반영
 
 ## Validation
 

--- a/Docs/04_Pull_Request/P44_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P44_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,364 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P44: Comment / Section Cleanup Policy**
+
+## 날짜
+
+**2026.07.23**
+
+## 상태
+
+- [x] comment / section cleanup 작업 계획 문서 작성
+- [x] stale / 오타 / 잘못된 주석 정리
+- [x] code-local TODO 분류 및 유지 기준 확정
+- [x] header / implementation section comment 양식 정리
+- [x] 반복 설명 / 태그형 / 장식성 주석 제거
+- [x] comment usage rule 문서화
+- [x] P3 유지 / 후속 이관 판단 기록
+- [x] PR final scan 완료
+
+## 브랜치
+
+- `refactor/comment-section-cleanup`
+
+## 요약
+
+이번 PR은 P42 `Debug Log Policy v1`, P43 `CVar Ownership Policy` 이후 이어지는 code quality cleanup 작업으로, 프로젝트 내부 주석과 section comment 사용 기준을 정리한다.
+
+기존 코드에는 다음 성격의 주석이 섞여 있었다.
+
+```text
+1. 실제 정책 / 예외 이유를 설명하는 주석
+2. header / cpp 구현부를 나누는 section comment
+3. Debug / Profiling helper 구역을 나누는 comment
+4. 코드가 그대로 말하는 반복 설명 주석
+5. [NOTE] / [Policy] / [Pass] 같은 태그형 주석
+6. separator / banner 형태의 장식성 주석
+7. 구현 위치에 남겨야 하는 TODO
+```
+
+이번 PR에서는 주석을 전부 제거하는 것이 아니라, "코드가 직접 말하지 못하는 이유 / 정책 / 예외 / 구역"만 남기는 기준을 고정했다.
+
+## 주요 변경
+
+### 1. 작업 계획 문서 작성
+
+`W05_Comment_Section_Cleanup_Work_Plan.md`를 추가하고, 이번 브랜치에서 다룰 범위와 제외 범위를 분리했다.
+
+포함 범위:
+
+```text
+- stale / 오타 / 잘못된 주석 정리
+- commented-out / temporary trace 확인
+- TODO 분류
+- section comment 양식 정리
+- 불필요한 설명 주석 제거
+- API / inline role comment 유효성 검토
+```
+
+제외 범위:
+
+```text
+- public API rename
+- 구조체 나누기 / 헤더 배치 규칙
+- DataAsset 분리 구현
+- UPROPERTY Category 재설계
+- RuntimeLOD CVar 위치 이동
+- const 정합성 정리
+- gameplay policy 구현
+```
+
+### 2. 주석 사용 규칙 고정
+
+워크플랜 문서에 `Comment Usage Rules`를 추가했다.
+
+최종 기준:
+
+```text
+Engine / Template Header
+Debug Helper
+Profiling Helper
+Header API Section
+Implementation Section
+Algorithm / Step
+Policy / Exception Reason
+Type / Data Meaning
+Sparse / One-off
+```
+
+핵심 원칙:
+
+```text
+무엇을 하는지 반복 설명하지 않는다.
+왜 필요한지, 어떤 정책/예외인지 설명한다.
+section comment는 짧은 명사구로 제한한다.
+태그형 [NOTE] / [Policy] / [Pass] 주석은 사용하지 않는다.
+separator / banner comment는 사용하지 않는다.
+UPROPERTY 변수 구간은 주석보다 Category / 변수명 / struct 분리로 관리한다.
+```
+
+### 3. stale / 오타 / 잘못된 표현 정리
+
+다음 유형을 정리했다.
+
+```text
+Acitve -> Active
+Delgate -> Delegate
+Flag Toogle -> Flag Toggle
+Deffered -> Deferred
+Seperate -> Separate
+Stemina -> Stamina
+BroadCast -> Broadcast
+FallBack -> Fallback
+```
+
+CVar help text와 debug / profiling 설명 문구도 실제 역할과 맞게 보정했다.
+
+### 4. TODO 분류
+
+의미 없는 TODO와 이미 문서로 추적 가능한 TODO는 제거했다.
+
+남긴 TODO는 다음 6개다.
+
+```text
+CPlayer.cpp
+-> TODO(Gameplay): dead actor TakeDamage route 정책
+
+CEnemy.cpp
+-> TODO(Gameplay): dead actor TakeDamage route 정책
+
+CCombatSignalTargetComponent.cpp
+-> TODO(CombatPolicy): target-side defensive gates
+-> TODO(CombatPolicy): mitigation policy
+-> TODO(CombatPolicy): final damage policy
+-> TODO(CombatPolicy): resource commit order
+```
+
+이 TODO들은 실제 구현 위치와 직접 연결되어 있어 code-local TODO로 유지한다.
+
+### 5. section comment 정리
+
+header / cpp 구현부 section comment를 다음 기준으로 맞췄다.
+
+```text
+Lifecycle
+Component Reference
+Query
+Mutation
+Runtime Lifecycle
+Runtime State
+Notify Routing
+Data Build
+State Transition
+Gate
+Counter
+Diagnostic Hook
+Debug Dump
+```
+
+`API`, `Current`, `Used`, `Temp`처럼 상태성 또는 넓은 표현은 제거하거나 더 구체적인 책임명으로 바꿨다.
+
+예:
+
+```text
+Interface API -> Interface
+ActionEvent API -> Action Event Routing
+Request API -> Chain Combat Request
+Mapping API -> Chain Intent Mapping
+```
+
+### 6. 반복 설명 / 태그형 / 장식성 주석 제거
+
+다음 유형을 제거하거나 문장형으로 바꿨다.
+
+```text
+[NOTE]
+[Policy]
+[Pass]
+/* === ... === */
+// -----------------------------------------------------------------------------
+// Exact
+// Tier 0
+// Cached
+// Remove Invalid Entry
+// Set Cooldown
+// Update blackboard
+// MODE 1 / MODE 2 / MODE 0
+```
+
+정책 의미가 있는 주석은 태그를 제거하고 이유 중심 문장으로 바꿨다.
+
+예:
+
+```cpp
+// Dead reaction is terminal and cannot be interrupted.
+```
+
+### 7. Type / Data 주석 최종 판단
+
+`CAIStructure.h`, `CWeaponStructure.h`에 남은 Type / Data 주석은 이번 브랜치에서 무리하게 제거하지 않는다.
+
+유지:
+
+```text
+enum None / All / Max sentinel 설명
+FDamageAmount damage pipeline 의미 설명
+GetTypeHash ADL 관련 짧은 설명
+```
+
+후속 이관:
+
+```text
+FAIContext field group 주석
+FOverlapContext actor/component alias 주석
+```
+
+이 항목은 `구조체 나누기 / 헤더 배치 규칙`, `네이밍 / 매개변수 작명 규칙`, `UPROPERTY Category 정리`에서 다시 판단한다.
+
+## 변경 파일 범위
+
+```text
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+Docs/04_Pull_Request/00_Pull_Request_Index.md
+Docs/04_Pull_Request/P44_UE5_Portfolio_Pull_Request.md
+
+Source/Portfolio/AI/*
+Source/Portfolio/Action/*
+Source/Portfolio/Character/*
+Source/Portfolio/Component/*
+Source/Portfolio/Controller/*
+Source/Portfolio/Core/Debug/*
+Source/Portfolio/Core/Profiling/*
+Source/Portfolio/Reaction/*
+Source/Portfolio/System/Combat/*
+Source/Portfolio/Type/*
+Source/Portfolio/Weapon/*
+```
+
+## 검증
+
+### Static check
+
+```text
+git status --short
+Result: clean
+
+git diff --check
+Result: Pass
+```
+
+### Comment rule scan
+
+다음 패턴을 재검색했다.
+
+```text
+/***
+***/
+^[space]*// [Tag]
+[NOTE]
+[Policy]
+[Pass]
+override this API
+Interface API
+ActionEvent API
+// -----------------------------------------------------------------------------
+Who: request source
+What: requested intent
+How: intent event
+[Case_
+```
+
+결과:
+
+```text
+Result: 0
+```
+
+### TODO scan
+
+```text
+TODO(Gameplay): 2
+TODO(CombatPolicy): 4
+```
+
+판단:
+
+```text
+남은 TODO 6개는 실제 구현 위치와 직접 연결된 정책 TODO이므로 유지한다.
+```
+
+### Build
+
+```text
+Not run
+```
+
+사유:
+
+```text
+이번 PR은 주석 / 문서 / section label 정리 중심이다.
+CReactionFeedbackComponent.cpp는 빈 wildcard branch를 제거하면서 동등 조건으로 정리했지만, 분기 의미는 기존과 동일하다.
+빌드가 필요한 header macro / reflection / asset reference 변경은 없다.
+```
+
+## 후속 작업
+
+이번 PR에서 처리하지 않는 항목:
+
+```text
+네이밍 / 매개변수 작명 규칙
+-> public API rename
+-> helper/API suffix 통일
+-> 매개변수명 정합성 정리
+
+구조체 나누기 / 헤더 배치 규칙
+-> CWeaponStructure.h 대형 type 분리
+-> FAIContext field group 정리
+-> FOverlapContext alias 정리
+-> EBTServiceIntervalPreset 위치 재검토
+
+UPROPERTY / Editor 노출 정리
+-> UPROPERTY Category naming 통일
+-> Category 변경에 따른 asset 영향 확인
+
+데이터 에셋 분리
+-> Action / Reaction data map build 이동
+-> DamageSpecContainer DataAsset migration
+-> AI perception config DataAsset migration
+-> feedback data type 이동
+
+상수 / CVar / RuntimeLOD 구조 정리
+-> CEnemy RuntimeLOD CVar 위치 이동
+-> RuntimeLOD policy/config 재구성
+
+const 정합성
+-> read-only API const 정리
+
+Gameplay / CombatPolicy TODO 구현
+-> dead actor TakeDamage route 정책
+-> target-side defensive gates
+-> mitigation / final damage / resource commit order
+```
+
+## PR 설명 초안
+
+```md
+## Summary
+
+- comment / section cleanup 작업 계획과 주석 사용 규칙을 문서화
+- stale / 오타 / 잘못된 주석, 태그형 주석, 장식성 banner, 코드 반복 설명 주석 정리
+- header / cpp section comment를 짧은 책임명 중심으로 정리
+- code-local TODO 6개를 Gameplay / CombatPolicy 후속 작업으로 유지 판단
+- Type / Data 주석 중 구조체/헤더 배치 작업으로 넘길 항목을 P3 final decision으로 기록
+
+## Validation
+
+- git status --short clean
+- git diff --check 통과
+- comment rule violation scan 결과 0
+- TODO scan 결과: 의도적으로 유지한 6개만 남음
+- Build not run: 주석 / 문서 / section label 정리 중심, reflection / asset reference 변경 없음
+```

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
@@ -154,7 +154,6 @@ namespace
 		RecordStateRuntimeLODTier(runtimeLODTier);
 		RecordAIIntentStateIntervalPreset(intervalPreset);
 
-		// return Interval float value
 		return GetAIIntentStateIntervalByPreset(intervalPreset);
 	}
 }

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -229,8 +229,6 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeEngageAssignmentContext(
 		return EContextBuildResult::Error;
 	}
 
-	// [TODO]
-	// Change from 'UCWorldSubsystem_CombatEngage' to 'CWorldSubsystem_EngageCoordinator'
 	const FEngageAssignmentContext previousAssignmentContext = subsystem->GetAssignment(aiController); // Previous Context
 
 	FEngageRequestContext requestContext;

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -66,7 +66,7 @@ void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, ui
 		return;
 	}
 
-	FAIContext aiContext; // OutParameter
+	FAIContext aiContext;
 
 	// Based OwnerPawn
 	EContextBuildResult deadResult = ComputeDeadContext(ownerPawn, blackboardComp, aiContext);
@@ -135,7 +135,7 @@ EContextBuildResult UCBTService_UpdateAIContext::BuildPerceptionContext(APawn* I
 	ACAIController* aiController = Cast<ACAIController>(InOwnerPawn->GetController());
 	if (!IsValid(aiController)) return EContextBuildResult::Error;
 
-	FTargetData topData; // OutParameter
+	FTargetData topData;
 	const EPerceptionBuildResult Result = aiController->BuildPerceptionContext(topData);
 
 	if (Result == EPerceptionBuildResult::Error) return EContextBuildResult::Error;

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
@@ -57,9 +57,7 @@ void UCBTService_UpdateAIIntentState::TickNode(UBehaviorTreeComponent& OwnerComp
 
 EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackboardComponent* InBlackboard, float InCurrentTime)
 {
-	// -----------------------------------------------------------------------------
-	// 1. Absolute States
-	// -----------------------------------------------------------------------------
+	// Absolute States
 	const EDeadState deadState = static_cast<EDeadState>(InBlackboard->GetValueAsEnum(CAIKey::Dead::DeadState.KeyName));
 	const bool bIsActiveReaction = InBlackboard->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName);
 	const bool bIsCombatAction = InBlackboard->GetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName);
@@ -74,9 +72,7 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 	if (bIsCombatAction)
 		return EAIIntentState::Engage;
 
-	// -----------------------------------------------------------------------------
-	// 2.  Context
-	// -----------------------------------------------------------------------------
+	// Context
 	AActor* target = Cast<AActor>(InBlackboard->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName));
 
 	const bool bHasTarget = IsValid(target);
@@ -90,26 +86,24 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 	const bool bInAlertRange = InBlackboard->GetValueAsBool(CAIKey::Alert::bInAlertRange.KeyName);
 	const ECombatRole combatRole = static_cast<ECombatRole>(InBlackboard->GetValueAsEnum(CAIKey::Engage::CombatRole.KeyName));
 
-	// -----------------------------------------------------------------------------
-	// 3. Decide Next AIIntentState
-	// -----------------------------------------------------------------------------
-	// [Case_01] No awareness: investigate only when requested or already active.
+	// Intent Decision
+	// No awareness: investigate only when requested or already active.
 	if (!bHasAwareness)
 	{
 		if (bUseInvestigate && (bShouldInvestigate || bIsInvestigating)) return EAIIntentState::Investigate;
 		return EAIIntentState::Idle;
 	}
 
-	// [Case_02] Aware + no combat role: observe only.
+	// Aware + no combat role: observe only.
 	if (combatRole == ECombatRole::None) return EAIIntentState::Observe;
 
-	// [Case_03] Aware + combat role: remember Engage as investigate candidate.
+	// Aware + combat role: remember Engage as investigate candidate.
 	if (combatRole == ECombatRole::Engage)
 	{
 		CAIBlackboardValueHelper::SetBoolIfChanged(InBlackboard, CAIKey::Investigate::bShouldInvestigate.KeyName, true);
 	}
 
-	// [Case_04] Aware + combat role: movement/combat state.
+	// Aware + combat role: movement/combat state.
 	if (!bInAlertRange) return EAIIntentState::Chase;
 
 	if (combatRole == ECombatRole::Engage) return EAIIntentState::Engage;
@@ -132,7 +126,7 @@ bool UCBTService_UpdateAIIntentState::ChangeAIIntentState(UBlackboardComponent* 
 	return true;
 }
 
-// [NOTE] Safety-net cleanup for unexpected State exit.
+// Cleanup handles unexpected intent-state exits.
 void UCBTService_UpdateAIIntentState::UpdateAIIntentStateTransition(UBlackboardComponent* InBlackboardComp, EAIIntentState InCurrentAIIntentState, EAIIntentState InNextAIIntentState)
 {
 	if (!IsValid(InBlackboardComp)) return;

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -45,7 +45,7 @@ void UCBTService_UpdateEngageContext::TickNode(UBehaviorTreeComponent& OwnerComp
 		return;
 	}
 
-	FEngageContext engageContext; // OutParameter
+	FEngageContext engageContext;
 
 	const EContextBuildResult buildResult = BuildEngageContext(ownerPawn, blackBoardComp, engageContext);
 

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.cpp
@@ -40,7 +40,6 @@ EBTNodeResult::Type UCBTTask_SelectPatrolPoint::ExecuteTask(UBehaviorTreeCompone
 	{
 	case EPatrolMode::Random:
 	{
-		// Select Point [Random]
 		nextIndex = FMath::RandRange(0, count - 1);
 
 		// Reroll
@@ -54,7 +53,6 @@ EBTNodeResult::Type UCBTTask_SelectPatrolPoint::ExecuteTask(UBehaviorTreeCompone
 	{
 		if (currentIndex < 0) currentIndex = 0;
 
-		// Select Point [Loop]
 		nextIndex = (currentIndex + 1) % count;
 
 		break;
@@ -64,7 +62,6 @@ EBTNodeResult::Type UCBTTask_SelectPatrolPoint::ExecuteTask(UBehaviorTreeCompone
 	{
 		if (currentIndex < 0) currentIndex = 0;
 
-		// Select Point [Reverse]
 		nextIndex = bPatrolReverse ? currentIndex - 1 : currentIndex + 1;
 
 		// Reverse in last point (count - 1 -> count - 2)

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartCombatAction.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_StartCombatAction.cpp
@@ -70,7 +70,6 @@ EBTNodeResult::Type UCBTTask_StartCombatAction::ExecuteTask(UBehaviorTreeCompone
 	const float cooldown = enemy->GetCombatActionCooldown();
 	const float nextCombatActionTime = currentTime + cooldown;
 	
-	// Set Cooldown
 	blackboardComp->SetValueAsFloat(CAIKey::Engage::NextCombatActionTime.KeyName, nextCombatActionTime);
 	FAICombatBTDebug::RecordCombatActionTaskSucceededForAudit(aiController, enemy, targetActor, CombatActionIntent, requestResult, cooldown, nextCombatActionTime);
 

--- a/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.cpp
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIStateRuntimeLODPolicy.cpp
@@ -7,7 +7,7 @@ namespace
 	TAutoConsoleVariable<int32> CVarAIStateRuntimeLODPolicyMode(
 		TEXT("Portfolio.AI.RuntimeLOD.StatePolicyMode"),
 		0,
-		TEXT("Controls AI Runtime LOD policy source. 0: per-system RuntimeLOD CVar modes, 1: state-based RuntimeLOD tier snapshot."),
+		TEXT("Controls AI Runtime LOD policy source. 0: per-system Runtime LOD CVar modes, 1: state-based Runtime LOD tier snapshot."),
 		ECVF_Default);
 }
 

--- a/Source/Portfolio/Action/CAction.cpp
+++ b/Source/Portfolio/Action/CAction.cpp
@@ -226,13 +226,11 @@ void UCAction::Complete()
 
 bool UCAction::ReserveChain(const FActionData& InData)
 {
-	// Specific Actions override this API.
 	return false;
 }
 
 void UCAction::ConsumeChain()
 {
-	// Specific Actions override this API.
 }
 
 EActionStopReason UCAction::ResolveActionStopReason(const FExecutionInterventionDirective& InDirective) const
@@ -469,7 +467,6 @@ void UCAction::HandleNotifyCommand(EActionNotifyCommand InCommand)
 
 void UCAction::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 {
-	// Specific Actions override this API.
 }
 
 void UCAction::HandleNotifyFeedback(EActionFeedbackTiming InTiming, FName InTriggerKey)

--- a/Source/Portfolio/Action/CAction.h
+++ b/Source/Portfolio/Action/CAction.h
@@ -163,7 +163,7 @@ protected:
 	void EmitActionEvent(EActionEventType InEventType, int32 InActionIndex = INDEX_NONE) const;
 
 public:
-	// [Legacy delegate]
+	// Legacy Delegate
 	UFUNCTION()
 	virtual void OnWeaponActorCollisionEnabled() {};
 

--- a/Source/Portfolio/Action/CAction.h
+++ b/Source/Portfolio/Action/CAction.h
@@ -145,12 +145,12 @@ public:
 
 public:
 	// Intervention Match
-	virtual bool WantIntervention(const FExecutionInterventionQuery& InQuery) const; 	// Incoming API
-	virtual bool AllowIntervention(const FExecutionInterventionQuery& InQuery) const;	// Acitve	API
+	virtual bool WantIntervention(const FExecutionInterventionQuery& InQuery) const;
+	virtual bool AllowIntervention(const FExecutionInterventionQuery& InQuery) const;
 
 public:
 	// Observable Overlay Match
-	virtual void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const;	// Incoming API
+	virtual void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const;
 
 private:
 	bool MatchesWantInterventionRules(const TArray<FExecutionInterventionWantRule>& InRules, const FExecutionParticipant& InParticipant) const;

--- a/Source/Portfolio/Character/CAnimInstance.h
+++ b/Source/Portfolio/Character/CAnimInstance.h
@@ -11,7 +11,6 @@ class PORTFOLIO_API UCAnimInstance : public UAnimInstance
 	GENERATED_BODY()
 
 protected:
-	/* === Injected Animation Data === */
 	UPROPERTY(BlueprintReadOnly, Category = "Movement")
 	float Speed = 0.f;
 
@@ -32,7 +31,6 @@ protected:
 	bool bIsGuardingPose = false;
 
 private:
-	/* === Cached Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Cached = nullptr;
 
@@ -49,7 +47,6 @@ private:
 	class UCDefenseComponent* DefenseComp_Cached = nullptr;
 
 private:
-	// Profiling State
 	float RuntimeLODAnimationRefreshElapsed = 0.f;
 
 public:
@@ -67,26 +64,24 @@ private:
 
 private:
 	// Animation Profiling Gate
-	// 1. Lifecycle
 	void InitializeAnimationStateForProfiling();
 	void ClearAnimationStateForProfiling();
 
-	// 2. Condition
+	// Condition
 	bool ShouldReduceEnemyAnimationRefreshForProfiling() const;
 	bool IsEnemyAnimationProfilingTarget() const;
 
-	// 3. Query
+	// Query
 	float GetReducedAnimationRefreshIntervalForProfiling() const;
 
-	// 4. Gate
+	// Gate
 	bool ShouldRefreshAnimationParameters(float DeltaSeconds);
 
 private:
 	// Animation Refresh Audit
-	// 1. Condition
 	bool ShouldAuditAnimationRefreshForProfiling() const;
 
-	// 2. Record
+	// Record
 	void RecordAnimationRefreshAttemptForProfiling() const;
 	void RecordAnimationRefreshExecutedForProfiling() const;
 	void RecordAnimationRefreshSkippedForProfiling() const;

--- a/Source/Portfolio/Character/CAnimInstance.h
+++ b/Source/Portfolio/Character/CAnimInstance.h
@@ -11,7 +11,7 @@ class PORTFOLIO_API UCAnimInstance : public UAnimInstance
 	GENERATED_BODY()
 
 protected:
-	/* === Injection Datas === */
+	/* === Injected Animation Data === */
 	UPROPERTY(BlueprintReadOnly, Category = "Movement")
 	float Speed = 0.f;
 

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -356,7 +356,7 @@ float ACEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, A
 	}
 	else
 	{
-		// FallBack
+		// Fallback
 		finalDamage = DamageAmount;
 	}
 

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -346,7 +346,7 @@ float ACEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, A
 	// Minimal validation
 	if (DamageAmount <= 0.f) return 0.f;
 
-	// TODO: Check DeadFlag and early return
+	// TODO(Gameplay): Decide whether dead actors should bypass the engine TakeDamage route.
 
 	float finalDamage = DamageAmount;
 
@@ -561,8 +561,6 @@ void ACEnemy::RequestChainCombatAction(EActionType InActionType, int32 InActionI
 // Mapping API (ActionData -> Intent)
 ECombatActionIntent ACEnemy::ResolveChainCombatIntent(EActionType InActionType, int32 InActionIndex) const
 {
-	// TODO: Use InActionIndex when ai combo branch
-
 	switch (InActionType)
 	{
 	case EActionType::ComboAttack:

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -126,7 +126,6 @@ void ACEnemy::BeginPlay()
 
 	if (IsValid(ActionComponent))
 	{
-		// Update blackboard
 		ActionComponent->OnActionTypeChanged.AddDynamic(this, &ACEnemy::OnActionTypeChanged);
 		ActionComponent->OnActionEvent.AddDynamic(this, &ACEnemy::OnActionEvent);
 	}

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -49,76 +49,59 @@ ACEnemy::ACEnemy()
 {
 	PrimaryActorTick.bCanEverTick = true;
 
-	// Init CapsuleComp
 	UCapsuleComponent* CapsuleComp = GetCapsuleComponent();
 	check(CapsuleComp);
 	CapsuleComp->InitCapsuleSize(40.0f, 90.0f);
 
-	// Init SkeletalMeshComp
 	USkeletalMeshComponent* MeshComp = GetMesh();
 	check(MeshComp);
 	MeshComp->SetRelativeLocation(FVector(0.0f, 0.0f, -90.0f));
 	MeshComp->SetRelativeRotation(FRotator(0.0f, -90.0f, 0.0f)); // FRotator: (Pitch, Yaw, Roll)
 
-	// Init CharacterMovementComp
 	UCharacterMovementComponent* characterMovementComp = GetCharacterMovement();
 	check(characterMovementComp);
 	characterMovementComp->bOrientRotationToMovement = true;
 	characterMovementComp->MaxWalkSpeed = 600.0f;
 
-	// Init MovementComp (Custom)
 	MovementComponent = CreateDefaultSubobject<UCMovementComponent>(TEXT("Movement"));
 	check(MovementComponent);
 
-	// Init WeaponComp
 	WeaponComponent = CreateDefaultSubobject<UCWeaponComponent>(TEXT("Weapon"));
 	check(WeaponComponent);
 
-	// Init StateComp
 	StateComponent = CreateDefaultSubobject<UCStateComponent>(TEXT("State"));
 	check(StateComponent);
 
-	// Init HealthComp
 	HealthComponent = CreateDefaultSubobject<UCHealthComponent>(TEXT("Health"));
 	check(HealthComponent);
 
-	// Init ObservableOverlayComp
 	ObservableOverlayComponent = CreateDefaultSubobject<UCObservableOverlayComponent>(TEXT("ObservableOverlay"));
 	check(ObservableOverlayComponent);
 
-	// Init CombatSignalSourceComp
 	CombatSignalSourceComponent = CreateDefaultSubobject<UCCombatSignalSourceComponent>(TEXT("CombatSignalSource"));
 	check(CombatSignalSourceComponent);
 
-	// Init CombatSignalTargetComp
 	CombatSignalTargetComponent = CreateDefaultSubobject<UCCombatSignalTargetComponent>(TEXT("CombatSignalTarget"));
 	check(CombatSignalTargetComponent);
 
-	// Init ActionOrchestratorComp
 	ActionOrchestratorComponent = CreateDefaultSubobject<UCActionOrchestratorComponent>(TEXT("ActionOrchestrator"));
 	check(ActionOrchestratorComponent);
 
-	// Init ReactionOrchestratorComp
 	ReactionOrchestratorComponent = CreateDefaultSubobject<UCReactionOrchestratorComponent>(TEXT("ReactionOrchestrator"));
 	check(ReactionOrchestratorComponent);
 
-	// Init ActionComp
 	ActionComponent = CreateDefaultSubobject<UCActionComponent>(TEXT("Action"));
 	check(ActionComponent);
 
-	// Init ReactionComp
 	ReactionComponent = CreateDefaultSubobject<UCReactionComponent>(TEXT("Reaction"));
 	check(ReactionComponent);
 
-	// Init HitFeedbackComp
 	HitFeedbackComponent = CreateDefaultSubobject<UCHitFeedbackComponent>(TEXT("HitFeedback"));
 	check(HitFeedbackComponent);
 
-	// Init ActionFeedbackComp
 	ActionFeedbackComponent = CreateDefaultSubobject<UCActionFeedbackComponent>(TEXT("ActionFeedback"));
 	check(ActionFeedbackComponent);
 
-	// Init ReactionFeedbackComp
 	ReactionFeedbackComponent = CreateDefaultSubobject<UCReactionFeedbackComponent>(TEXT("ReactionFeedback"));
 	check(ReactionFeedbackComponent);
 }
@@ -343,7 +326,6 @@ void ACEnemy::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 
 float ACEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
-	// Minimal validation
 	if (DamageAmount <= 0.f) return 0.f;
 
 	// TODO(Gameplay): Decide whether dead actors should bypass the engine TakeDamage route.
@@ -356,11 +338,9 @@ float ACEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, A
 	}
 	else
 	{
-		// Fallback
 		finalDamage = DamageAmount;
 	}
 
-	// Engine-Event Trigger
 	Super::TakeDamage(finalDamage, DamageEvent, EventInstigator, DamageCauser);
 
 	return finalDamage;

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -528,7 +528,7 @@ void ACEnemy::OnActionEvent(ACharacter* InOwnerCharacter, EActionType InActionTy
 	}
 }
 
-// Request API (ActionData -> Intent -> Handle)
+// Chain Combat Request
 void ACEnemy::RequestChainCombatAction(EActionType InActionType, int32 InActionIndex)
 {
 	const ECombatActionIntent combatActionIntent = ResolveChainCombatIntent(InActionType, InActionIndex);
@@ -538,7 +538,7 @@ void ACEnemy::RequestChainCombatAction(EActionType InActionType, int32 InActionI
 	if (!actionRequestResult.IsReservedResult()) return;
 }
 
-// Mapping API (ActionData -> Intent)
+// Chain Intent Mapping
 ECombatActionIntent ACEnemy::ResolveChainCombatIntent(EActionType InActionType, int32 InActionIndex) const
 {
 	switch (InActionType)

--- a/Source/Portfolio/Character/Enemy/CEnemy.h
+++ b/Source/Portfolio/Character/Enemy/CEnemy.h
@@ -256,7 +256,7 @@ private:
 	void OnActionEvent(ACharacter* InOwnerCharacter, EActionType InActionType, int32 InActionIndex, EActionEventType InActionEventType);
 
 private:
-	// ActionEvent API (Event -> Intent -> Handle)
+	// Action Event Routing
 	void RequestChainCombatAction(EActionType InActionType, int32 InActionIndex);
 	ECombatActionIntent ResolveChainCombatIntent(EActionType InActionType, int32 InActionIndex) const;
 };

--- a/Source/Portfolio/Character/Enemy/CEnemy.h
+++ b/Source/Portfolio/Character/Enemy/CEnemy.h
@@ -153,21 +153,20 @@ private:
 
 private:
 	// Runtime LOD
-	// 1. Update
 	void UpdateRuntimeLODMeshMode();
 	void UpdateRuntimeLODActorTickMode();
 
-	// 2. Lifecycle
+	// Lifecycle
 	void CacheRuntimeLODActorTickOriginalState();
 
-	// 3. Dispatch
+	// Dispatch
 	void ApplyRuntimeLODActorTickMode(int32 InActorTickMode);
 
-	// 4. Enemy Actor Tick Mode
+	// Actor Tick Mode
 	void ApplyRuntimeLODActorTickDefault();
 	void ApplyRuntimeLODActorTickDisabled();
 
-	// 5. Enemy Actor Tick State
+	// Actor Tick State
 	void RestoreRuntimeLODActorTick();
 	void DisableRuntimeLODActorTick();
 

--- a/Source/Portfolio/Character/Player/CPlayer.cpp
+++ b/Source/Portfolio/Character/Player/CPlayer.cpp
@@ -33,18 +33,15 @@
 
 ACPlayer::ACPlayer()
 {
-	// Init CapsuleComp
 	UCapsuleComponent* CapsuleComp = GetCapsuleComponent();
 	check(CapsuleComp);
 	CapsuleComp->InitCapsuleSize(40.0f, 90.0f);
 
-	// Init SkeletalMeshComp
 	USkeletalMeshComponent* MeshComp = GetMesh();
 	check(MeshComp);
 	MeshComp->SetRelativeLocation(FVector(0.0f, 0.0f, -90.0f));
 	MeshComp->SetRelativeRotation(FRotator(0.0f, -90.0f, 0.0f)); // FRotator: (Pitch, Yaw, Roll)
 
-	// Init CharacterMovementComp
 	UCharacterMovementComponent* characterMovementComp = GetCharacterMovement();
 	check(characterMovementComp);
 	characterMovementComp->bOrientRotationToMovement = true;
@@ -52,7 +49,6 @@ ACPlayer::ACPlayer()
 
 	bUseControllerRotationYaw = false;
 
-	// Init SpringArmComp
 	SpringArmComponent = CreateDefaultSubobject<USpringArmComponent>(TEXT("SpringArm"));
 	check(SpringArmComponent);
 	SpringArmComponent->SetupAttachment(GetCapsuleComponent());
@@ -60,70 +56,54 @@ ACPlayer::ACPlayer()
 	SpringArmComponent->TargetArmLength = 300.0f;
 	SpringArmComponent->bUsePawnControlRotation = true;
 
-	// Init CameraComp
 	CameraComponent = CreateDefaultSubobject<UCameraComponent>(TEXT("Camera"));
 	check(CameraComponent);
 	CameraComponent->SetupAttachment(SpringArmComponent);
 	CameraComponent->SetRelativeLocation(FVector(0.0f, 40.0f, 0.0f));
 	CameraComponent->bUsePawnControlRotation = false;
 
-	// Init MovementComp (Custom)
 	MovementComponent = CreateDefaultSubobject<UCMovementComponent>(TEXT("Movement"));
 	check(MovementComponent);
 
-	// Init WeaponComp
 	WeaponComponent = CreateDefaultSubobject<UCWeaponComponent>(TEXT("Weapon"));
 	check(WeaponComponent);
 
-	// Init StateComp
 	StateComponent = CreateDefaultSubobject<UCStateComponent>(TEXT("State"));
 	check(StateComponent);
 
-	// Init HealthComp
 	HealthComponent = CreateDefaultSubobject<UCHealthComponent>(TEXT("Health"));
 	check(HealthComponent);
 
-	// Init DefenseComp
 	DefenseComponent = CreateDefaultSubobject<UCDefenseComponent>(TEXT("Defense"));
 	check(DefenseComponent);
 
-	// Init ObservableOverlayComp
 	ObservableOverlayComponent = CreateDefaultSubobject<UCObservableOverlayComponent>(TEXT("ObservableOverlay"));
 	check(ObservableOverlayComponent);
 
-	// Init CombatSignalSourceComp
 	CombatSignalSourceComponent = CreateDefaultSubobject<UCCombatSignalSourceComponent>(TEXT("CombatSignalSource"));
 	check(CombatSignalSourceComponent);
 
-	// Init CombatSignalTargetComp
 	CombatSignalTargetComponent = CreateDefaultSubobject<UCCombatSignalTargetComponent>(TEXT("CombatSignalTarget"));
 	check(CombatSignalTargetComponent);
 
-	// Init ActionOrchestratorComp
 	ActionOrchestratorComponent = CreateDefaultSubobject<UCActionOrchestratorComponent>(TEXT("ActionOrchestrator"));
 	check(ActionOrchestratorComponent);
 
-	// Init ReactionOrchestratorComp
 	ReactionOrchestratorComponent = CreateDefaultSubobject<UCReactionOrchestratorComponent>(TEXT("ReactionOrchestrator"));
 	check(ReactionOrchestratorComponent);
 
-	// Init ActionComp
 	ActionComponent = CreateDefaultSubobject<UCActionComponent>(TEXT("Action"));
 	check(ActionComponent);
 
-	// Init ReactionComp
 	ReactionComponent = CreateDefaultSubobject<UCReactionComponent>(TEXT("Reaction"));
 	check(ReactionComponent);
 
-	// Init HitFeedbackComp
 	HitFeedbackComponent = CreateDefaultSubobject<UCHitFeedbackComponent>(TEXT("HitFeedback"));
 	check(HitFeedbackComponent);
 
-	// Init ActionFeedbackComp
 	ActionFeedbackComponent = CreateDefaultSubobject<UCActionFeedbackComponent>(TEXT("ActionFeedback"));
 	check(ActionFeedbackComponent);
 
-	// Init ReactionFeedbackComp
 	ReactionFeedbackComponent = CreateDefaultSubobject<UCReactionFeedbackComponent>(TEXT("ReactionFeedback"));
 	check(ReactionFeedbackComponent);
 }
@@ -237,7 +217,6 @@ void ACPlayer::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 
 float ACPlayer::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
-	// Minimal validation
 	if (DamageAmount <= 0.f) return 0.f;
 
 	// TODO(Gameplay): Decide whether dead actors should bypass the engine TakeDamage route.
@@ -250,11 +229,9 @@ float ACPlayer::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, 
 	}
 	else
 	{
-		// Fallback
 		finalDamage = DamageAmount;
 	}
 
-	// Engine-Event Trigger
 	Super::TakeDamage(finalDamage, DamageEvent, EventInstigator, DamageCauser);
 
 	return finalDamage;

--- a/Source/Portfolio/Character/Player/CPlayer.cpp
+++ b/Source/Portfolio/Character/Player/CPlayer.cpp
@@ -250,7 +250,7 @@ float ACPlayer::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, 
 	}
 	else
 	{
-		// FallBack
+		// Fallback
 		finalDamage = DamageAmount;
 	}
 

--- a/Source/Portfolio/Character/Player/CPlayer.cpp
+++ b/Source/Portfolio/Character/Player/CPlayer.cpp
@@ -240,7 +240,7 @@ float ACPlayer::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, 
 	// Minimal validation
 	if (DamageAmount <= 0.f) return 0.f;
 
-	// TODO: Check DeadFlag and early return
+	// TODO(Gameplay): Decide whether dead actors should bypass the engine TakeDamage route.
 
 	float finalDamage = DamageAmount;
 

--- a/Source/Portfolio/Character/Player/CPlayer.h
+++ b/Source/Portfolio/Character/Player/CPlayer.h
@@ -121,7 +121,7 @@ private:
 	bool TryRequestParryStaggerReaction(const FCombatResultPacket& InCombatResultPacket);
 
 public:
-	// Interface API
+	// Interface
 	int GetTargetPriority() const override { return Priority; }
 
 public:

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -672,7 +672,6 @@ UCAction* UCActionComponent::FindActionExecutor(const UClass* InClass)
 
 	if (!IsValid(found))
 	{
-		// Remove Invalid Entry
 		ActionExecutorMap.Remove(InClass);
 
 		return nullptr;

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -212,7 +212,7 @@ UCAction* UCActionComponent::ResolveActionExecutor(const FActionData& InData)
 	UCAction* found = FindActionExecutor(InData.ActionExecutorKey.Get());
 	if (IsValid(found)) return found;
 
-	// 2) [Policy] Try Add and cache Action; return if valid
+	// 2) Try add and cache Action; return if valid.
 	UCAction* add = AddActionExecutor(InData.ActionExecutorKey);
 	if (IsValid(add)) return add;
 
@@ -282,7 +282,6 @@ bool UCActionComponent::ApplyActionDecision(const FActionExecutionResult& InResu
 
 	case EExecutionApplyMode::Intervene:
 	{
-		// [NOTE] Try Apply Intervention
 		if (!ApplyExecutionInterventionDirective(InResult.InterventionDirective))
 		{
 			FActionComponentDebug::RecordActionDecisionRejectedForAudit(OwnerCharacter_Injected, InResult, TEXT("ApplyDecision"), TEXT("InterventionFailed"));
@@ -590,7 +589,7 @@ void UCActionComponent::BuildActionDataMap(bool bRebuildAll)
 			}
 			else // bRebuildAll == false
 			{
-				// [Policy] Currently set to 'skip'. (Options: ignore | restart | stop-then-play)
+				// Duplicate action data is skipped unless the map is being rebuilt.
 				continue;
 			}
 		}
@@ -787,7 +786,7 @@ bool UCActionComponent::InterruptActiveAction(const FExecutionInterventionDirect
 	UCAction* activeExecutor = GetActiveActionExecutor();
 	if (!IsValid(activeExecutor))
 	{
-		// [NOTE] Fallback
+		// Force end when the active executor is already invalid.
 		return EndActiveAction(finishReason);
 	}
 
@@ -795,7 +794,7 @@ bool UCActionComponent::InterruptActiveAction(const FExecutionInterventionDirect
 
 	if (IsActive())
 	{
-		// [NOTE] Fallback
+		// Force end when the executor interrupt callback did not clear active state.
 		return EndActiveAction(finishReason);
 	}
 

--- a/Source/Portfolio/Component/CActionComponent.h
+++ b/Source/Portfolio/Component/CActionComponent.h
@@ -18,12 +18,9 @@ class PORTFOLIO_API UCActionComponent : public UActorComponent
 public:
 	UCActionComponent();
 
-	// === ActionData ======================================= //
 private:
 	UPROPERTY(EditAnywhere, Category = "Action|Data")
 	TArray<FActionData> ActionDatas;
-
-	// ====================================================== //
 
 private:
 	UPROPERTY(Transient)
@@ -33,7 +30,6 @@ private:
 	TMap<class UClass*, class UCAction*> ActionExecutorMap;
 
 private:
-	/* === Active Action Context === */
 	UPROPERTY(Transient)
 	EActionType ActiveActionType = EActionType::Max;
 
@@ -47,7 +43,6 @@ private:
 	class UCAction* ActiveActionExecutor = nullptr;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
@@ -79,7 +74,6 @@ private:
 	class UCActionFeedbackComponent* ActionFeedbackComp_Injected = nullptr;
 
 public:
-	/* === Delegate === */
 	FActionTypeChanged OnActionTypeChanged;
 	FActionEventSignature OnActionEvent;
 

--- a/Source/Portfolio/Component/CActionComponent.h
+++ b/Source/Portfolio/Component/CActionComponent.h
@@ -165,7 +165,7 @@ private:
 	void ResetActiveActionRuntimeState();
 
 private:
-	// Data Build (temporary: move to DataAsset)
+	// Data Build
 	void BuildActionDataMap(bool bRebuildAll);
 	void BuildActionExecutorMap(bool bRebuildAll);
 

--- a/Source/Portfolio/Component/CActionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CActionFeedbackComponent.cpp
@@ -325,7 +325,6 @@ void UCActionFeedbackComponent::PlayActionVFX(const FActionVFXFeedbackData& InAc
 
 	case EActionVFXPlayType::Loop:
 	{
-		// TODO: Implement Loop
 		FCombatFeedbackDebug::RecordActionFeedbackPresentationRejectedForAudit(OwnerCharacter_Injected, this, TEXT("VFX"), InActionVFXFeedbackData.VFX, TEXT("LoopNotImplemented"));
 		return;
 	}
@@ -366,7 +365,6 @@ void UCActionFeedbackComponent::PlayActionSFX(const FActionSFXFeedbackData& InAc
 
 	case EActionSFXPlayType::Loop:
 	{
-		// TODO: Implement Loop
 		FCombatFeedbackDebug::RecordActionFeedbackPresentationRejectedForAudit(OwnerCharacter_Injected, this, TEXT("SFX"), InActionSFXFeedbackData.SFX, TEXT("LoopNotImplemented"));
 		return;
 	}

--- a/Source/Portfolio/Component/CActionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CActionFeedbackComponent.cpp
@@ -171,7 +171,7 @@ void UCActionFeedbackComponent::ExecuteTrailFeedbacks(const FActionFeedbackReque
 			continue;
 		}
 
-		// Tie: Error (Architect Miss)
+		// Duplicate highest score: reject ambiguous trail match.
 		++bestMatchCount;
 	}
 

--- a/Source/Portfolio/Component/CActionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CActionFeedbackComponent.cpp
@@ -89,29 +89,24 @@ bool UCActionFeedbackComponent::CanPlayActionFeedback(const FActionFeedbackReque
 
 EActionFeedbackMatchTier UCActionFeedbackComponent::CalculateMatchTier(const FActionFeedbackKey& InDataKey, EActionFeedbackTiming InDataTiming, FName InDataTriggerKey, const FActionFeedbackRequest& InActionFeedbackRequest) const
 {
-	// Exact
 	if (InDataTiming != InActionFeedbackRequest.ActionFeedbackTiming)
 		return EActionFeedbackMatchTier::None;
 
 	if (InDataTriggerKey != InActionFeedbackRequest.TriggerKey)
 		return EActionFeedbackMatchTier::None;
 
-	// Exact & Wildcard
 	const bool bActionExact = (InDataKey.ActionType == InActionFeedbackRequest.ActionFeedbackKey.ActionType);
 	const bool bActionAny = (InDataKey.ActionType == EActionType::All);
 
 	const bool bIndexExact = (InDataKey.ActionIndex == InActionFeedbackRequest.ActionFeedbackKey.ActionIndex);
 	const bool bIndexAny = (InDataKey.ActionIndex == INDEX_NONE);
 
-	// Tier 0
 	if (bActionExact && bIndexExact)
 		return EActionFeedbackMatchTier::ExactActionExactIndex;
 
-	// Tier 1	
 	if (bActionExact && bIndexAny)
 		return EActionFeedbackMatchTier::ExactActionAnyIndex;
 
-	// Tier 2
 	if (bActionAny && bIndexAny)
 		return EActionFeedbackMatchTier::AnyActionAnyIndex;
 
@@ -150,7 +145,6 @@ FActionSFXExecutionKey UCActionFeedbackComponent::BuildActionSFXExecutionKey(con
 
 void UCActionFeedbackComponent::ExecuteTrailFeedbacks(const FActionFeedbackRequest& InActionFeedbackRequest)
 {
-	// Cached Score and Data
 	EActionFeedbackMatchTier bestTier = EActionFeedbackMatchTier::None;
 	const FTrailFeedbackData* bestData = nullptr;
 	int32 bestMatchCount = 0;
@@ -162,7 +156,6 @@ void UCActionFeedbackComponent::ExecuteTrailFeedbacks(const FActionFeedbackReque
 		if (matchTier == EActionFeedbackMatchTier::None) continue;
 		if (static_cast<uint8>(matchTier) < static_cast<uint8>(bestTier)) continue;
 
-		// New high score: Reset and update
 		if (static_cast<uint8>(matchTier) > static_cast<uint8>(bestTier))
 		{
 			bestTier = matchTier;
@@ -171,7 +164,6 @@ void UCActionFeedbackComponent::ExecuteTrailFeedbacks(const FActionFeedbackReque
 			continue;
 		}
 
-		// Duplicate highest score: reject ambiguous trail match.
 		++bestMatchCount;
 	}
 
@@ -203,7 +195,6 @@ void UCActionFeedbackComponent::ExecuteVFXFeedbacks(const FActionFeedbackRequest
 		if (matchTier == EActionFeedbackMatchTier::None) continue;
 		if (static_cast<uint8>(matchTier) < static_cast<uint8>(bestTier)) continue;
 
-		// New high score: Reset and update
 		if (static_cast<uint8>(matchTier) > static_cast<uint8>(bestTier))
 		{
 			bestTier = matchTier;
@@ -212,7 +203,6 @@ void UCActionFeedbackComponent::ExecuteVFXFeedbacks(const FActionFeedbackRequest
 			continue;
 		}
 
-		// Tie: Add to list
 		matchedDatas.Add(&actionVFXFeedbackData);
 	}
 
@@ -252,7 +242,6 @@ void UCActionFeedbackComponent::ExecuteSFXFeedbacks(const FActionFeedbackRequest
 		if (matchTier == EActionFeedbackMatchTier::None) continue;
 		if (static_cast<uint8>(matchTier) < static_cast<uint8>(bestTier)) continue;
 
-		// New high score: Reset and update
 		if (static_cast<uint8>(matchTier) > static_cast<uint8>(bestTier))
 		{
 			bestTier = matchTier;
@@ -261,7 +250,6 @@ void UCActionFeedbackComponent::ExecuteSFXFeedbacks(const FActionFeedbackRequest
 			continue;
 		}
 
-		// Tie: Add to list
 		matchedDatas.Add(&actionSFXFeedbackData);
 	}
 

--- a/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
+++ b/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
@@ -162,7 +162,6 @@ FActionRequestResult UCActionOrchestratorComponent::ConsumeDeferredAction(EDefer
 	if (InConsumeKey == EDeferredActionConsumeKey::None || InConsumeKey == EDeferredActionConsumeKey::Max)
 		return BuildActionRequestResult(EActionRequestResultType::Rejected, EActionRequestRejectReason::InvalidRequest);
 
-	// Find the deferred candidate for this consume key.
 	const int32 foundIndex = DeferredActionCandidates.IndexOfByPredicate(
 		[InConsumeKey](const FDeferredActionCandidate& InEntry)
 		{

--- a/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
+++ b/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
@@ -398,7 +398,6 @@ FActionRequestResult UCActionOrchestratorComponent::ProcessActionCandidate(const
 
 	const FExecutionDecisionQuery decisionQuery = BuildDecisionQuery(incomingContext);
 
-	// [NOTE] Returns true when the incoming candidate should be deferred and provides its consume key.
 	EDeferredActionConsumeKey consumeKey = EDeferredActionConsumeKey::None;
 	if (TryResolveDeferredConsumeKey(InIncomingCandidate, decisionQuery, consumeKey))
 	{
@@ -679,7 +678,6 @@ void UCActionOrchestratorComponent::ResolveExecutionApplyMode(const FExecutionDe
 	InOutResult.ApplyMode = EExecutionApplyMode::None;
 	InOutResult.InterventionDirective = FExecutionInterventionDirective();
 
-	// [NOTE] Early return ignore and reject decision
 	if (!InOutResult.IsAcceptedDecision()) return;
 
 	switch (InOutResult.Relationship)
@@ -885,11 +883,9 @@ bool UCActionOrchestratorComponent::BuildInterventionDirective(const FExecutionI
 
 FActionRequestResult UCActionOrchestratorComponent::DispatchActionDecision(const FActionExecutionResult& InResult)
 {
-	// [NOTE] Request ignore result
 	if (InResult.Decision == EExecutionDecision::Ignore)
 		return BuildActionRequestResult(EActionRequestResultType::Ignored);
 
-	// [NOTE] Request rejected result
 	if (!InResult.IsAcceptedDecision())
 		return BuildActionRequestResult(EActionRequestResultType::Rejected, InResult.RejectReason);
 

--- a/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
+++ b/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
@@ -330,14 +330,12 @@ bool UCActionOrchestratorComponent::ResolveCombatActionCandidate(const FCombatAc
 		{
 		case EActionIntentEvent::Started:
 		{
-			// Temporary: Started -> Guard In data key.
 			incomingCandidate.ActionDataKey.ActionIndex = GetGuardActionPhaseIndex(EGuardActionPhase::In);
 			break;
 		}
 
 		case EActionIntentEvent::Completed:
 		{
-			// Temporary: Completed -> Guard Out data key.
 			incomingCandidate.ActionDataKey.ActionIndex = GetGuardActionPhaseIndex(EGuardActionPhase::Out);
 			break;
 		}

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -368,7 +368,7 @@ void UCCombatSignalSourceComponent::ComputeSourceDamage(FCombatSignalSourceConte
 		return;
 	}
 
-	// [NOTE] Minimal sender-side request damage.
+	// Use base damage as the minimal sender-side request damage.
 	InOutCombatSignalSourceContext.DamageAmount = FDamageAmount();
 	InOutCombatSignalSourceContext.DamageAmount.RequestDamage = InOutCombatSignalSourceContext.DamageSpec.BaseDamage;
 

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -298,7 +298,6 @@ bool UCCombatSignalSourceComponent::ValidateContext(FCombatSignalSourceContext& 
 		return false;
 	}
 
-	// Valid Context
 	InOutCombatSignalSourceContext.bAccepted = true;
 	InOutCombatSignalSourceContext.RejectReason = ECombatSignalSourceRejectReason::None;
 	return true;
@@ -467,7 +466,6 @@ void UCCombatSignalSourceComponent::CacheDamagedTargetInWindow(const FCombatSign
 	AActor* targetActor = InCombatSignalSourceContext.TargetActor;
 	if (!IsValid(targetActor)) return;
 
-	// Cached
 	auto& damagedTargets = DamagedTargetContainer.FindOrAdd(InCombatSignalSourceContext.HitWindowKey);
 	damagedTargets.Add(targetActor);
 }

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.h
@@ -18,7 +18,7 @@ public:
 
 private:
 	UPROPERTY(EditAnywhere)
-	TMap<FDamageSpecKey, FDamageSpec> DamageSpecContainer;	// TODO: Seperate DataAsset (DB)
+	TMap<FDamageSpecKey, FDamageSpec> DamageSpecContainer;	// TODO: Separate DataAsset (DB)
 
 private:
 	TMap<FCombatSignalHitWindowKey, TSet<TWeakObjectPtr<AActor>>> DamagedTargetContainer;

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.h
@@ -24,7 +24,6 @@ private:
 	TMap<FCombatSignalHitWindowKey, TSet<TWeakObjectPtr<AActor>>> DamagedTargetContainer;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.h
@@ -18,7 +18,7 @@ public:
 
 private:
 	UPROPERTY(EditAnywhere)
-	TMap<FDamageSpecKey, FDamageSpec> DamageSpecContainer;	// TODO: Separate DataAsset (DB)
+	TMap<FDamageSpecKey, FDamageSpec> DamageSpecContainer;
 
 private:
 	TMap<FCombatSignalHitWindowKey, TSet<TWeakObjectPtr<AActor>>> DamagedTargetContainer;

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -502,8 +502,6 @@ AController* UCCombatSignalTargetComponent::ResolveInstigatorController(AControl
 	if (!IsValid(DamageCauser))
 		return nullptr;
 
-	/* === Fallback Process (DamageCauser-based) === */
-
 	// 2-1) Case 01: Explicit instigator set on the causer (ex. projectile / weaponActor / trap)
 	if (AController* causerInstigator = DamageCauser->GetInstigatorController())
 		return causerInstigator;
@@ -529,8 +527,6 @@ AController* UCCombatSignalTargetComponent::ResolveInstigatorController(AControl
 				return ownerController;
 		}
 	}
-
-	/* ============================================= */
 
 	return nullptr;
 }

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -318,11 +318,11 @@ bool UCCombatSignalTargetComponent::CanReceiveCombatSignal(FCombatSignalTargetCo
 		return true;
 	}
 
-	// TODO:
-	// Gate 3: invulnerable / iframe / god-mode state
-	// Gate 4: defensive friendly-fire check on receiver side
-	// Gate 5: receiver-side damage cooldown / hit immunity window
-	// Gate 6: defensive self-damage policy
+	// TODO(CombatPolicy): Add target-side defensive gates.
+	// - Invulnerable / iframe / god-mode state
+	// - Defensive friendly-fire check on receiver side
+	// - Receiver-side damage cooldown / hit immunity window
+	// - Defensive self-damage policy
 
 	InOutCombatSignalTargetContext.bAccepted = true;
 	InOutCombatSignalTargetContext.RejectReason = ECombatSignalTargetRejectReason::None;
@@ -335,7 +335,7 @@ bool UCCombatSignalTargetComponent::CanReceiveCombatSignal(FCombatSignalTargetCo
 void UCCombatSignalTargetComponent::ComputeTargetDamage(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const
 {
 	// Process 1: Compute Mitigation Damage
-	InOutCombatSignalTargetContext.MitigatedDamage = ComputeMitigatedDamage(InOutCombatSignalTargetContext);	// TODO
+	InOutCombatSignalTargetContext.MitigatedDamage = ComputeMitigatedDamage(InOutCombatSignalTargetContext);
 
 	// Gate 1: Zero damage
 	if (InOutCombatSignalTargetContext.bShouldCommitDamage && InOutCombatSignalTargetContext.MitigatedDamage <= KINDA_SMALL_NUMBER)
@@ -350,7 +350,7 @@ void UCCombatSignalTargetComponent::ComputeTargetDamage(FCombatSignalTargetConte
 	InOutCombatSignalTargetContext.RejectReason = ECombatSignalTargetRejectReason::None;
 
 	// Process 2: Compute FinalTaken Damage
-	InOutCombatSignalTargetContext.FinalTakenDamage = ComputeFinalTakenDamage(InOutCombatSignalTargetContext);	// TODO
+	InOutCombatSignalTargetContext.FinalTakenDamage = ComputeFinalTakenDamage(InOutCombatSignalTargetContext);
 }
 
 float UCCombatSignalTargetComponent::ComputeMitigatedDamage(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const
@@ -368,7 +368,7 @@ float UCCombatSignalTargetComponent::ComputeMitigatedDamage(FCombatSignalTargetC
 		mitigatedDamage *= 0.5f;
 	}
 
-	// TODO: Defense / Armor / Resistance Policy
+	// TODO(CombatPolicy): Add defense / armor / resistance mitigation policy.
 
 	return FMath::Max(0.f, mitigatedDamage);
 }
@@ -384,7 +384,7 @@ float UCCombatSignalTargetComponent::ComputeFinalTakenDamage(FCombatSignalTarget
 
 	const float finalTakenDamage = mitigatedDamage;
 
-	// TODO: Critical / Guard / Headshot etc Policy
+	// TODO(CombatPolicy): Add critical / guard / headshot final damage policy.
 
 	return FMath::Max(0.f, finalTakenDamage);
 }
@@ -418,7 +418,7 @@ void UCCombatSignalTargetComponent::CommitCombatSignalTarget(FCombatSignalTarget
 	// Process 4: Commit Damage To Health
 	InOutCombatSignalTargetContext.CommittedDamage = InOutCombatSignalTargetContext.bShouldCommitDamage ? CommitDamageToHealth(InOutCombatSignalTargetContext) : 0.f;
 
-	// TODO: Shield / Mana / Stamina etc + Commit Order
+	// TODO(CombatPolicy): Add shield / mana / stamina resource commit order.
 
 	// Post-state Snapshot: Set BuildResult
 	InOutCombatSignalTargetContext.DeadState_After = HealthComp_Injected->GetDeadState();
@@ -456,16 +456,12 @@ void UCCombatSignalTargetComponent::DispatchAcceptedCombatResult(const FCombatSi
 			HitFeedbackComp_Injected->PlayHitFeedback(InCombatSignalTargetPacket);
 		}
 	}
-
-	// TODO:
-	// - Debug/UI Feedback
 }
 
 void UCCombatSignalTargetComponent::DispatchRejectedCombatResult(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const
 {
 	FCombatSignalDebug::RecordTargetRejectedForAudit(InCombatSignalTargetPacket);
 	FCombatSignalDebug::PrintTargetPacketDebug(InCombatSignalTargetPacket);
-	// - Debug/UI rejected feedback
 }
 
 void UCCombatSignalTargetComponent::DispatchCombatResultToReceiver(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -334,10 +334,8 @@ bool UCCombatSignalTargetComponent::CanReceiveCombatSignal(FCombatSignalTargetCo
 
 void UCCombatSignalTargetComponent::ComputeTargetDamage(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const
 {
-	// Process 1: Compute Mitigation Damage
 	InOutCombatSignalTargetContext.MitigatedDamage = ComputeMitigatedDamage(InOutCombatSignalTargetContext);
 
-	// Gate 1: Zero damage
 	if (InOutCombatSignalTargetContext.bShouldCommitDamage && InOutCombatSignalTargetContext.MitigatedDamage <= KINDA_SMALL_NUMBER)
 	{
 		InOutCombatSignalTargetContext.bAccepted = false;
@@ -349,7 +347,6 @@ void UCCombatSignalTargetComponent::ComputeTargetDamage(FCombatSignalTargetConte
 	InOutCombatSignalTargetContext.bAccepted = true;
 	InOutCombatSignalTargetContext.RejectReason = ECombatSignalTargetRejectReason::None;
 
-	// Process 2: Compute FinalTaken Damage
 	InOutCombatSignalTargetContext.FinalTakenDamage = ComputeFinalTakenDamage(InOutCombatSignalTargetContext);
 }
 
@@ -357,7 +354,7 @@ float UCCombatSignalTargetComponent::ComputeMitigatedDamage(FCombatSignalTargetC
 {
 	const float requestedDamage = InOutCombatSignalTargetContext.RequestedDamage;
 
-	// Minimal safe policy (Check NaN, +Inf/-Inf)
+	// Non-finite damage is clamped out before target-side policy evaluation.
 	if (!FMath::IsFinite(requestedDamage)) return 0.f;
 
 	float mitigatedDamage = requestedDamage;
@@ -379,7 +376,7 @@ float UCCombatSignalTargetComponent::ComputeFinalTakenDamage(FCombatSignalTarget
 
 	const float mitigatedDamage = InOutCombatSignalTargetContext.MitigatedDamage;
 
-	// Minimal safe policy (Check NaN, +Inf/-Inf)
+	// Non-finite damage is clamped out before final damage policy evaluation.
 	if (!FMath::IsFinite(mitigatedDamage)) return 0.f;
 
 	const float finalTakenDamage = mitigatedDamage;
@@ -415,12 +412,10 @@ void UCCombatSignalTargetComponent::CommitCombatSignalTarget(FCombatSignalTarget
 {
 	if (!IsValid(HealthComp_Injected)) return;
 
-	// Process 4: Commit Damage To Health
 	InOutCombatSignalTargetContext.CommittedDamage = InOutCombatSignalTargetContext.bShouldCommitDamage ? CommitDamageToHealth(InOutCombatSignalTargetContext) : 0.f;
 
 	// TODO(CombatPolicy): Add shield / mana / stamina resource commit order.
 
-	// Post-state Snapshot: Set BuildResult
 	InOutCombatSignalTargetContext.DeadState_After = HealthComp_Injected->GetDeadState();
 	InOutCombatSignalTargetContext.HealthPointAfter = HealthComp_Injected->GetCurrentHP();
 }

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -418,7 +418,7 @@ void UCCombatSignalTargetComponent::CommitCombatSignalTarget(FCombatSignalTarget
 	// Process 4: Commit Damage To Health
 	InOutCombatSignalTargetContext.CommittedDamage = InOutCombatSignalTargetContext.bShouldCommitDamage ? CommitDamageToHealth(InOutCombatSignalTargetContext) : 0.f;
 
-	// TODO: Shield / Mana / Stemina etc + Commit Order
+	// TODO: Shield / Mana / Stamina etc + Commit Order
 
 	// Post-state Snapshot: Set BuildResult
 	InOutCombatSignalTargetContext.DeadState_After = HealthComp_Injected->GetDeadState();

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.h
@@ -16,7 +16,6 @@ public:
 	UCCombatSignalTargetComponent();
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 

--- a/Source/Portfolio/Component/CHealthComponent.cpp
+++ b/Source/Portfolio/Component/CHealthComponent.cpp
@@ -124,8 +124,6 @@ bool UCHealthComponent::TryUpdateMaxHP(float InNewMaxHP, EMaxHPUpdatePolicy InUp
 		CurrentHP = FMath::Clamp(CurrentHP, 1.f, MaxHP);
 	}
 
-	// TODO: `FOnMaxHealthChanged` Delegate Broadcast
-
 	return true;
 }
 
@@ -145,8 +143,6 @@ float UCHealthComponent::TakeDamage(float InTakeDamageAmount)
 
 	PreviousHP = oldHP;
 	CurrentHP = newHP;
-
-	// TODO: `FOnHealthChanged` Delegate Broadcast
 
 	UpdateDeadState();
 
@@ -170,8 +166,6 @@ float UCHealthComponent::TakeHeal(float InTakeHealAmount)
 
 	PreviousHP = oldHP;
 	CurrentHP = newHP;
-
-	// TODO: `FOnHealthChanged` Delegate Broadcast
 
 	UpdateDeadState();
 

--- a/Source/Portfolio/Component/CHealthComponent.cpp
+++ b/Source/Portfolio/Component/CHealthComponent.cpp
@@ -124,7 +124,7 @@ bool UCHealthComponent::TryUpdateMaxHP(float InNewMaxHP, EMaxHPUpdatePolicy InUp
 		CurrentHP = FMath::Clamp(CurrentHP, 1.f, MaxHP);
 	}
 
-	// TODO: `FOnMaxHealthChanged` Delegate BroadCast
+	// TODO: `FOnMaxHealthChanged` Delegate Broadcast
 
 	return true;
 }
@@ -146,7 +146,7 @@ float UCHealthComponent::TakeDamage(float InTakeDamageAmount)
 	PreviousHP = oldHP;
 	CurrentHP = newHP;
 
-	// TODO: `FOnHealthChanged` Delegate BroadCast
+	// TODO: `FOnHealthChanged` Delegate Broadcast
 
 	UpdateDeadState();
 
@@ -171,7 +171,7 @@ float UCHealthComponent::TakeHeal(float InTakeHealAmount)
 	PreviousHP = oldHP;
 	CurrentHP = newHP;
 
-	// TODO: `FOnHealthChanged` Delegate BroadCast
+	// TODO: `FOnHealthChanged` Delegate Broadcast
 
 	UpdateDeadState();
 

--- a/Source/Portfolio/Component/CHealthComponent.h
+++ b/Source/Portfolio/Component/CHealthComponent.h
@@ -17,7 +17,6 @@ public:
 	UCHealthComponent();
 
 private:
-	// === Initialize ===
 	UPROPERTY(EditAnywhere, Category = "Health|HP", meta = (ClampMin = 0.00))
 	float InitMaxHP = 0.f;
 
@@ -42,7 +41,6 @@ private:
 	EDeadState DeadState = EDeadState::Alive;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
@@ -60,7 +58,7 @@ public:
 	void InitializeHealth(float InInitMaxHP, float InInitCurrentHP, EMaxHPUpdatePolicy InUpdatePolicy);
 
 public:
-	/* === Skill API === */
+	// Skill API
 	// (Current not used)
 	bool TryKill();
 	bool TryRevive(float InReviveHP);
@@ -78,7 +76,7 @@ public:
 	bool CanRevive() const;
 
 public:
-	/* === Getter === */
+	// Query
 	float GetMaxHP() const { return MaxHP; }
 	float GetCurrentHP() const { return CurrentHP; }
 	float GetPreviousHP() const { return PreviousHP; }

--- a/Source/Portfolio/Component/CHealthComponent.h
+++ b/Source/Portfolio/Component/CHealthComponent.h
@@ -14,7 +14,7 @@ class PORTFOLIO_API UCHealthComponent : public UActorComponent
 	GENERATED_BODY()
 
 public:
-	UCHealthComponent(); // TODO: Extend ResourceComponent
+	UCHealthComponent();
 
 private:
 	// === Initialize ===

--- a/Source/Portfolio/Component/CHealthComponent.h
+++ b/Source/Portfolio/Component/CHealthComponent.h
@@ -58,8 +58,7 @@ public:
 	void InitializeHealth(float InInitMaxHP, float InInitCurrentHP, EMaxHPUpdatePolicy InUpdatePolicy);
 
 public:
-	// Skill API
-	// (Current not used)
+	// State Transition
 	bool TryKill();
 	bool TryRevive(float InReviveHP);
 	bool TryCancelRevive();

--- a/Source/Portfolio/Component/CHitFeedbackComponent.h
+++ b/Source/Portfolio/Component/CHitFeedbackComponent.h
@@ -45,7 +45,6 @@ private:
 	bool bEnableCameraShake = true;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 

--- a/Source/Portfolio/Component/CMovementComponent.cpp
+++ b/Source/Portfolio/Component/CMovementComponent.cpp
@@ -175,7 +175,6 @@ void UCMovementComponent::StopRuntimeLODActiveMovement()
 	aiController->StopMovement();
 }
 
-// [Final Movement Gate]
 // Final movement gate for axis input accepted by the orchestrator.
 bool UCMovementComponent::CanAcceptMoveInput() const
 {

--- a/Source/Portfolio/Component/CMovementComponent.cpp
+++ b/Source/Portfolio/Component/CMovementComponent.cpp
@@ -73,7 +73,6 @@ void UCMovementComponent::UpdateRuntimeLODMovementMode()
 
 	EnsureRuntimeLODMovementOriginalStateCached();
 
-	// Update Mode
 	if (RuntimeLODMovementState.AppliedMode != requestedMovementMode)
 	{
 		const int32 previousMovementMode = RuntimeLODMovementState.AppliedMode;
@@ -82,7 +81,6 @@ void UCMovementComponent::UpdateRuntimeLODMovementMode()
 		FMovementDebug::RecordRuntimeLODMovementModeAppliedForAudit(OwnerCharacter_Injected, this, previousMovementMode, requestedMovementMode, IsComponentTickEnabled(), bCanMove, bRuntimeLODMovementIntentBlocked);
 	}
 
-	// Block Intent
 	if (FAIMovementRuntimeLODPolicy::ShouldBlockMovementIntent(requestedMovementMode))
 	{
 		BlockRuntimeLODMovementIntent();
@@ -99,21 +97,18 @@ void UCMovementComponent::EnsureRuntimeLODMovementOriginalStateCached()
 
 void UCMovementComponent::ApplyRuntimeLODMovementMode(int32 InMovementMode)
 {
-	// MODE 1
 	if (FAIMovementRuntimeLODPolicy::ShouldDisableMovementStateRefresh(InMovementMode))
 	{
 		ApplyRuntimeLODMovementStateRefreshDisabled();
 		return;
 	}
 
-	// MODE 2
 	if (FAIMovementRuntimeLODPolicy::ShouldBlockMovementIntent(InMovementMode))
 	{
 		ApplyRuntimeLODMovementIntentBlocked();
 		return;
 	}
 
-	// MODE 0
 	ApplyRuntimeLODMovementDefault();
 }
 

--- a/Source/Portfolio/Component/CMovementComponent.h
+++ b/Source/Portfolio/Component/CMovementComponent.h
@@ -22,15 +22,11 @@ private:
 		bool bOriginalStateCached = false;
 	};
 
-	// === MovementData ===================================== //
 private:
 	UPROPERTY(EditAnywhere, Category = "Movement|Gait")
 	TMap<EMovementGait, float> GaitSpeedMap;
 
-	// ====================================================== //
-
 private:
-	/* === State === */
 	UPROPERTY(Transient)
 	EMovementGait CurrentMovementGait = EMovementGait::Run;
 
@@ -61,7 +57,6 @@ private:
 	float CurrentDirection = 0.f;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
@@ -85,21 +80,20 @@ protected:
 
 private:
 	// Runtime LOD
-	// 1. Update
 	void UpdateRuntimeLODMovementMode();
 
-	// 2. Lifecycle
+	// Lifecycle
 	void EnsureRuntimeLODMovementOriginalStateCached();
 
-	// 3. Dispatch
+	// Dispatch
 	void ApplyRuntimeLODMovementMode(int32 InMovementMode);
 
-	// 4. Movement Mode
+	// Movement Mode
 	void ApplyRuntimeLODMovementDefault();
 	void ApplyRuntimeLODMovementStateRefreshDisabled();
 	void ApplyRuntimeLODMovementIntentBlocked();
 
-	// 5. Movement State
+	// Movement State
 	void RestoreRuntimeLODMovementStateRefresh();
 	void DisableRuntimeLODMovementStateRefresh();
 	void AllowRuntimeLODMovementIntent();
@@ -107,11 +101,11 @@ private:
 	void StopRuntimeLODActiveMovement();
 
 public:
-	/* === Check / Query === */
+	// Check / Query
 	FORCEINLINE bool CheckCurrentMovementGait(EMovementGait InNewMovementGait) const { return CurrentMovementGait == InNewMovementGait; }
 
 public:
-	/* === Getter === */
+	// Query
 	FORCEINLINE EMovementGait GetCurrentMovementGait() const { return CurrentMovementGait; }
 
 public:
@@ -121,7 +115,7 @@ public:
 	FORCEINLINE float GetCurrentDirection() const { return CurrentDirection; }
 
 public:
-	/* === Setter === */
+	// Mutation
 	FORCEINLINE void SetStop() { bCanMove = false; }
 	FORCEINLINE void SetMove()
 	{
@@ -131,7 +125,7 @@ public:
 	}
 
 public:
-	/* === Movement Arbitration === */
+	// Movement Arbitration
 	bool CanAcceptMoveInput() const;
 
 	void BlockMovementIntentForRuntimeLOD();
@@ -150,7 +144,7 @@ public:
 	void OnStopJump();
 
 public:
-	/* === Movement Policy === */
+	// Movement Policy
 	void ApplyMovementOverride(EMovementGait InGait, EMovementRotationMode InRotationMode);
 	void ClearMovementOverride();
 

--- a/Source/Portfolio/Component/CPlayerFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CPlayerFeedbackComponent.cpp
@@ -63,7 +63,7 @@ void UCPlayerFeedbackComponent::EndPlay(const EEndPlayReason::Type EndPlayReason
 
 void UCPlayerFeedbackComponent::HandleCameraShakeRequest(const FCameraShakeRequest& InCameraShakeRequest)
 {
-	// [NOTE] Only the local player controller.
+	// Camera shake is requested only by the local player controller.
 	if (!CanCameraShake(InCameraShakeRequest)) return;
 
 	const float finalScale = ResolveCameraShake(InCameraShakeRequest);

--- a/Source/Portfolio/Component/CPlayerFeedbackComponent.h
+++ b/Source/Portfolio/Component/CPlayerFeedbackComponent.h
@@ -21,7 +21,6 @@ private:
 	float LocalSourceShakeScale = 0.5f;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class APlayerController* OwnerPlayerController_Injected = nullptr;
 

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -170,11 +170,9 @@ bool UCReactionComponent::ResolveReactionData(const FReactionDataKey& InDataKey,
 		const FDamageSpecKey& candidateKey = candidateKeys[candidateIndex];
 		FReactionDataKey reactionDataKey;
 
-		// Rebuild CandidateSpecKey + Type
 		reactionDataKey.DamageSpecKey = candidateKey;
 		reactionDataKey.ReactionType = reactionType;
 
-		// Find ReactionData
 		const FReactionData* foundPtr = ReactionDataMap.Find(reactionDataKey);
 		if (!foundPtr) continue;
 
@@ -560,7 +558,6 @@ UCReaction* UCReactionComponent::FindReactionExecutor(const UClass* InClass)
 
 	if (!IsValid(found))
 	{
-		// Remove Invalid Entry
 		ReactionExecutorMap.Remove(InClass);
 
 		return nullptr;

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -159,7 +159,7 @@ bool UCReactionComponent::ResolveReactionData(const FReactionDataKey& InDataKey,
 		return false;
 	}
 
-	TArray<FDamageSpecKey> candidateKeys; // OutParameter
+	TArray<FDamageSpecKey> candidateKeys;
 	EReactionType reactionType = InDataKey.ReactionType;
 	
 	// Candidate SpecKey

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -200,7 +200,7 @@ UCReaction* UCReactionComponent::ResolveReactionExecutor(const FReactionData& In
 	UCReaction* found = FindReactionExecutor(InData.ReactionExecutorKey.Get());
 	if (IsValid(found)) return found;
 
-	// 2) [Policy] Try Add and cache Reaction; return if valid
+	// 2) Try add and cache Reaction; return if valid.
 	UCReaction* add = AddReactionExecutor(InData.ReactionExecutorKey);
 	if (IsValid(add)) return add;
 
@@ -249,14 +249,13 @@ bool UCReactionComponent::ApplyReactionDecision(const FReactionExecutionResult& 
 
 	case EExecutionApplyMode::Reserve:
 	{
-		// [NOTE] Reaction does not support reserved execution.
+		// Reaction does not support reserved execution.
 		FReactionComponentDebug::RecordReactionDecisionRejectedForAudit(OwnerCharacter_Injected, InResult, TEXT("Reserve"), TEXT("UnsupportedReserve"));
 		return false;
 	}
 
 	case EExecutionApplyMode::Intervene:
 	{
-		// [NOTE] Try Apply Intervention
 		if (!ApplyExecutionInterventionDirective(InResult.InterventionDirective))
 		{
 			FReactionComponentDebug::RecordReactionDecisionRejectedForAudit(OwnerCharacter_Injected, InResult, TEXT("Intervene"), TEXT("InterventionFailed"));
@@ -479,7 +478,7 @@ void UCReactionComponent::BuildReactionDataMap(bool bRebuildAll)
 			}
 			else // bRebuildAll == false
 			{
-				// [Policy] Currently set to 'skip'. (Options: ignore | restart | stop-then-play)
+				// Duplicate reaction data is skipped unless the map is being rebuilt.
 				continue;
 			}
 		}
@@ -690,7 +689,7 @@ bool UCReactionComponent::InterruptActiveReaction(const FExecutionInterventionDi
 	UCReaction* activeExecutor = GetActiveReactionExecutor();
 	if (!IsValid(activeExecutor))
 	{
-		// [NOTE] Fallback when executor Interrupt() did not clear the active state through callback.
+		// Force end when the active executor is already invalid.
 		FReactionComponentDebug::RecordReactionNotifyIgnoredForAudit(OwnerCharacter_Injected, activeExecutor, TEXT("Interrupt"), NAME_None, TEXT("InvalidExecutorFallbackEnd"));
 		return EndActiveReaction(finishReason);
 	}
@@ -699,7 +698,7 @@ bool UCReactionComponent::InterruptActiveReaction(const FExecutionInterventionDi
 
 	if (IsActive())
 	{
-		// [NOTE] Fallback when executor Interrupt() did not clear the active state through callback.
+		// Force end when the executor interrupt callback did not clear active state.
 		FReactionComponentDebug::RecordReactionNotifyIgnoredForAudit(OwnerCharacter_Injected, activeExecutor, TEXT("Interrupt"), NAME_None, TEXT("ExecutorDidNotEndFallbackEnd"));
 		return EndActiveReaction(finishReason);
 	}

--- a/Source/Portfolio/Component/CReactionComponent.h
+++ b/Source/Portfolio/Component/CReactionComponent.h
@@ -18,12 +18,9 @@ class PORTFOLIO_API UCReactionComponent : public UActorComponent
 public:
 	UCReactionComponent();
 
-	// === ReactionData ===================================== //
 private:
 	UPROPERTY(EditAnywhere, Category = "Reaction|Data")
 	TArray<FReactionData> ReactionDatas;
-
-	// ====================================================== //
 
 private:
 	UPROPERTY(Transient)
@@ -43,7 +40,6 @@ private:
 	class UCReaction* ActiveReactionExecutor = nullptr;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
@@ -66,7 +62,6 @@ private:
 	class UCReactionFeedbackComponent* ReactionFeedbackComp_Injected = nullptr;
 
 public:
-	/* === Delegate === */
 	FReactionTypeChanged OnReactionTypeChanged;
 
 public:

--- a/Source/Portfolio/Component/CReactionComponent.h
+++ b/Source/Portfolio/Component/CReactionComponent.h
@@ -135,7 +135,7 @@ private:
 	void ResetActiveReactionRuntimeState();
 
 private:
-	// Data Build (temporary: move to DataAsset)
+	// Data Build
 	void BuildReactionDataMap(bool bRebuildAll);
 	void BuildReactionExecutorMap(bool bRebuildAll);
 

--- a/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
@@ -353,7 +353,6 @@ void UCReactionFeedbackComponent::PlayReactionVFX(const FReactionVFXFeedbackData
 
 	case EReactionVFXPlayType::Loop:
 	{
-		// TODO: Implement Loop
 		FCombatFeedbackDebug::RecordReactionFeedbackPresentationRejectedForAudit(OwnerCharacter_Injected, this, TEXT("VFX"), InReactionVFXFeedbackData.VFX, TEXT("LoopNotImplemented"));
 		return;
 	}
@@ -393,7 +392,6 @@ void UCReactionFeedbackComponent::PlayReactionSFX(const FReactionSFXFeedbackData
 
 	case EReactionSFXPlayType::Loop:
 	{
-		// TODO: Implement Loop
 		FCombatFeedbackDebug::RecordReactionFeedbackPresentationRejectedForAudit(OwnerCharacter_Injected, this, TEXT("SFX"), InReactionSFXFeedbackData.SFX, TEXT("LoopNotImplemented"));
 		return;
 	}

--- a/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
@@ -121,11 +121,7 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 	{
 		OutScore += ReactionFeedbackScore::ReactionExact;
 	}
-	else if (InDataKey.ReactionType == EReactionType::All)
-	{
-		// [Pass] Wildcard match.
-	}
-	else
+	else if (InDataKey.ReactionType != EReactionType::All)
 	{
 		return false;
 	}
@@ -135,11 +131,7 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 	{
 		OutScore += ReactionFeedbackScore::WeaponExact;
 	}
-	else if (InDataKey.DamageSpecKey.WeaponType == EWeaponType::All)
-	{
-		// [Pass] Wildcard match.
-	}
-	else
+	else if (InDataKey.DamageSpecKey.WeaponType != EWeaponType::All)
 	{
 		return false;
 	}
@@ -149,11 +141,7 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 	{
 		OutScore += ReactionFeedbackScore::ActionExact;
 	}
-	else if (InDataKey.DamageSpecKey.ActionType == EActionType::All)
-	{
-		// [Pass] Wildcard match.
-	}
-	else
+	else if (InDataKey.DamageSpecKey.ActionType != EActionType::All)
 	{
 		return false;
 	}
@@ -163,11 +151,7 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 	{
 		OutScore += ReactionFeedbackScore::IndexExact;
 	}
-	else if (InDataKey.DamageSpecKey.ActionIndex == INDEX_NONE)
-	{
-		// [Pass] Wildcard match.
-	}
-	else
+	else if (InDataKey.DamageSpecKey.ActionIndex != INDEX_NONE)
 	{
 		return false;
 	}

--- a/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
@@ -116,7 +116,6 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 
 	const FReactionFeedbackKey& requestKey = InReactionFeedbackRequest.ReactionFeedbackKey;
 
-	// ReactionType
 	if (InDataKey.ReactionType == requestKey.ReactionType)
 	{
 		OutScore += ReactionFeedbackScore::ReactionExact;
@@ -126,7 +125,6 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 		return false;
 	}
 
-	// WeaponType
 	if (InDataKey.DamageSpecKey.WeaponType == requestKey.DamageSpecKey.WeaponType)
 	{
 		OutScore += ReactionFeedbackScore::WeaponExact;
@@ -136,7 +134,6 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 		return false;
 	}
 
-	// ActionType
 	if (InDataKey.DamageSpecKey.ActionType == requestKey.DamageSpecKey.ActionType)
 	{
 		OutScore += ReactionFeedbackScore::ActionExact;
@@ -146,7 +143,6 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 		return false;
 	}
 
-	// ActionIndex
 	if (InDataKey.DamageSpecKey.ActionIndex == requestKey.DamageSpecKey.ActionIndex)
 	{
 		OutScore += ReactionFeedbackScore::IndexExact;

--- a/Source/Portfolio/Component/CReactionOrchestratorComponent.cpp
+++ b/Source/Portfolio/Component/CReactionOrchestratorComponent.cpp
@@ -107,8 +107,6 @@ bool UCReactionOrchestratorComponent::CanAcceptReactionRequest(EReactionRequestR
 		return false;
 	}
 
-	// [NOTE]
-	// Do not reject dead state here.
 	// DeadReaction may be requested after health and dead state have already been committed.
 
 	return true;
@@ -452,7 +450,6 @@ void UCReactionOrchestratorComponent::ResolveExecutionApplyMode(const FExecution
 	InOutResult.ApplyMode = EExecutionApplyMode::None;
 	InOutResult.InterventionDirective = FExecutionInterventionDirective();
 
-	// [NOTE] Early return ignore and reject decision
 	if (!InOutResult.IsAcceptedDecision()) return;
 
 	switch (InOutResult.Relationship)
@@ -472,7 +469,7 @@ void UCReactionOrchestratorComponent::ResolveExecutionApplyMode(const FExecution
 
 	case EExecutionRelationship::Sequential:
 	{
-		// [NOTE] Reaction does not support sequential execution.
+		// Reaction does not support sequential execution.
 		InOutResult.Decision = EExecutionDecision::Reject;
 		InOutResult.RejectReason = EReactionRequestRejectReason::InvalidSequential;
 		return;
@@ -517,7 +514,6 @@ void UCReactionOrchestratorComponent::ResolveInterventionDirective(const FExecut
 
 	if (!InOutResult.IsAcceptedDecision()) return;
 
-	// [NOTE] Start immediately when there is no active execution.
 	if (!InQuery.HasActivePart()) return;
 
 	FExecutionInterventionQuery interventionQuery;
@@ -536,9 +532,7 @@ void UCReactionOrchestratorComponent::ResolveInterventionDirective(const FExecut
 
 	if (bIncomingDead)
 	{
-		// [NOTE]
-		// Force intervention.
-		// Do not ask incoming WantIntervention or active AllowIntervention.
+		// DeadReaction forces intervention without querying participant permissions.
 		FExecutionInterventionDirective directive;
 
 		if (!BuildInterventionDirective(interventionQuery, EExecutionStopSource::ReactionOrchestration, EExecutionAfterStopAction::StartIncoming, directive))
@@ -681,11 +675,9 @@ bool UCReactionOrchestratorComponent::BuildInterventionDirective(const FExecutio
 
 FReactionRequestResult UCReactionOrchestratorComponent::DispatchReactionDecision(const FReactionExecutionResult& InResult)
 {
-	// [NOTE] Request ignore result
 	if (InResult.Decision == EExecutionDecision::Ignore)
 		return BuildReactionRequestResult(EReactionRequestResultType::Ignored, EReactionRequestRejectReason::None);
 
-	// [NOTE] Request rejected result
 	if (!InResult.IsAcceptedDecision())
 		return BuildReactionRequestResult(EReactionRequestResultType::Rejected, InResult.RejectReason);
 

--- a/Source/Portfolio/Component/CStateComponent.h
+++ b/Source/Portfolio/Component/CStateComponent.h
@@ -28,7 +28,7 @@ private:
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
 public:
-	/* === [Out] Custom Delgate Events === */
+	/* === [Out] Custom Delegate Events === */
 	FExecutionStateChanged OnExecutionStateChanged;
 
 public:

--- a/Source/Portfolio/Component/CStateComponent.h
+++ b/Source/Portfolio/Component/CStateComponent.h
@@ -18,17 +18,14 @@ public:
 	UCStateComponent();
 
 private:
-	/* === State === */
 	UPROPERTY(Transient)
 	EExecutionState CurrentExecutionState = EExecutionState::Idle;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
 public:
-	/* === [Out] Custom Delegate Events === */
 	FExecutionStateChanged OnExecutionStateChanged;
 
 public:
@@ -42,15 +39,15 @@ public:
 	void OnDeadStateChanged(EDeadState InPrevDeadState, EDeadState InNewDeadState);
 
 public:
-	/* === Check / Query === */
+	// Check / Query
 	FORCEINLINE bool CheckCurExecutionState(EExecutionState InNewExecutionState) const { return CurrentExecutionState == InNewExecutionState; }
 
 public:
-	/* === Getter === */
+	// Query
 	FORCEINLINE EExecutionState GetCurrentExecutionState() const { return CurrentExecutionState; }
 
 public:
-	/* === Setter === */
+	// Mutation
 	void SetIdleState();
 	void SetActionState();
 	void SetReactionState();

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -224,7 +224,6 @@ bool UCWeaponComponent::CreateWeaponActor(AActor* InOwnerCharacter, EWeaponType 
 	SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 
 	// 2) Spawn WeaponActor
-	// TODO: Deferred Spawn
 	ACWeaponActor* weaponActor = World->SpawnActor<ACWeaponActor>(InWeaponActorClass, SpawnParams);
 
 	// 3) Check WeaponActor Validation

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -113,10 +113,8 @@ void UCWeaponComponent::PushContext(const FActionContext& InActionContext)
 	IHitContextProvider* provider = Cast<IHitContextProvider>(WeaponActor);
 	if (!provider) return;
 
-	// 1) Build contexts from current state
 	const FWeaponContext weaponContext = BuildWeaponContext();
 
-	// 2) Push/Cache into the carrier
 	provider->SetLastWeaponContext(weaponContext);
 	provider->SetLastActionContext(InActionContext);
 }
@@ -218,15 +216,12 @@ bool UCWeaponComponent::CreateWeaponActor(AActor* InOwnerCharacter, EWeaponType 
 	UWorld* World = InOwnerCharacter->GetWorld();
 	if (!World) return false;
 
-	// 1) SpawnParams
 	FActorSpawnParameters SpawnParams;
 	SpawnParams.Owner = InOwnerCharacter;
 	SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 
-	// 2) Spawn WeaponActor
 	ACWeaponActor* weaponActor = World->SpawnActor<ACWeaponActor>(InWeaponActorClass, SpawnParams);
 
-	// 3) Check WeaponActor Validation
 	if (!ensureMsgf(
 		IsValid(weaponActor),
 		TEXT("[Weapon|Component|WeaponActorSpawnFailed] Reason=SpawnActorReturnedInvalid | Owner=%s | Component=%s | Asset=%s | WeaponType=%s"),

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -224,7 +224,7 @@ bool UCWeaponComponent::CreateWeaponActor(AActor* InOwnerCharacter, EWeaponType 
 	SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 
 	// 2) Spawn WeaponActor
-	// TODO : Deffered Spawn
+	// TODO: Deferred Spawn
 	ACWeaponActor* weaponActor = World->SpawnActor<ACWeaponActor>(InWeaponActorClass, SpawnParams);
 
 	// 3) Check WeaponActor Validation

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -16,7 +16,6 @@ class PORTFOLIO_API UCWeaponComponent : public UActorComponent
 public:
 	UCWeaponComponent();
 
-	// === WeaponData ======================================= //
 private:
 	UPROPERTY(EditAnywhere, Category = "Weapon")
 	EWeaponType WeaponActorClassKey = EWeaponType::Max;
@@ -24,10 +23,7 @@ private:
 	UPROPERTY(EditAnywhere, Category = "Weapon")
 	TSubclassOf<class ACWeaponActor> WeaponActorClass;
 
-	// ====================================================== //
-
 private:
-	/* === State === */
 	UPROPERTY(Transient)
 	EWeaponType CurrentWeaponType = EWeaponType::Unarmed;
 
@@ -38,7 +34,6 @@ private:
 	bool bWeaponActorDisabledForProfiling = false;
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
@@ -46,7 +41,6 @@ private:
 	class UCCombatSignalSourceComponent* CombatSignalSourceComp_Injected = nullptr;
 
 public:
-	/* === [Out] Custom Delegate Events === */
 	FWeaponTypeChanged OnWeaponTypeChanged;
 
 public:
@@ -62,11 +56,11 @@ protected:
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 public:
-	/* === Check / Query === */
+	// Check / Query
 	FORCEINLINE bool CheckCurrentWeaponType(EWeaponType InNewWeaponType) const { return CurrentWeaponType == InNewWeaponType; }
 
 public:
-	/* === Getter === */
+	// Query
 	FORCEINLINE EWeaponType GetCurrentWeaponType() { return CurrentWeaponType; }
 
 public:

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -46,7 +46,7 @@ private:
 	class UCCombatSignalSourceComponent* CombatSignalSourceComp_Injected = nullptr;
 
 public:
-	/* === [Out] Custom Delgate Events === */
+	/* === [Out] Custom Delegate Events === */
 	FWeaponTypeChanged OnWeaponTypeChanged;
 
 public:

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -106,17 +106,6 @@ bool ACAIController::InitializeSightConfig()
 	return true;
 }
 
-// -----------------------------------------------------------------------------
-// [AI Perception & Blackboard Initialization]
-// 1. Controller		: Perception and interpretation (like human awareness)
-// 2. Blackboard		: Storage of perceived facts
-// 3. BehaviorTree		: Decision making based on facts
-// 
-// 4. Service Node		: Periodically maintains perceived facts
-// 5. Decorator Node	: Evaluates logical conditions on perceived facts
-// 6. Task Node			: Executes the decided actions
-// -----------------------------------------------------------------------------
-
 // Runtime Lifecycle
 
 bool ACAIController::InitializeControllerRuntime(APawn* InPawn)
@@ -288,7 +277,7 @@ void ACAIController::StopBehaviorTreeRuntime()
 
 void ACAIController::OnPerceptionUpdated(const TArray<AActor*>& UpdatedActors)
 {
-	// [Disable OnPerceptionUpdated]
+	// Target-specific perception updates are handled by OnTargetPerceptionUpdated.
 }
 
 void ACAIController::OnTargetPerceptionUpdated(AActor* Actor, FAIStimulus Stimulus)
@@ -330,8 +319,7 @@ void ACAIController::OnTargetPerceptionUpdated(AActor* Actor, FAIStimulus Stimul
 
 void ACAIController::OnTargetPerceptionForgotten(AActor* Actor)
 {
-	// [Disable OnTargetPerceptionForgotten]
-	// - TargetForgotten is Controlled by bHasLOS and bHasMemory
+	// Target forgotten state is derived from LOS and memory state.
 }
 
 // Query
@@ -348,24 +336,6 @@ EPerceptionBuildResult ACAIController::BuildPerceptionContext(FTargetData& OutTa
 
 void ACAIController::UpdateTargetDataMap()
 {
-	// -----------------------------------------------------------------------------
-	// [Target Perception Level]
-	// 1. Active Target 
-	//	- TargetActor	: Valid
-	//	- bHasLOS		: true
-	//	- bHasMemory	: true
-	// 
-	// 2. Lost Target but Remembered 
-	//	- TargetActor	: Invalid
-	//	- bHasLOS		: false
-	//	- bHasMemory	: true
-	// 
-	// 3. Timeout and Expired
-	//	- TargetActor	: Invalid
-	//	- bHasLOS		: false
-	//	- bHasMemory	: false
-	// -----------------------------------------------------------------------------
-
 	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return;
 

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -212,7 +212,6 @@ bool ACAIController::SetupBlackboardComponent()
 	if (!BlackboardAsset) return false;
 	if (!CAIKeyRegistry::ValidateRequiredKeys(BlackboardAsset)) return false;
 
-	// blackboardComp: Out Parameter
 	UBlackboardComponent* blackboardComp = nullptr;
 	bool bUsed = UseBlackboard(BlackboardAsset, blackboardComp);
 
@@ -368,7 +367,6 @@ void ACAIController::UpdateTargetDataMap()
 	//	- bHasMemory	: false
 	// -----------------------------------------------------------------------------
 
-	// Used BT_Service API
 	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return;
 

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -91,7 +91,6 @@ bool ACAIController::InitializeSightConfig()
 	SightConfig = CreateDefaultSubobject<UAISenseConfig_Sight>("SightConfig");
 	if (!IsValid(SightConfig)) return false;
 
-	// Set Default (Overridable in Blueprint Editor)
 	SightConfig->SightRadius = 500.f;
 	SightConfig->LoseSightRadius = 600.f;
 	SightConfig->PeripheralVisionAngleDegrees = 45.f;

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -88,7 +88,6 @@ bool ACAIController::InitializeSightConfig()
 {
 	if (!IsValid(AIPerceptionComp)) return false;
 
-	// TODO: Move perception config to data-driven asset.
 	SightConfig = CreateDefaultSubobject<UAISenseConfig_Sight>("SightConfig");
 	if (!IsValid(SightConfig)) return false;
 

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -22,7 +22,6 @@ protected:
 	TMap<AActor*, FTargetData> TargetDataMap;
 
 protected:
-	/* --- Asset --- */
 	UPROPERTY(EditDefaultsOnly)
 	class UBlackboardData* BlackboardAsset;
 
@@ -30,22 +29,18 @@ protected:
 	class UBehaviorTree* BehaviorTreeAsset;
 
 protected:
-	/* --- Component --- */
 	UPROPERTY(VisibleAnywhere)
 	class UAIPerceptionComponent* AIPerceptionComp;
 
 protected:
-	/* --- Cached --- */
 	UPROPERTY(Transient)
 	class APawn* ControlledPawn_Cached;
 
 protected:
-	/* --- Config --- */
 	UPROPERTY(Transient)
 	class UAISenseConfig_Sight* SightConfig;
 
 private:
-	// Profiling State
 	UPROPERTY(Transient)
 	bool bPerceptionDisabledForProfiling = false;
 
@@ -134,37 +129,34 @@ private:
 
 private:
 	// Runtime LOD Snapshot
-	// 1. Lifecycle
 	void InitializeRuntimeLODTierSnapshot();
 	void ClearRuntimeLODTierSnapshot();
 
-	// 2. Set
+	// Mutation
 	void SetCurrentRuntimeLODTier(EAIRuntimeLODTier InTier);
 
 private:
 	// Perception Profiling Gate
-	// 1. Lifecycle
 	void InitializePerceptionStateForProfiling();
 	void ClearPerceptionStateForProfiling();
 
-	// 2. Condition
+	// Condition
 	bool ShouldDisableEnemyPerceptionForProfiling() const;
 
-	// 3. Set
+	// Mutation
 	void DisableEnemyPerceptionForProfiling();
 	void EnableEnemyPerceptionForProfiling();
 	void SetPerceptionSenseEnabledForProfiling(bool bEnabled);
 
 private:
 	// Perception Candidate Audit
-	// 1. Lifecycle
 	void InitializePerceptionCandidateAudit();
 	void ClearPerceptionCandidateAudit();
 
-	// 2. Condition
+	// Condition
 	bool ShouldAuditPerceptionCandidates() const;
 
-	// 3. Record
+	// Record
 	void RecordRawPerceptionCandidate(class AActor* InActor);
 	void RecordValidTargetProvider(class AActor* InActor);
 	void RecordInvalidTargetProvider(class AActor* InActor);
@@ -172,11 +164,10 @@ private:
 
 private:
 	// Blackboard / Engage Latency Audit
-	// 1. Lifecycle
 	void InitializeBlackboardEngageLatencyAudit();
 	void ClearBlackboardEngageLatencyAudit();
 
-	// 2. Condition
+	// Condition
 	bool ShouldAuditBlackboardEngageLatency() const;
 
 };

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
@@ -9,13 +9,13 @@ namespace
 	TAutoConsoleVariable<int32> CVarPerceptionCandidateAudit(
 		TEXT("Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit"),
 		0,
-		TEXT("Enable Enemy Perception candidate audit for runtime LOD measurement. 0: disabled, 1: enabled."),
+		TEXT("Enable ACEnemy perception candidate audit for runtime LOD measurement. 0: disabled, 1: enabled."),
 		ECVF_Default);
 
 	TAutoConsoleVariable<int32> CVarBlackboardEngageLatencyAudit(
 		TEXT("Portfolio.AI.RuntimeLOD.BlackboardEngageLatencyAudit"),
 		0,
-		TEXT("Enable Enemy Blackboard / Engage latency audit for runtime LOD measurement. 0: disabled, 1: enabled."),
+		TEXT("Enable ACEnemy Blackboard / Engage latency audit for runtime LOD measurement. 0: disabled, 1: enabled."),
 		ECVF_Default);
 #endif
 }

--- a/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FAIPerceptionDebug.cpp
@@ -9,13 +9,13 @@ namespace
 	TAutoConsoleVariable<int32> CVarPerceptionCandidateAudit(
 		TEXT("Portfolio.AI.RuntimeLOD.PerceptionCandidateAudit"),
 		0,
-		TEXT("Enable ACEnemy perception candidate audit for runtime LOD measurement. 0: disabled, 1: enabled."),
+		TEXT("Print ACEnemy perception candidate audit summary for runtime LOD measurement. 0: disabled, 1: enabled."),
 		ECVF_Default);
 
 	TAutoConsoleVariable<int32> CVarBlackboardEngageLatencyAudit(
 		TEXT("Portfolio.AI.RuntimeLOD.BlackboardEngageLatencyAudit"),
 		0,
-		TEXT("Enable ACEnemy Blackboard / Engage latency audit for runtime LOD measurement. 0: disabled, 1: enabled."),
+		TEXT("Print ACEnemy Blackboard / Engage latency audit summary for runtime LOD measurement. 0: disabled, 1: enabled."),
 		ECVF_Default);
 #endif
 }

--- a/Source/Portfolio/Core/Debug/FCombatEngageDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FCombatEngageDebug.cpp
@@ -11,13 +11,13 @@ namespace
 	TAutoConsoleVariable<int32> CVarEngageAssignmentAudit(
 		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentAudit"),
 		0,
-		TEXT("Print minimal CombatEngage assignment warmup audit logs. 0: disabled, 1: enabled."),
+		TEXT("Print CombatEngage assignment warmup and rebuild summary audit logs. 0: disabled, 1: enabled."),
 		ECVF_Default);
 
 	TAutoConsoleVariable<int32> CVarEngageAssignmentVerboseAudit(
 		TEXT("Portfolio.AI.RuntimeLOD.EngageAssignmentVerboseAudit"),
 		0,
-		TEXT("Print detailed CombatEngage assignment candidate logs. 0: disabled, 1: enabled."),
+		TEXT("Print detailed CombatEngage assignment request candidate and slot decision audit logs. 0: disabled, 1: enabled."),
 		ECVF_Default);
 #endif
 }

--- a/Source/Portfolio/Core/Debug/FCombatFeedbackDebug.cpp
+++ b/Source/Portfolio/Core/Debug/FCombatFeedbackDebug.cpp
@@ -9,7 +9,7 @@ namespace
 	TAutoConsoleVariable<int32> CVarCombatFeedbackAudit(
 		TEXT("Portfolio.Debug.FeedbackAudit"),
 		0,
-		TEXT("Print combat feedback request, match, asset, and dispatch diagnostic hook logs. 0: disabled, 1: enabled."),
+		TEXT("Print combat feedback request, channel, presentation, asset, and shared dispatch diagnostic hook logs. 0: disabled, 1: enabled."),
 		ECVF_Default);
 #endif
 

--- a/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.cpp
@@ -10,7 +10,7 @@ namespace
 	TAutoConsoleVariable<int32> CVarDisableEnemyPerception(
 		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyPerception"),
 		0,
-		TEXT("Disable Enemy AI Perception for runtime LOD measurement. 0: enable perception, 1: disable Enemy perception."),
+		TEXT("Disable ACEnemy AI perception for runtime LOD measurement. 0: enable perception, 1: disable ACEnemy perception."),
 		ECVF_Default);
 #endif
 }

--- a/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.cpp
@@ -10,13 +10,13 @@ namespace
 	TAutoConsoleVariable<int32> CVarDisableEnemyHitProcessing(
 		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyHitProcessing"),
 		0,
-		TEXT("Disable Enemy hit processing for combat collision profiling. 0: process hit, 1: skip Enemy hit processing after overlap."),
+		TEXT("Disable ACEnemy hit processing for combat collision profiling. 0: process hit, 1: skip ACEnemy hit processing after overlap."),
 		ECVF_Default);
 
 	TAutoConsoleVariable<int32> CVarDisableEnemyWeaponActor(
 		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyWeaponActor"),
 		0,
-		TEXT("Disable Enemy WeaponActor creation for runtime LOD measurement. 0: spawn WeaponActor, 1: skip Enemy WeaponActor."),
+		TEXT("Disable ACEnemy WeaponActor creation for runtime LOD measurement. 0: spawn WeaponActor, 1: skip ACEnemy WeaponActor."),
 		ECVF_Default);
 #endif
 

--- a/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.cpp
@@ -11,7 +11,7 @@ namespace
 	TAutoConsoleVariable<int32> CVarDisableEnemyCombatFeedback(
 		TEXT("Portfolio.AI.RuntimeLOD.DisableEnemyCombatFeedback"),
 		0,
-		TEXT("Disable Enemy combat feedback presentation for runtime LOD profiling. 0: play feedback, 1: skip Enemy feedback presentation."),
+		TEXT("Disable ACEnemy combat feedback presentation for runtime LOD profiling. 0: play feedback, 1: skip ACEnemy feedback presentation."),
 		ECVF_Default);
 
 	// Action Counter

--- a/Source/Portfolio/Reaction/CReaction.cpp
+++ b/Source/Portfolio/Reaction/CReaction.cpp
@@ -423,7 +423,6 @@ void UCReaction::HandleNotifyCommand(EReactionNotifyCommand InCommand)
 
 void UCReaction::HandleSpecificNotifyCommand(EReactionNotifyCommand InCommand)
 {
-	// Specific Reactions override this API.
 }
 
 void UCReaction::HandleNotifyFeedback(EReactionFeedbackTiming InTiming, FName InTriggerKey)

--- a/Source/Portfolio/Reaction/CReaction.h
+++ b/Source/Portfolio/Reaction/CReaction.h
@@ -15,7 +15,6 @@ class PORTFOLIO_API UCReaction : public UObject
 	GENERATED_BODY()
 
 protected:
-	/* === Runtime State === */
 	UPROPERTY(Transient)
 	bool bIsActive = false;
 
@@ -40,7 +39,6 @@ protected:
 	EReactionStopReason LastStopReason_Cached = EReactionStopReason::None;
 
 protected:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 

--- a/Source/Portfolio/Reaction/CReaction.h
+++ b/Source/Portfolio/Reaction/CReaction.h
@@ -134,12 +134,12 @@ public:
 
 public:
 	// Intervention Match
-	virtual bool WantIntervention(const FExecutionInterventionQuery& InQuery) const;	// Incoming API
-	virtual bool AllowIntervention(const FExecutionInterventionQuery& InQuery) const;	// Acitve	API
+	virtual bool WantIntervention(const FExecutionInterventionQuery& InQuery) const;
+	virtual bool AllowIntervention(const FExecutionInterventionQuery& InQuery) const;
 
 public:
 	// Observable Overlay Match
-	virtual void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const;	// Incoming API
+	virtual void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const;
 
 private:
 	bool MatchesWantInterventionRules(const TArray<FExecutionInterventionWantRule>& InRules, const FExecutionParticipant& InParticipant) const;

--- a/Source/Portfolio/Reaction/CReaction_Dead.cpp
+++ b/Source/Portfolio/Reaction/CReaction_Dead.cpp
@@ -59,6 +59,6 @@ void UCReaction_Dead::ResolveObservableOverlayCondition(const FObservableOverlay
 
 bool UCReaction_Dead::AllowIntervention(const FExecutionInterventionQuery& InQuery) const
 {
-	// [NOTE] Dead reaction is terminal and cannot be interrupted.
+	// Dead reaction is terminal and cannot be interrupted.
 	return false;
 }

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -77,7 +77,7 @@ void UCWorldSubsystem_CombatEngage::Tick(float DeltaTime)
 
 TStatId UCWorldSubsystem_CombatEngage::GetStatId() const
 {
-	// [NOTE] Returns a stat id, so Unreal can track this tickable subsystem in the unreal stat system.
+	// Unreal uses this stat id to track the tickable subsystem.
 	RETURN_QUICK_DECLARE_CYCLE_STAT(UCWorldSubsystem_CombatEngage, STATGROUP_Tickables);
 }
 

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -126,7 +126,7 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 
 	bool bCompletedWarmupThisRebuild = false;
 
-	// Flag Toogle
+	// Flag Toggle
 	if (!bAssignmentWarmupCompleted)
 	{
 		if (GetEngageAssignmentWarmupTime() > 0.f && AssignmentWarmupStartTime < 0.f) return;

--- a/Source/Portfolio/Type/CActionOrchestrationStructure.h
+++ b/Source/Portfolio/Type/CActionOrchestrationStructure.h
@@ -85,15 +85,12 @@ struct FMovementActionRequest
 	GENERATED_BODY()
 
 public:
-	// Who: request source
 	UPROPERTY(Transient)
 	EActionIntentSource IntentSource = EActionIntentSource::None;
 
-	// What: requested intent
 	UPROPERTY(Transient)
 	EMovementActionIntent IntentType = EMovementActionIntent::None;
 
-	// How: intent event
 	UPROPERTY(Transient)
 	EActionIntentEvent IntentEvent = EActionIntentEvent::None;
 
@@ -107,15 +104,12 @@ struct FEquipmentActionRequest
 	GENERATED_BODY()
 
 public:
-	// Who: request source
 	UPROPERTY(Transient)
 	EActionIntentSource IntentSource = EActionIntentSource::None;
 
-	// What: requested intent
 	UPROPERTY(Transient)
 	EEquipmentActionIntent IntentType = EEquipmentActionIntent::None;
 
-	// How: intent event
 	UPROPERTY(Transient)
 	EActionIntentEvent IntentEvent = EActionIntentEvent::None;
 };
@@ -126,15 +120,12 @@ struct FCombatActionRequest
 	GENERATED_BODY()
 
 public:
-	// Who: request source
 	UPROPERTY(Transient)
 	EActionIntentSource IntentSource = EActionIntentSource::None;
 
-	// What: requested intent
 	UPROPERTY(Transient)
 	ECombatActionIntent IntentType = ECombatActionIntent::None;
 
-	// How: intent event
 	UPROPERTY(Transient)
 	EActionIntentEvent IntentEvent = EActionIntentEvent::None;
 

--- a/Source/Portfolio/Type/CCombatSignalStructure.h
+++ b/Source/Portfolio/Type/CCombatSignalStructure.h
@@ -52,35 +52,27 @@ struct FCombatSignalHeader
 	GENERATED_BODY()
 
 public:
-	// Signal category.
 	UPROPERTY(Transient)
 	ECombatSignalType SignalType = ECombatSignalType::None;
 
-	// Signal source.
 	UPROPERTY(Transient)
 	AActor* SourceActor = nullptr;
 
-	// Signal target.
 	UPROPERTY(Transient)
 	AActor* TargetActor = nullptr;
 
-	// Intent owner.
 	UPROPERTY(Transient)
 	AActor* InstigatorActor = nullptr;
 
-	// Intent causer.
 	UPROPERTY(Transient)
 	AActor* SignalCauser = nullptr;
 
-	// Correlation id.
 	UPROPERTY(Transient)
 	FGuid TraceId = FGuid();
 
-	// Source-local order.
 	UPROPERTY(Transient)
 	int32 SequenceId = INDEX_NONE;
 
-	// Debug label.
 	UPROPERTY(Transient)
 	FName DebugTag = NAME_None;
 
@@ -101,31 +93,24 @@ struct FCombatSignal
 	GENERATED_BODY()
 
 public:
-	// Signal metadata.
 	UPROPERTY(Transient)
 	FCombatSignalHeader Header = FCombatSignalHeader();
 
-	// Signal identity.
 	UPROPERTY(Transient)
 	FName SignalTag = NAME_None;
 
-	// Optional cue identity.
 	UPROPERTY(Transient)
 	FName CueTag = NAME_None;
 
-	// Pre-evaluation damage.
 	UPROPERTY(Transient)
 	float RequestedDamage = 0.0f;
 
-	// Hit or cue point.
 	UPROPERTY(Transient)
 	FVector ImpactLocation = FVector::ZeroVector;
 
-	// Hit normal.
 	UPROPERTY(Transient)
 	FVector ImpactNormal = FVector::ZeroVector;
 
-	// Signal direction.
 	UPROPERTY(Transient)
 	FVector Direction = FVector::ZeroVector;
 
@@ -146,23 +131,18 @@ struct FCombatSignalContext
 	GENERATED_BODY()
 
 public:
-	// Incoming signal.
 	UPROPERTY(Transient)
 	FCombatSignal Signal = FCombatSignal();
 
-	// Actual receiver.
 	UPROPERTY(Transient)
 	AActor* ReceiverActor = nullptr;
 
-	// Source validity.
 	UPROPERTY(Transient)
 	bool bSourceActorValid = false;
 
-	// Target validity.
 	UPROPERTY(Transient)
 	bool bTargetActorValid = false;
 
-	// Receiver validity.
 	UPROPERTY(Transient)
 	bool bReceiverActorValid = false;
 
@@ -182,35 +162,27 @@ struct FCombatSignalEvaluation
 	GENERATED_BODY()
 
 public:
-	// Signal metadata.
 	UPROPERTY(Transient)
 	FCombatSignalHeader Header = FCombatSignalHeader();
 
-	// Evaluated outcome.
 	UPROPERTY(Transient)
 	ECombatSignalOutcome Outcome = ECombatSignalOutcome::None;
 
-	// Apply gate.
 	UPROPERTY(Transient)
 	bool bShouldApply = false;
 
-	// Source notify gate.
 	UPROPERTY(Transient)
 	bool bShouldNotifySource = false;
 
-	// Evaluated damage.
 	UPROPERTY(Transient)
 	float FinalDamage = 0.0f;
 
-	// Reaction identity.
 	UPROPERTY(Transient)
 	FName ReactionTag = NAME_None;
 
-	// Feedback identity.
 	UPROPERTY(Transient)
 	FName FeedbackTag = NAME_None;
 
-	// Result identity.
 	UPROPERTY(Transient)
 	FName ResultTag = NAME_None;
 
@@ -232,31 +204,24 @@ struct FCombatSignalApplyResult
 	GENERATED_BODY()
 
 public:
-	// Signal metadata.
 	UPROPERTY(Transient)
 	FCombatSignalHeader Header = FCombatSignalHeader();
 
-	// Applied outcome.
 	UPROPERTY(Transient)
 	ECombatSignalOutcome Outcome = ECombatSignalOutcome::None;
 
-	// Apply state.
 	UPROPERTY(Transient)
 	bool bApplied = false;
 
-	// Damage commit state.
 	UPROPERTY(Transient)
 	bool bDamageCommitted = false;
 
-	// Committed damage.
 	UPROPERTY(Transient)
 	float CommittedDamage = 0.0f;
 
-	// Reaction request state.
 	UPROPERTY(Transient)
 	bool bReactionRequested = false;
 
-	// Feedback request state.
 	UPROPERTY(Transient)
 	bool bFeedbackRequested = false;
 
@@ -278,27 +243,21 @@ struct FCombatSignalResult
 	GENERATED_BODY()
 
 public:
-	// Signal metadata.
 	UPROPERTY(Transient)
 	FCombatSignalHeader Header = FCombatSignalHeader();
 
-	// Result state.
 	UPROPERTY(Transient)
 	ECombatSignalResultType ResultType = ECombatSignalResultType::None;
 
-	// Result outcome.
 	UPROPERTY(Transient)
 	ECombatSignalOutcome Outcome = ECombatSignalOutcome::None;
 
-	// Handled flag.
 	UPROPERTY(Transient)
 	bool bHandled = false;
 
-	// Success flag.
 	UPROPERTY(Transient)
 	bool bSucceeded = false;
 
-	// Result identity.
 	UPROPERTY(Transient)
 	FName ResultTag = NAME_None;
 

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -1131,7 +1131,6 @@ public:
 	UPROPERTY(Transient)
 	AActor* TargetActor = nullptr;
 
-	// Damage MetaData
 	UPROPERTY(Transient)
 	FDamageImpactInfo DamageImpactInfo = FDamageImpactInfo();
 
@@ -1161,7 +1160,6 @@ struct FCombatSignalTargetPayload
 	GENERATED_BODY()
 
 public:
-	// ObjectData
 	UPROPERTY(Transient)
 	class AActor* SourceActor = nullptr;
 
@@ -1173,8 +1171,6 @@ public:
 
 	UPROPERTY(Transient)
 	class AActor* DamageCauser = nullptr;
-
-	// Damage MetaData
 
 	UPROPERTY(Transient)
 	FDamageImpactInfo DamageImpactInfo = FDamageImpactInfo();
@@ -1188,7 +1184,6 @@ public:
 	UPROPERTY(Transient)
 	FDamageAmount DamageAmount = FDamageAmount();
 
-	//Damage AmountData
 	UPROPERTY(Transient)
 	float RequestedDamage = 0.f;
 
@@ -1202,7 +1197,6 @@ struct FCombatSignalTargetContext
 	GENERATED_BODY()
 
 public:
-	// Resolved objects [Set BuildContext]
 	UPROPERTY(Transient)
 	class AActor* SourceActor = nullptr;
 
@@ -1215,14 +1209,12 @@ public:
 	UPROPERTY(Transient)
 	class AActor* DamageCauser = nullptr;
 
-	// Damage MetaData [Set BuildContext]
 	UPROPERTY(Transient)
 	FDamageImpactInfo DamageImpactInfo = FDamageImpactInfo();
 
 	UPROPERTY(Transient)
 	FDamageSpecKey DamageSpecKey = FDamageSpecKey();
 
-	// Query Acceptable [Set ValidateContext / CanReceiveCombatSignal / ComputeTargetDamage]
 	UPROPERTY(Transient)
 	bool bAccepted = true;
 
@@ -1235,14 +1227,12 @@ public:
 	UPROPERTY(Transient)
 	bool bShouldCommitDamage = true;
 
-	// Pre-state Snapshot [Set HandleDefaultDamageEvent before ValidatePolicy]
 	UPROPERTY(Transient)
 	float HealthPointBefore = 0.f;
 
 	UPROPERTY(Transient)
 	EDeadState DeadState_Before = EDeadState::Alive;
 
-	// DamageAmounts [Set ComputeTargetDamage & CommitCombatSignalTarget]
 	UPROPERTY(Transient)
 	float RequestedDamage = 0.f;		// Raw incoming damage requested by Apply pipeline. (ex. [skill] 100)
 
@@ -1255,7 +1245,6 @@ public:
 	UPROPERTY(Transient)
 	float CommittedDamage = 0.f;		// Actual HP loss committed to Health. (ex. [shield absorbs] 60 -> HP: -30 / SP: -30)
 
-	// Post-state Snapshot [Set BuildResult]
 	UPROPERTY(Transient)
 	float HealthPointAfter = 0.f;
 
@@ -1284,11 +1273,9 @@ public:
 	UPROPERTY(Transient)
 	bool bShouldCommitDamage = true;
 
-	// Damage MetaData
 	UPROPERTY(Transient)
 	FDamageSpecKey DamageSpecKey = FDamageSpecKey();
 
-	// Damage Amount
 	UPROPERTY(Transient)
 	float RequestDamage = 0.f;
 

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -488,9 +488,6 @@ enum class ECombatSignalTargetRejectReason : uint8
 	InvalidInstigator,
 
 	AlreadyDead,
-	// Invulnerable,
-
-	// DamageCooldown,
 	ZeroDamage,
 
 	UnknownCueTag,

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -968,16 +968,7 @@ FORCEINLINE uint32 GetTypeHash(const FDamageSpecKey& InOther)
 	return H;
 }
 
-/***
- * [EN]
- * USTRUCT Set/Map key checklist:
- * 1) operator==
- * 2) GetTypeHash
- *
- * GetTypeHash notes:
- * - Prefer a normal overload at namespace/global scope (avoid hidden-friend in the struct).
- * - Avoid ::GetTypeHash(...); call GetTypeHash(...) to keep ADL available.
- ***/
+// Global GetTypeHash keeps ADL available for this map key.
 
 USTRUCT(BlueprintType)
 struct FDamageSpec

--- a/Source/Portfolio/Type/CWeaponStructure.h
+++ b/Source/Portfolio/Type/CWeaponStructure.h
@@ -352,7 +352,6 @@ enum class EExecutionAfterStopAction : uint8
 	Max,
 };
 
-// [NOTE] Temp
 UENUM(BlueprintType)
 enum class EActionStopSource : uint8
 {
@@ -367,7 +366,6 @@ enum class EActionStopSource : uint8
 	Max,
 };
 
-// [NOTE] Temp
 UENUM(BlueprintType)
 enum class EActionStopReason : uint8
 {
@@ -509,7 +507,6 @@ enum class EDamageDefenseOutcome : uint8
 	Max,
 };
 
-// [NOTE] Temp
 UENUM(BlueprintType)
 enum class EReactionStopSource : uint8
 {
@@ -524,7 +521,6 @@ enum class EReactionStopSource : uint8
 	Max,
 };
 
-// [NOTE] Temp
 UENUM(BlueprintType)
 enum class EReactionStopReason : uint8
 {
@@ -595,7 +591,6 @@ enum class EReactionRequestRejectReason : uint8
 	Max,
 };
 
-// [TODO] Migrate to CActionFeedbackStructure
 UENUM(BlueprintType)
 enum class EActionFeedbackTiming : uint8
 {
@@ -613,7 +608,6 @@ enum class EActionFeedbackTiming : uint8
 	TriggerWindowEnd
 };
 
-// [TODO] Migrate to CActionFeedbackStructure
 enum class EActionFeedbackMatchTier : uint8
 {
 	None = 0,
@@ -623,7 +617,6 @@ enum class EActionFeedbackMatchTier : uint8
 	ExactActionExactIndex,
 };
 
-// [TODO] Migrate to CActionFeedbackStructure
 UENUM(BlueprintType)
 enum class EActionVFXPlayType : uint8
 {
@@ -631,7 +624,6 @@ enum class EActionVFXPlayType : uint8
 	Loop
 };
 
-// [TODO] Migrate to CActionFeedbackStructure
 UENUM(BlueprintType)
 enum class EActionSFXPlayType : uint8
 {
@@ -837,7 +829,6 @@ public:
 	FWeaponContext() = default;
 };
 
-// [TODO] Translate to FActionExecutionContext
 USTRUCT(BlueprintType)
 struct FActionContext
 {
@@ -1270,14 +1261,6 @@ public:
 
 	UPROPERTY(Transient)
 	EDeadState DeadState_After = EDeadState::Alive;
-
-	// TODO:
-	// - HitBoneName
-	// - HitDirection
-	// - HitImpulseVector
-	// - TeamId / Attribute
-	// - StateSnapshot
-	// - Cached Component (Minimal)
 
 public:
 	FCombatSignalTargetContext() = default;

--- a/Source/Portfolio/Weapon/CWeaponActor.h
+++ b/Source/Portfolio/Weapon/CWeaponActor.h
@@ -79,7 +79,7 @@ private:
 	TArray<class UShapeComponent*> Collisions_Cached;
 
 public:
-	/* === [OUT] Custom Delgate Events === */
+	/* === [OUT] Custom Delegate Events === */
 	// Collision (Enabled/Disabled)
 	FWeaponActorCollisionEnabled OnWeaponActorCollisionEnabled;
 	FWeaponActorCollisionDisabled OnWeaponActorCollisionDisabled;
@@ -152,7 +152,7 @@ public:
 	void CollisionDisabled();
 
 public:
-	/* === [IN] Engine Delgate Events === */
+	/* === [IN] Engine Delegate Events === */
 	// UShapeComponent
 	UFUNCTION()
 	void OnComponentBeginOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);

--- a/Source/Portfolio/Weapon/CWeaponActor.h
+++ b/Source/Portfolio/Weapon/CWeaponActor.h
@@ -21,7 +21,6 @@ class PORTFOLIO_API ACWeaponActor : public AActor, public IHitContextProvider
 public:
 	ACWeaponActor();
 
-	// === Weapon Actor Data ================================ //
 public:
 	UPROPERTY(EditAnywhere, Category = "Weapon|SocketName")
 	FName SocketName_Holster;
@@ -32,8 +31,6 @@ public:
 private:
 	UPROPERTY(EditAnywhere, Category = "Feedback|Trail")
 	bool bDisableTrailOnBeginPlay = true;
-
-	// ====================================================== //
 
 private:
 	UPROPERTY(Transient)
@@ -47,7 +44,6 @@ private:
 	int32 CurrentHitWindowId = INDEX_NONE;
 
 private:
-	/* === Components === */
 	UPROPERTY(VisibleAnywhere)
 	class USceneComponent* RootSceneComponent = nullptr;
 
@@ -55,7 +51,6 @@ private:
 	class UNiagaraComponent* TrailComponent = nullptr;
 
 private:
-	/* === Context Carrier === */
 	UPROPERTY(Transient)
 	FOverlapContext LastOverlapContext_Cached;
 
@@ -67,7 +62,6 @@ private:
 
 
 private:
-	/* === Injected Objects === */
 	UPROPERTY(Transient)
 	class ACharacter* OwnerCharacter_Injected = nullptr;
 
@@ -79,12 +73,9 @@ private:
 	TArray<class UShapeComponent*> Collisions_Cached;
 
 public:
-	/* === [OUT] Custom Delegate Events === */
-	// Collision (Enabled/Disabled)
 	FWeaponActorCollisionEnabled OnWeaponActorCollisionEnabled;
 	FWeaponActorCollisionDisabled OnWeaponActorCollisionDisabled;
 
-	// Overlap (Raw Overlap)
 	FWeaponActorBeginOverlap OnWeaponActorBeginOverlap;
 	FWeaponActorEndOverlap OnWeaponActorEndOverlap;
 
@@ -115,19 +106,19 @@ private:
 	void ClearTrailState();
 
 public:
-	/* === IHitContextProducer (Getter) === */
+	// Hit Context Provider Query
 	virtual const FOverlapContext& GetLastOverlapContext() const override;
 	virtual const FWeaponContext& GetLastWeaponContext() const override;
 	virtual const FActionContext& GetLastActionContext() const override;
 
 public:
-	/* === IHitContextProducer (Setter) === */
+	// Hit Context Provider Mutation
 	virtual void SetLastOverlapContext(const FOverlapContext& InOverlapContext) override;
 	virtual void SetLastWeaponContext(const FWeaponContext& InWeaponContext) override;
 	virtual void SetLastActionContext(const FActionContext& InActionContext) override;
 
 public:
-	/* === Getter === */
+	// Query
 	FORCEINLINE EWeaponType GetWeaponType() const { return WeaponType; }
 
 public:
@@ -135,25 +126,22 @@ public:
 	FORCEINLINE int32 GetCurrentHitWindowId() const { return CurrentHitWindowId; }
 
 public:
-	/* === Setter === */
+	// Mutation
 	void ChangeWeaponType(EWeaponType InWeaponType);
 	void ToggleTrailActive(bool bEnable);
 
 public:
-	/* === AnimNotify Events === */
-	// CAnimNotify_Equip / Unequip
+	// Equip Notify Events
 	void AttachToHandSocket();
 	void AttachToHolsterSocket();
 
 public:
-	/* === AnimNotify Events === */
-	// CAnimNotify_Collision
+	// Collision Notify Events
 	void CollisionEnabled(FName InName);
 	void CollisionDisabled();
 
 public:
-	/* === [IN] Engine Delegate Events === */
-	// UShapeComponent
+	// Engine Delegate Events
 	UFUNCTION()
 	void OnComponentBeginOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
 


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P44: 주석 / 섹션 정리 정책**

## 날짜

**2026.07.23**

## 상태

- [x] comment / section cleanup 작업 계획 문서 작성
- [x] stale / 오타 / 잘못된 주석 정리
- [x] code-local TODO 분류 및 유지 기준 확정
- [x] header / implementation section comment 양식 정리
- [x] 반복 설명 / 태그형 / 장식성 주석 제거
- [x] comment usage rule 문서화
- [x] P3 유지 / 후속 이관 판단 기록
- [x] PR final scan 완료

## 브랜치

- `refactor/comment-section-cleanup`

## 요약

이번 PR은 P42 `Debug Log Policy v1`, P43 `CVar Ownership Policy` 이후 이어지는 code quality cleanup 작업으로, 프로젝트 내부 주석과 section comment 사용 기준을 정리한다.

기존 코드에는 다음 성격의 주석이 섞여 있었다.

```text
1. 실제 정책 / 예외 이유를 설명하는 주석
2. header / cpp 구현부를 나누는 section comment
3. Debug / Profiling helper 구역을 나누는 comment
4. 코드가 그대로 말하는 반복 설명 주석
5. [NOTE] / [Policy] / [Pass] 같은 태그형 주석
6. separator / banner 형태의 장식성 주석
7. 구현 위치에 남겨야 하는 TODO
```

이번 PR에서는 주석을 전부 제거하는 것이 아니라, "코드가 직접 말하지 못하는 이유 / 정책 / 예외 / 구역"만 남기는 기준을 고정했다.

## 주요 변경

### 1. 작업 계획 문서 작성

`W05_Comment_Section_Cleanup_Work_Plan.md`를 추가하고, 이번 브랜치에서 다룰 범위와 제외 범위를 분리했다.

포함 범위:

```text
- stale / 오타 / 잘못된 주석 정리
- commented-out / temporary trace 확인
- TODO 분류
- section comment 양식 정리
- 불필요한 설명 주석 제거
- API / inline role comment 유효성 검토
```

제외 범위:

```text
- public API rename
- 구조체 나누기 / 헤더 배치 규칙
- DataAsset 분리 구현
- UPROPERTY Category 재설계
- RuntimeLOD CVar 위치 이동
- const 정합성 정리
- gameplay policy 구현
```

### 2. 주석 사용 규칙 고정

워크플랜 문서에 `Comment Usage Rules`를 추가했다.

최종 기준:

```text
Engine / Template Header
Debug Helper
Profiling Helper
Header API Section
Implementation Section
Algorithm / Step
Policy / Exception Reason
Type / Data Meaning
Sparse / One-off
```

핵심 원칙:

```text
무엇을 하는지 반복 설명하지 않는다.
왜 필요한지, 어떤 정책/예외인지 설명한다.
section comment는 짧은 명사구로 제한한다.
태그형 [NOTE] / [Policy] / [Pass] 주석은 사용하지 않는다.
separator / banner comment는 사용하지 않는다.
UPROPERTY 변수 구간은 주석보다 Category / 변수명 / struct 분리로 관리한다.
```

### 3. stale / 오타 / 잘못된 표현 정리

다음 유형을 정리했다.

```text
Acitve -> Active
Delgate -> Delegate
Flag Toogle -> Flag Toggle
Deffered -> Deferred
Seperate -> Separate
Stemina -> Stamina
BroadCast -> Broadcast
FallBack -> Fallback
```

CVar help text와 debug / profiling 설명 문구도 실제 역할과 맞게 보정했다.

### 4. TODO 분류

의미 없는 TODO와 이미 문서로 추적 가능한 TODO는 제거했다.

남긴 TODO는 다음 6개다.

```text
CPlayer.cpp
-> TODO(Gameplay): dead actor TakeDamage route 정책

CEnemy.cpp
-> TODO(Gameplay): dead actor TakeDamage route 정책

CCombatSignalTargetComponent.cpp
-> TODO(CombatPolicy): target-side defensive gates
-> TODO(CombatPolicy): mitigation policy
-> TODO(CombatPolicy): final damage policy
-> TODO(CombatPolicy): resource commit order
```

이 TODO들은 실제 구현 위치와 직접 연결되어 있어 code-local TODO로 유지한다.

### 5. section comment 정리

header / cpp 구현부 section comment를 다음 기준으로 맞췄다.

```text
Lifecycle
Component Reference
Query
Mutation
Runtime Lifecycle
Runtime State
Notify Routing
Data Build
State Transition
Gate
Counter
Diagnostic Hook
Debug Dump
```

`API`, `Current`, `Used`, `Temp`처럼 상태성 또는 넓은 표현은 제거하거나 더 구체적인 책임명으로 바꿨다.

예:

```text
Interface API -> Interface
ActionEvent API -> Action Event Routing
Request API -> Chain Combat Request
Mapping API -> Chain Intent Mapping
```

### 6. 반복 설명 / 태그형 / 장식성 주석 제거

다음 유형을 제거하거나 문장형으로 바꿨다.

```text
[NOTE]
[Policy]
[Pass]
/* === ... === */
// -----------------------------------------------------------------------------
// Exact
// Tier 0
// Cached
// Remove Invalid Entry
// Set Cooldown
// Update blackboard
// MODE 1 / MODE 2 / MODE 0
```

정책 의미가 있는 주석은 태그를 제거하고 이유 중심 문장으로 바꿨다.

예:

```cpp
// Dead reaction is terminal and cannot be interrupted.
```

### 7. Type / Data 주석 최종 판단

`CAIStructure.h`, `CWeaponStructure.h`에 남은 Type / Data 주석은 이번 브랜치에서 무리하게 제거하지 않는다.

유지:

```text
enum None / All / Max sentinel 설명
FDamageAmount damage pipeline 의미 설명
GetTypeHash ADL 관련 짧은 설명
```

후속 이관:

```text
FAIContext field group 주석
FOverlapContext actor/component alias 주석
```

이 항목은 `구조체 나누기 / 헤더 배치 규칙`, `네이밍 / 매개변수 작명 규칙`, `UPROPERTY Category 정리`에서 다시 판단한다.

## 변경 파일 범위

```text
Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
Docs/04_Pull_Request/00_Pull_Request_Index.md
Docs/04_Pull_Request/P44_UE5_Portfolio_Pull_Request.md

Source/Portfolio/AI/*
Source/Portfolio/Action/*
Source/Portfolio/Character/*
Source/Portfolio/Component/*
Source/Portfolio/Controller/*
Source/Portfolio/Core/Debug/*
Source/Portfolio/Core/Profiling/*
Source/Portfolio/Reaction/*
Source/Portfolio/System/Combat/*
Source/Portfolio/Type/*
Source/Portfolio/Weapon/*
```

## 검증

### Static check

```text
git status --short
Result: clean

git diff --check
Result: Pass
```

### Comment rule scan

다음 패턴을 재검색했다.

```text
/***
***/
^[space]*// [Tag]
[NOTE]
[Policy]
[Pass]
override this API
Interface API
ActionEvent API
// -----------------------------------------------------------------------------
Who: request source
What: requested intent
How: intent event
[Case_
```

결과:

```text
Result: 0
```

### TODO scan

```text
TODO(Gameplay): 2
TODO(CombatPolicy): 4
```

판단:

```text
남은 TODO 6개는 실제 구현 위치와 직접 연결된 정책 TODO이므로 유지한다.
```

### Build

```text
Not run
```

사유:

```text
이번 PR은 주석 / 문서 / section label 정리 중심이다.
CReactionFeedbackComponent.cpp는 빈 wildcard branch를 제거하면서 동등 조건으로 정리했지만, 분기 의미는 기존과 동일하다.
빌드가 필요한 header macro / reflection / asset reference 변경은 없다.
```

## 후속 작업

이번 PR에서 처리하지 않는 항목:

```text
네이밍 / 매개변수 작명 규칙
-> public API rename
-> helper/API suffix 통일
-> 매개변수명 정합성 정리

구조체 나누기 / 헤더 배치 규칙
-> CWeaponStructure.h 대형 type 분리
-> FAIContext field group 정리
-> FOverlapContext alias 정리
-> EBTServiceIntervalPreset 위치 재검토

UPROPERTY / Editor 노출 정리
-> UPROPERTY Category naming 통일
-> Category 변경에 따른 asset 영향 확인

데이터 에셋 분리
-> Action / Reaction data map build 이동
-> DamageSpecContainer DataAsset migration
-> AI perception config DataAsset migration
-> feedback data type 이동

상수 / CVar / RuntimeLOD 구조 정리
-> CEnemy RuntimeLOD CVar 위치 이동
-> RuntimeLOD policy/config 재구성

const 정합성
-> read-only API const 정리

Gameplay / CombatPolicy TODO 구현
-> dead actor TakeDamage route 정책
-> target-side defensive gates
-> mitigation / final damage / resource commit order
```

## 관련 문서

```text
Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
-> 이번 브랜치의 작업 범위, 주석 사용 규칙, 유지 TODO 판단을 기록한다.

Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
-> W05 코드 품질 작업 흐름에서 이번 브랜치 위치를 관리한다.

Docs/04_Pull_Request/00_Pull_Request_Index.md
-> P44 문서와 GitHub PR 번호를 연결한다.
```

## PR 설명 초안

```md
## Summary

- 주석 / 섹션 정리 작업 계획과 주석 사용 규칙을 문서화
- stale comment, 오타, 잘못된 설명, 태그형 주석, 장식성 banner, 코드 반복 설명 주석 정리
- header / cpp section comment를 짧은 책임명 중심으로 정리
- code-local TODO 6개를 Gameplay / CombatPolicy 후속 작업으로 유지 판단
- Type / Data 주석 중 구조체 / 헤더 배치 작업으로 넘길 항목을 P3 final decision으로 기록
- PR 문서에 관련 문서 섹션과 GitHub PR 번호 반영

## Validation

- git status --short clean
- git diff --check 통과
- comment rule violation scan 결과 0
- TODO scan 결과: 의도적으로 유지한 6개만 남음
- Build not run: 주석 / 문서 / section label 정리 중심, reflection / asset reference 변경 없음
```
