### PR TITLE
P45: Naming / Typo / API Cleanup

### DIFF
--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
@@ -157,7 +157,7 @@ static void RecordUpdateAIContextTick();
 static void RecordResolvedTier(EAIRuntimeLODTier InTier);
 ```
 
-`Core/Profiling` 밖의 owner class가 profiling event를 별도 wrapper로 분리해야 할 때는 필요하면 `ForProfiling` suffix를 허용한다. 다만 helper API 자체는 suffix 없는 `Record...` 형태를 기본으로 한다.
+`Core/Profiling` 밖의 owner class가 profiling event를 별도 wrapper로 분리해야 할 때도 가능하면 suffix 없는 `Record...` 형태를 사용한다. profiling 책임은 호출 위치의 섹션명과 `Core/Profiling` helper class 이름으로 표현한다.
 
 ---
 
@@ -171,10 +171,6 @@ Comp vs Component 전면 통일
 
 CWorldSubSystemStructure / SubSystem -> Subsystem
 -> 파일명, generated include, UHT, include 경로 영향 가능
-
-Core/Profiling API suffix 통일
--> helper class 이름이 profiling 책임을 드러내므로 함수명에서는 ForProfiling suffix를 제거하는 방향
--> 호출부가 있는 rename이므로 네이밍 브랜치에서 별도 commit으로 처리
 
 책임명 자체가 애매한 public API rename
 -> 실제 책임 재분류가 필요할 수 있음

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
@@ -1,0 +1,177 @@
+# W05 Naming Rules
+
+## 제목
+
+**W05: 네이밍 규칙**
+
+## 날짜
+
+**2026.07.23**
+
+## 상태
+
+- [x] Unreal C++ 관례와 프로젝트 기존 관례 기준으로 초안 작성
+- [x] 네이밍 / 오타 / API 정리 브랜치에서 우선 적용
+
+---
+
+## 1. 목적
+
+이 문서는 W05 코드 품질 정리에서 반복 적용할 네이밍 기준을 고정한다.
+
+목표는 프로젝트 전체 이름을 새 체계로 한 번에 바꾸는 것이 아니다. Unreal C++ 관례와 현재 프로젝트에 이미 자리 잡은 강한 관례를 기준으로, 단발성 오타 / 표기 흔들림 / 매개변수명 불일치를 판단하기 위한 기준을 둔다.
+
+---
+
+## 2. Public Type / API
+
+class, struct, enum, public function은 Unreal C++ 관례에 맞춰 `PascalCase`를 사용한다.
+
+```cpp
+class UCActionComponent;
+struct FActionExecutionContext;
+enum class EActionRequestResultType;
+
+bool CanResolveAction(...) const;
+FActionRequestResult HandleCombatAction(...);
+```
+
+---
+
+## 3. 매개변수
+
+입력 매개변수는 `In`, 출력 매개변수는 `Out`, 입출력 매개변수는 `InOut` prefix를 사용한다.
+
+```cpp
+void BuildContext(const FCombatSignalTargetPayload& InPayload, FCombatSignalTargetContext& OutContext);
+void UpdateContext(FAIContext& InOutAIContext);
+```
+
+참조 표기는 `FType& Value`, `const FType& Value` 형태로 통일한다.
+
+```cpp
+void SubmitRequest(const FEngageRequestContext& InEngageRequestContext);
+EContextBuildResult BuildEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext& OutEngageContext);
+```
+
+---
+
+## 4. 지역 변수
+
+지역 변수는 `lowerCamelCase`를 사용한다.
+
+```cpp
+UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
+const float distanceToTarget = FVector::Dist(ownerLocation, targetLocation);
+```
+
+`Blackboard`는 하나의 단어로 취급한다.
+
+```cpp
+// Good
+UBlackboardComponent* blackboardComp;
+
+// Avoid
+UBlackboardComponent* blackBoardComp;
+```
+
+---
+
+## 5. bool 이름
+
+bool 변수는 Unreal 관례대로 `bPascalCase`를 사용한다.
+
+```cpp
+bool bCanMove = true;
+bool bHasLOS = false;
+```
+
+bool query 함수는 `Is`, `Has`, `Can`, `Should` 계열을 사용한다.
+
+```cpp
+bool IsActive() const;
+bool HasTarget() const;
+bool CanMove() const;
+bool ShouldAuditCombatSignal();
+```
+
+`Getb...` 형태는 신규 API에서 사용하지 않는다.
+
+```cpp
+// Prefer
+bool ShouldUsePatrol() const;
+
+// Avoid
+bool GetbUsePatrol() const;
+```
+
+---
+
+## 6. 내부 참조 suffix
+
+DI로 주입된 참조는 `_Injected`, runtime cache는 `_Cached` suffix를 유지한다.
+
+```cpp
+UCActionComponent* ActionComp_Injected = nullptr;
+APawn* ControlledPawn_Cached = nullptr;
+```
+
+이 suffix는 현재 프로젝트에서 역할을 명확히 드러내는 강한 관례이므로 W05 범위에서 바꾸지 않는다.
+
+---
+
+## 7. Component / Comp 표기
+
+`Component`와 `Comp`는 다음 기준으로 구분한다.
+
+```text
+public API / UPROPERTY member
+-> 가능하면 Component 사용
+
+local variable / injected member / cached member
+-> 기존 프로젝트 관례상 Comp 허용
+```
+
+`GetMovementComp()`, `MovementComp_Injected` 같은 이름은 이미 광범위하게 사용되고 있으므로 단발 오타 정리 브랜치에서 전면 변경하지 않는다.
+
+---
+
+## 8. Debug / Profiling API
+
+Debug helper는 기존 규칙을 유지한다.
+
+```cpp
+static bool ShouldAuditActionComponent();
+static bool ShouldPrintActionComponentDebug();
+static void RecordActionDecisionRejectedForAudit(...);
+static void PrintActionExecutionContextDebug(...);
+static void ReportActionNotifyTriggerWarning(...);
+```
+
+신규 profiling API는 `Record...ForProfiling()` 형태를 권장한다.
+
+```cpp
+static void RecordAnimationRefreshExecutedForProfiling();
+```
+
+단, 이미 counter class 이름으로 profiling 성격이 드러나는 기존 combat profiling API의 전면 rename은 별도 판단한다.
+
+---
+
+## 9. 보류 기준
+
+다음 항목은 네이밍 문제로 보여도 단발 오타 정리로 처리하지 않는다.
+
+```text
+Comp vs Component 전면 통일
+-> public getter, injected/cache member, local variable까지 광범위하게 영향
+
+CWorldSubSystemStructure / SubSystem -> Subsystem
+-> 파일명, generated include, UHT, include 경로 영향 가능
+
+combat profiling API suffix 전면 통일
+-> 기존 counter class와 호출부가 넓음
+
+책임명 자체가 애매한 public API rename
+-> 실제 책임 재분류가 필요할 수 있음
+```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
@@ -127,12 +127,13 @@ APawn* ControlledPawn_Cached = nullptr;
 ```text
 public API / UPROPERTY member
 -> 가능하면 Component 사용
+-> Unreal engine API / parent class API와 이름 충돌 가능성이 있으면 Comp 허용
 
 local variable / injected member / cached member
 -> 기존 프로젝트 관례상 Comp 허용
 ```
 
-`GetMovementComp()`, `MovementComp_Injected` 같은 이름은 이미 광범위하게 사용되고 있으므로 단발 오타 정리 브랜치에서 전면 변경하지 않는다.
+`GetMovementComp()`, `MovementComp_Injected` 같은 이름은 이미 광범위하게 사용되고 있고, 일부 component 계열 public API는 engine / parent API와 충돌을 피하기 위한 회피 네이밍일 수 있다. 따라서 단발 오타 정리 브랜치에서 전면 변경하지 않는다.
 
 ---
 
@@ -148,13 +149,15 @@ static void PrintActionExecutionContextDebug(...);
 static void ReportActionNotifyTriggerWarning(...);
 ```
 
-신규 profiling API는 `Record...ForProfiling()` 형태를 권장한다.
+Profiling helper는 class / namespace가 이미 profiling 책임을 드러내므로 함수명에 `ForProfiling` suffix를 반복하지 않는다.
 
 ```cpp
-static void RecordAnimationRefreshExecutedForProfiling();
+static void RecordAnimationRefreshExecuted();
+static void RecordUpdateAIContextTick();
+static void RecordResolvedTier(EAIRuntimeLODTier InTier);
 ```
 
-단, 이미 counter class 이름으로 profiling 성격이 드러나는 기존 combat profiling API의 전면 rename은 별도 판단한다.
+`Core/Profiling` 밖의 owner class가 profiling event를 별도 wrapper로 분리해야 할 때는 필요하면 `ForProfiling` suffix를 허용한다. 다만 helper API 자체는 suffix 없는 `Record...` 형태를 기본으로 한다.
 
 ---
 
@@ -169,8 +172,9 @@ Comp vs Component 전면 통일
 CWorldSubSystemStructure / SubSystem -> Subsystem
 -> 파일명, generated include, UHT, include 경로 영향 가능
 
-combat profiling API suffix 전면 통일
--> 기존 counter class와 호출부가 넓음
+Core/Profiling API suffix 통일
+-> helper class 이름이 profiling 책임을 드러내므로 함수명에서는 ForProfiling suffix를 제거하는 방향
+-> 호출부가 있는 rename이므로 네이밍 브랜치에서 별도 commit으로 처리
 
 책임명 자체가 애매한 public API rename
 -> 실제 책임 재분류가 필요할 수 있음

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
@@ -169,9 +169,6 @@ static void RecordResolvedTier(EAIRuntimeLODTier InTier);
 Comp vs Component 전면 통일
 -> public getter, injected/cache member, local variable까지 광범위하게 영향
 
-CWorldSubSystemStructure / SubSystem -> Subsystem
--> 파일명, generated include, UHT, include 경로 영향 가능
-
 책임명 자체가 애매한 public API rename
 -> 실제 책임 재분류가 필요할 수 있음
 ```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
@@ -14,7 +14,8 @@
 - [x] 네이밍 규칙 문서 분리
 - [x] 이번 브랜치 처리 범위 / 보류 범위 분류
 - [ ] P0 단발 네이밍 불일치 수정
-- [ ] P1 public API rename 후보 판단
+- [ ] P1 public API rename 적용
+- [ ] Profiling helper API suffix 정리
 - [ ] 검증 및 PR 문서 작성
 
 ---
@@ -84,9 +85,9 @@ CBTService_UpdateEngageContext.h
 -> FEngageContext & -> FEngageContext&
 ```
 
-### P1: 판단 후 선택 적용
+### P1: public API rename 적용
 
-다음 항목은 규칙상 수정 방향은 명확하지만 public C++ API rename이다. 호출부 범위와 빌드 영향 확인 후 적용 여부를 결정한다.
+다음 항목은 public C++ API rename이지만, 기존 이름이 bool getter 규칙과 맞지 않으므로 이번 브랜치에서 적용한다.
 
 ```text
 CEnemy.h
@@ -98,7 +99,29 @@ CEnemy.h
 -> CAIController.cpp
 ```
 
-`UFUNCTION`이 아니므로 Blueprint 직접 영향은 낮지만 public inline API이므로 별도 commit 또는 별도 판단 단위로 처리한다.
+`UFUNCTION`이 아니므로 Blueprint 직접 영향은 낮지만 public inline API이므로 P0 단발 수정과 별도 commit으로 처리한다.
+
+### P1: Profiling helper API suffix 정리
+
+`Core/Profiling` helper class는 class 이름이 profiling 책임을 이미 드러내므로 `ForProfiling` suffix를 제거하는 방향으로 통일한다.
+
+```text
+CAIAnimationProfiling
+-> RecordAnimationRefreshAttemptForProfiling() -> RecordAnimationRefreshAttempt()
+-> RecordAnimationRefreshExecutedForProfiling() -> RecordAnimationRefreshExecuted()
+-> RecordAnimationRefreshSkippedForProfiling() -> RecordAnimationRefreshSkipped()
+
+CAIBehaviorTreeProfiling
+-> RecordUpdateAIContextTickForProfiling() -> RecordUpdateAIContextTick()
+-> RecordUpdateAIIntentStateTickForProfiling() -> RecordUpdateAIIntentStateTick()
+-> RecordUpdateEngageContextTickForProfiling() -> RecordUpdateEngageContextTick()
+-> RecordAIIntentIntervalPresetForProfiling() -> RecordAIIntentIntervalPreset()
+
+CAIStateRuntimeLODProfiling
+-> RecordResolvedTierForProfiling() -> RecordResolvedTier()
+```
+
+`CCombatFeedbackProfiling`, `FCombatCollisionProfilingCounters`는 이미 suffix 없는 형태이므로 유지한다.
 
 ---
 
@@ -115,9 +138,9 @@ CWorldSubSystemStructure / SubSystem -> Subsystem
 -> 파일명, generated include, UHT, include 경로 영향 가능
 -> 구조체 나누기 / 헤더 배치 규칙 작업에서 처리
 
-combat profiling API suffix 전면 통일
--> 기존 counter class와 호출부가 넓음
--> profiling naming 작업으로 별도 처리
+Core/Profiling 밖 owner-side profiling wrapper 전면 통일
+-> helper API 통일 이후 필요하면 별도 판단
+-> owner class 내부 wrapper는 profiling side effect를 드러내기 위해 ForProfiling suffix를 허용
 
 RequestAICombatSignalCue 같은 책임명 불일치 후보
 -> 실제 책임 재분류가 필요할 수 있음
@@ -131,11 +154,11 @@ RequestAICombatSignalCue 같은 책임명 불일치 후보
 ```text
 1. P0 단발 네이밍 불일치 수정
 2. rg 재검색으로 잔존 후보 확인
-3. P1 GetbUse 계열 적용 여부 판단
-4. 필요 시 P1 별도 commit 처리
+3. P1 GetbUse 계열을 ShouldUse 계열로 별도 commit 처리
+4. P1 Core/Profiling helper API suffix를 별도 commit 처리
 5. W05 문서와 PR 문서 업데이트
 6. git diff --check
-7. C++ header/API 변경이 있으면 PortfolioEditor Development 빌드
+7. C++ header/API 변경이 있으므로 PortfolioEditor Development 빌드
 ```
 
 ---
@@ -146,6 +169,7 @@ RequestAICombatSignalCue 같은 책임명 불일치 후보
 
 ```powershell
 rg -n "inAxisValue|executorkey|dist_target|blackBoardComp|FEngageContext &|FEngageRequestContext &" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
+rg -n "GetbUse|Record[A-Za-z0-9]+ForProfiling" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
 git diff --check
 ```
 
@@ -163,10 +187,10 @@ C++ API 변경 시 빌드:
 PR 가능:
 - 기능 동작 변경이 없다
 - P0 네이밍 불일치가 제거됐다
-- P1 public API rename 여부가 문서에 기록됐다
+- P1 public API rename과 profiling helper API suffix 정리가 문서 기준과 일치한다
 - 보류 항목이 삭제되지 않고 후속 범위로 남아 있다
 - git diff --check가 통과했다
-- header/API rename을 적용했다면 Development 빌드를 확인했다
+- Development 빌드를 확인했다
 
 PR 보류:
 - Blueprint / asset reference 위험이 있는 rename이 섞였다

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
@@ -13,10 +13,11 @@
 - [x] 네이밍 패턴 스캔
 - [x] 네이밍 규칙 문서 분리
 - [x] 이번 브랜치 처리 범위 / 보류 범위 분류
-- [ ] P0 단발 네이밍 불일치 수정
-- [ ] P1 public API rename 적용
-- [ ] Profiling helper API suffix 정리
-- [ ] 검증 및 PR 문서 작성
+- [x] P0 단발 네이밍 불일치 수정
+- [x] P1 public API rename 적용
+- [x] Profiling helper API suffix 정리
+- [x] 최종 검증
+- [ ] PR 문서 작성
 
 ---
 
@@ -73,6 +74,7 @@ CReactionComponent.cpp
 
 CBTService_UpdateAIContext.cpp
 -> dist_target -> distanceToTarget
+-> dist_home -> distanceToHome
 
 CBTService_UpdateEngageContext.cpp
 -> blackBoardComp -> blackboardComp
@@ -139,8 +141,8 @@ CWorldSubSystemStructure / SubSystem -> Subsystem
 -> 구조체 나누기 / 헤더 배치 규칙 작업에서 처리
 
 Core/Profiling 밖 owner-side profiling wrapper 전면 통일
--> helper API 통일 이후 필요하면 별도 판단
--> owner class 내부 wrapper는 profiling side effect를 드러내기 위해 ForProfiling suffix를 허용
+-> helper API와 owner-side wrapper 모두 이번 브랜치에서 suffix를 제거
+-> profiling 책임은 `Core/Profiling` helper class 이름과 호출 섹션으로 표현
 
 RequestAICombatSignalCue 같은 책임명 불일치 후보
 -> 실제 책임 재분류가 필요할 수 있음
@@ -156,9 +158,11 @@ RequestAICombatSignalCue 같은 책임명 불일치 후보
 2. rg 재검색으로 잔존 후보 확인
 3. P1 GetbUse 계열을 ShouldUse 계열로 별도 commit 처리
 4. P1 Core/Profiling helper API suffix를 별도 commit 처리
-5. W05 문서와 PR 문서 업데이트
-6. git diff --check
-7. C++ header/API 변경이 있으므로 PortfolioEditor Development 빌드
+5. 추가 local snake_case 후보 정리
+6. W05 문서 업데이트
+7. git diff --check
+8. C++ header/API 변경이 있으므로 PortfolioEditor Development 빌드
+9. PR 문서 업데이트
 ```
 
 ---
@@ -168,7 +172,7 @@ RequestAICombatSignalCue 같은 책임명 불일치 후보
 정적 확인:
 
 ```powershell
-rg -n "inAxisValue|executorkey|dist_target|blackBoardComp|FEngageContext &|FEngageRequestContext &" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
+rg -n "inAxisValue|executorkey|dist_target|dist_home|blackBoardComp|FEngageContext &|FEngageRequestContext &" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
 rg -n "GetbUse|Record[A-Za-z0-9]+ForProfiling" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
 git diff --check
 ```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
@@ -18,7 +18,7 @@
 - [x] Profiling helper API suffix 정리
 - [x] World subsystem structure file rename 적용
 - [x] 최종 검증
-- [ ] PR 문서 작성
+- [x] PR 문서 작성
 
 ---
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
@@ -16,6 +16,7 @@
 - [x] P0 단발 네이밍 불일치 수정
 - [x] P1 public API rename 적용
 - [x] Profiling helper API suffix 정리
+- [x] World subsystem structure file rename 적용
 - [x] 최종 검증
 - [ ] PR 문서 작성
 
@@ -125,6 +126,19 @@ CAIStateRuntimeLODProfiling
 
 `CCombatFeedbackProfiling`, `FCombatCollisionProfilingCounters`는 이미 suffix 없는 형태이므로 유지한다.
 
+### P1: World subsystem structure file rename
+
+`CWorldSubSystemStructure`는 파일명과 include 경로만 `SubSystem` 표기가 남아 있고, 내부 타입명에는 영향이 없다.
+따라서 이번 브랜치에서 `CWorldSubsystemStructure`로 정리한다.
+
+```text
+Source/Portfolio/Type/CWorldSubSystemStructure.h
+-> Source/Portfolio/Type/CWorldSubsystemStructure.h
+
+Source/Portfolio/Type/CWorldSubSystemStructure.cpp
+-> Source/Portfolio/Type/CWorldSubsystemStructure.cpp
+```
+
 ---
 
 ## 4. 이번 브랜치 보류 범위
@@ -135,10 +149,6 @@ CAIStateRuntimeLODProfiling
 Comp vs Component 전면 통일
 -> public getter, injected/cache member, local variable까지 광범위하게 영향
 -> API 스타일 변경 작업으로 분리
-
-CWorldSubSystemStructure / SubSystem -> Subsystem
--> 파일명, generated include, UHT, include 경로 영향 가능
--> 구조체 나누기 / 헤더 배치 규칙 작업에서 처리
 
 Core/Profiling 밖 owner-side profiling wrapper 전면 통일
 -> helper API와 owner-side wrapper 모두 이번 브랜치에서 suffix를 제거
@@ -159,10 +169,11 @@ RequestAICombatSignalCue 같은 책임명 불일치 후보
 3. P1 GetbUse 계열을 ShouldUse 계열로 별도 commit 처리
 4. P1 Core/Profiling helper API suffix를 별도 commit 처리
 5. 추가 local snake_case 후보 정리
-6. W05 문서 업데이트
-7. git diff --check
-8. C++ header/API 변경이 있으므로 PortfolioEditor Development 빌드
-9. PR 문서 업데이트
+6. CWorldSubsystemStructure 파일명 / include 경로 정리
+7. W05 문서 업데이트
+8. git diff --check
+9. C++ header/API 변경이 있으므로 PortfolioEditor Development 빌드
+10. PR 문서 업데이트
 ```
 
 ---
@@ -173,7 +184,7 @@ RequestAICombatSignalCue 같은 책임명 불일치 후보
 
 ```powershell
 rg -n "inAxisValue|executorkey|dist_target|dist_home|blackBoardComp|FEngageContext &|FEngageRequestContext &" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
-rg -n "GetbUse|Record[A-Za-z0-9]+ForProfiling" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
+rg -n "GetbUse|Record[A-Za-z0-9]+ForProfiling|CWorldSubSystemStructure" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
 git diff --check
 ```
 
@@ -192,12 +203,12 @@ PR 가능:
 - 기능 동작 변경이 없다
 - P0 네이밍 불일치가 제거됐다
 - P1 public API rename과 profiling helper API suffix 정리가 문서 기준과 일치한다
-- 보류 항목이 삭제되지 않고 후속 범위로 남아 있다
+- 보류 항목은 구조 영향이 큰 범위만 후속 범위로 남아 있다
 - git diff --check가 통과했다
 - Development 빌드를 확인했다
 
 PR 보류:
 - Blueprint / asset reference 위험이 있는 rename이 섞였다
-- 파일명 / generated include / UHT 영향 rename이 섞였다
+- 파일명 / generated include / UHT 영향 rename이 빌드로 검증되지 않았다
 - 네이밍 정리를 넘어 책임 재설계가 필요해졌다
 ```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
@@ -1,0 +1,175 @@
+# W05 Naming / Typo / API Cleanup Work Plan
+
+## 제목
+
+**W05: 네이밍 / 오타 / API 정리 작업 계획**
+
+## 날짜
+
+**2026.07.23**
+
+## 상태
+
+- [x] 네이밍 패턴 스캔
+- [x] 네이밍 규칙 문서 분리
+- [x] 이번 브랜치 처리 범위 / 보류 범위 분류
+- [ ] P0 단발 네이밍 불일치 수정
+- [ ] P1 public API rename 후보 판단
+- [ ] 검증 및 PR 문서 작성
+
+---
+
+## 브랜치
+
+```text
+refactor/naming-typo-api-cleanup
+```
+
+---
+
+## 1. 목표
+
+이번 작업은 기능 동작을 바꾸지 않고, 프로젝트 내부 네이밍의 신뢰도를 정리한다.
+
+목표는 새 네이밍 체계를 크게 도입하는 것이 아니다. 이미 프로젝트에 자리 잡은 강한 관례를 문서로 고정하고, 단발성 오타 / 표기 흔들림 / 매개변수명 불일치만 정리한다.
+
+```text
+1. 명백한 오타와 단발 네이밍 불일치 제거
+2. Unreal C++ 관례와 현재 프로젝트 관례의 경계 고정
+3. public API / Blueprint / UHT 영향이 있는 rename은 별도 판단
+4. 이후 네이밍 리뷰에서 사용할 기준 문서 연결
+```
+
+---
+
+## 2. 적용 규칙
+
+네이밍 규칙은 별도 문서에서 관리한다.
+
+```text
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+```
+
+이번 브랜치는 위 규칙을 기준으로 단발 오타 / 표기 흔들림 / 매개변수명 불일치만 정리한다.
+
+---
+
+## 3. 이번 브랜치 처리 범위
+
+### P0: 바로 수정
+
+다음 항목은 local-only 또는 형식성 변경이다. Blueprint / asset reference 영향이 없으므로 이번 브랜치에서 처리한다.
+
+```text
+CPlayerController.cpp
+-> inAxisValue -> InAxisValue
+
+CActionComponent.cpp
+-> executorkey -> executorKey
+
+CReactionComponent.cpp
+-> executorkey -> executorKey
+
+CBTService_UpdateAIContext.cpp
+-> dist_target -> distanceToTarget
+
+CBTService_UpdateEngageContext.cpp
+-> blackBoardComp -> blackboardComp
+-> dist_target -> distanceToTarget
+
+CWorldSubsystem_CombatEngage.cpp
+-> FEngageRequestContext & -> FEngageRequestContext&
+
+CBTService_UpdateEngageContext.h
+-> FEngageContext & -> FEngageContext&
+```
+
+### P1: 판단 후 선택 적용
+
+다음 항목은 규칙상 수정 방향은 명확하지만 public C++ API rename이다. 호출부 범위와 빌드 영향 확인 후 적용 여부를 결정한다.
+
+```text
+CEnemy.h
+-> GetbUsePatrol() -> ShouldUsePatrol()
+-> GetbUseInvestigate() -> ShouldUseInvestigate()
+-> GetbUseAlertStep() -> ShouldUseAlertStep()
+
+호출부:
+-> CAIController.cpp
+```
+
+`UFUNCTION`이 아니므로 Blueprint 직접 영향은 낮지만 public inline API이므로 별도 commit 또는 별도 판단 단위로 처리한다.
+
+---
+
+## 4. 이번 브랜치 보류 범위
+
+다음 항목은 네이밍 이슈로 보이더라도 변경 범위나 구조 영향이 크므로 이번 브랜치에서 처리하지 않는다.
+
+```text
+Comp vs Component 전면 통일
+-> public getter, injected/cache member, local variable까지 광범위하게 영향
+-> API 스타일 변경 작업으로 분리
+
+CWorldSubSystemStructure / SubSystem -> Subsystem
+-> 파일명, generated include, UHT, include 경로 영향 가능
+-> 구조체 나누기 / 헤더 배치 규칙 작업에서 처리
+
+combat profiling API suffix 전면 통일
+-> 기존 counter class와 호출부가 넓음
+-> profiling naming 작업으로 별도 처리
+
+RequestAICombatSignalCue 같은 책임명 불일치 후보
+-> 실제 책임 재분류가 필요할 수 있음
+-> 동작 경계 검토 후 별도 commit 또는 후속 브랜치로 분리
+```
+
+---
+
+## 5. 작업 순서
+
+```text
+1. P0 단발 네이밍 불일치 수정
+2. rg 재검색으로 잔존 후보 확인
+3. P1 GetbUse 계열 적용 여부 판단
+4. 필요 시 P1 별도 commit 처리
+5. W05 문서와 PR 문서 업데이트
+6. git diff --check
+7. C++ header/API 변경이 있으면 PortfolioEditor Development 빌드
+```
+
+---
+
+## 6. 검증 기준
+
+정적 확인:
+
+```powershell
+rg -n "inAxisValue|executorkey|dist_target|blackBoardComp|FEngageContext &|FEngageRequestContext &" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
+git diff --check
+```
+
+C++ API 변경 시 빌드:
+
+```powershell
+& "C:\Program Files\Epic Games\UE_5.4\Engine\Build\BatchFiles\Build.bat" PortfolioEditor Win64 Development -Project="C:\UE5_Portfolio\Portfolio_UE5.4_verGit\Portfolio\Portfolio.uproject" -WaitMutex -FromMsBuild
+```
+
+---
+
+## 7. PR 가능 조건
+
+```yaml
+PR 가능:
+- 기능 동작 변경이 없다
+- P0 네이밍 불일치가 제거됐다
+- P1 public API rename 여부가 문서에 기록됐다
+- 보류 항목이 삭제되지 않고 후속 범위로 남아 있다
+- git diff --check가 통과했다
+- header/API rename을 적용했다면 Development 빌드를 확인했다
+
+PR 보류:
+- Blueprint / asset reference 위험이 있는 rename이 섞였다
+- 파일명 / generated include / UHT 영향 rename이 섞였다
+- 네이밍 정리를 넘어 책임 재설계가 필요해졌다
+```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -102,6 +102,8 @@ W05 묶음은 다음 조건을 만족하면 코드 품질 1차 정리가 완료�
 Work List / Notes
 - Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
 - Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+- Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+- Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
 - Docs/01_Work_List/00_Work_List_Index.md
 - Docs/06_notes/N08_Code_Quality_Cleanup_Plan_Note.md
 ```
@@ -349,6 +351,7 @@ refactor/naming-typo-api-cleanup
 - 기능 변경 없이 오타와 명백한 네이밍 불일치를 정리한다.
 - Blueprint / asset reference 위험이 있는 rename은 별도 확인 후 처리한다.
 - `RequestAICombatSignalCue` 같은 책임명 불일치 후보는 별도 commit으로 분리한다.
+- 네이밍 규칙은 `W05_Naming_Rules.md`에, 이번 브랜치 처리 / 보류 범위는 `W05_Naming_Typo_API_Cleanup_Work_Plan.md`에 기록한다.
 
 ---
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -252,7 +252,7 @@ Source/Portfolio/Type/CCombatSignalStructure.h
 Source/Portfolio/Type/CActionOrchestrationStructure.h
 Source/Portfolio/Type/CReactionOrchestrationStructure.h
 Source/Portfolio/Type/CReactionFeedbackStructure.h
-Source/Portfolio/Type/CWorldSubSystemStructure.h
+Source/Portfolio/Type/CWorldSubsystemStructure.h
 Source/Portfolio/Type/CAIStructure.h
 Source/Portfolio/Type/CCharacterComponentReferenceStructure.h
 ```

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -6,6 +6,7 @@
 
 | ID | 제목 | 파일 | 브랜치 | GitHub PR | 관련 문서 |
 | --- | --- | --- | --- | --- | --- |
+| P45 | Naming / Typo / API Cleanup | `P45_UE5_Portfolio_Pull_Request.md` | `refactor/naming-typo-api-cleanup` |  | W05 |
 | P44 | 주석 / 섹션 정리 정책 | `P44_UE5_Portfolio_Pull_Request.md` | `refactor/comment-section-cleanup` | #99 | W05 |
 | P42 | Debug Log Policy v1 | `P42_UE5_Portfolio_Pull_Request.md` | `refactor/debug-log-policy-v1` |  | W05, N22, N23, N24, N25, N26 |
 | P43 | CVar Ownership Policy | `P43_UE5_Portfolio_Pull_Request.md` | `refactor/cvar-ownership-policy` |  | W05, N23, N26, N27 |

--- a/Docs/04_Pull_Request/P45_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P45_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,228 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P45: Naming / Typo / API Cleanup**
+
+## 날짜
+
+**2026.07.23**
+
+## 상태
+
+- [x] 네이밍 규칙 문서 분리
+- [x] local naming / typo 불일치 정리
+- [x] bool query public API를 `Should...` 기준으로 정리
+- [x] profiling helper counter API suffix 정리
+- [x] `CWorldSubsystemStructure` 파일명 / include 표기 정리
+- [x] 네이밍 잔여 패턴 재확인
+- [x] `PortfolioEditor Win64 Development` build 통과
+- [x] PIE 확인
+
+## 브랜치
+
+- `refactor/naming-typo-api-cleanup`
+
+## 요약
+
+이번 PR은 W05 code quality cleanup의 네이밍 / 오타 / API 표기 정리 범위를 처리한다.
+
+주석 / CVar / debug helper처럼 별도 정책이 필요한 구조 변경은 이전 PR에서 분리했고, 이번 PR에서는 기능 동작을 바꾸지 않는 이름 정합성에 집중했다.
+
+정리 기준은 다음 문서로 고정했다.
+
+```text
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
+```
+
+## 주요 변경
+
+### 1. 네이밍 규칙 문서화
+
+다음 기준을 W05 문서로 분리했다.
+
+```text
+Public type / API
+-> PascalCase
+
+Input / output parameter
+-> In / Out / InOut prefix
+
+Reference style
+-> FType& Value
+-> const FType& Value
+
+Local variable
+-> lowerCamelCase
+
+bool variable
+-> bPascalCase
+
+bool query function
+-> Is / Has / Can / Should
+
+DI / runtime cache suffix
+-> _Injected / _Cached 유지
+```
+
+`Comp` / `Component` 전면 통일과 책임명이 애매한 public API rename은 구조 판단이 필요하므로 후속 범위로 남겼다.
+
+### 2. local naming / typo 정리
+
+단발 오타와 local-only naming 흔들림을 정리했다.
+
+```text
+CPlayerController.cpp
+-> inAxisValue -> InAxisValue
+
+CActionComponent.cpp
+-> executorkey -> executorKey
+
+CReactionComponent.cpp
+-> executorkey -> executorKey
+
+CBTService_UpdateAIContext.cpp
+-> dist_target -> distanceToTarget
+-> dist_home -> distanceToHome
+
+CBTService_UpdateEngageContext.cpp
+-> blackBoardComp -> blackboardComp
+-> dist_target -> distanceToTarget
+
+CBTService_UpdateEngageContext.h
+-> FEngageContext & -> FEngageContext&
+
+CWorldSubsystem_CombatEngage.h / .cpp
+-> FEngageRequestContext & -> FEngageRequestContext&
+```
+
+### 3. bool query public API 정리
+
+`Getb...` 형태의 bool getter를 query API 기준에 맞췄다.
+
+```text
+CEnemy.h
+-> GetbUsePatrol() -> ShouldUsePatrol()
+-> GetbUseInvestigate() -> ShouldUseInvestigate()
+-> GetbUseAlertStep() -> ShouldUseAlertStep()
+
+호출부
+-> CAIController.cpp
+```
+
+### 4. profiling helper API suffix 정리
+
+`Core/Profiling` helper class는 class 이름이 profiling 책임을 이미 드러내므로 `ForProfiling` suffix를 제거했다.
+
+```text
+CAIAnimationProfiling
+-> RecordAnimationRefreshAttempt()
+-> RecordAnimationRefreshExecuted()
+-> RecordAnimationRefreshSkipped()
+
+CAIBehaviorTreeProfiling
+-> RecordUpdateAIContextTick()
+-> RecordUpdateAIIntentStateTick()
+-> RecordUpdateEngageContextTick()
+-> RecordAIIntentIntervalPreset()
+
+CAIStateRuntimeLODProfiling
+-> RecordResolvedTier()
+```
+
+`UCAnimInstance`의 owner-side profiling wrapper도 같은 기준으로 suffix 없는 `Record...` 형태로 맞췄다.
+
+### 5. World subsystem structure 표기 정리
+
+파일명과 include 경로에 남아 있던 `SubSystem` 표기를 `Subsystem`으로 정리했다.
+
+```text
+Source/Portfolio/Type/CWorldSubSystemStructure.h
+-> Source/Portfolio/Type/CWorldSubsystemStructure.h
+
+Source/Portfolio/Type/CWorldSubSystemStructure.cpp
+-> Source/Portfolio/Type/CWorldSubsystemStructure.cpp
+
+#include "Type/CWorldSubSystemStructure.h"
+-> #include "Type/CWorldSubsystemStructure.h"
+
+#include "CWorldSubSystemStructure.generated.h"
+-> #include "CWorldSubsystemStructure.generated.h"
+```
+
+내부 `USTRUCT` / `UENUM` 타입명은 변경하지 않았다.
+
+## 변경 파일 범위
+
+```text
+Docs/01_Work_List/W05_Code_Quality_Plan/*
+Docs/04_Pull_Request/P45_UE5_Portfolio_Pull_Request.md
+Docs/04_Pull_Request/00_Pull_Request_Index.md
+
+Source/Portfolio/AI/BehaviorTree/Service/*
+Source/Portfolio/AI/Blackboard/*
+Source/Portfolio/AI/RuntimeLOD/*
+Source/Portfolio/Character/*
+Source/Portfolio/Component/*
+Source/Portfolio/Controller/*
+Source/Portfolio/Core/Debug/*
+Source/Portfolio/Core/Profiling/*
+Source/Portfolio/System/Combat/*
+Source/Portfolio/Type/*
+```
+
+## 검증
+
+### Branch scan
+
+```text
+Branch:
+refactor/naming-typo-api-cleanup
+
+main 대비 변경:
+36 files changed, 483 insertions(+), 92 deletions(-)
+```
+
+### Static check
+
+다음 잔여 패턴을 확인했다.
+
+```powershell
+rg -n "inAxisValue|executorkey|dist_target|dist_home|blackBoardComp|FEngageContext &|FEngageRequestContext &" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
+Result: 0
+
+rg -n "GetbUse|Record[A-Za-z0-9]+ForProfiling|CWorldSubSystemStructure" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
+Result: 0
+
+git diff --check main...HEAD
+Result: Pass
+```
+
+### Build
+
+```text
+PortfolioEditor Win64 Development
+Result: Pass
+```
+
+### PIE
+
+```text
+PIE
+Result: Pass
+```
+
+## 후속 작업
+
+이번 PR에서 처리하지 않는 항목:
+
+```text
+Comp vs Component 전면 통일
+-> public getter, injected/cache member, local variable까지 영향
+-> Unreal engine / parent API collision 회피 이름도 같이 봐야 하므로 별도 브랜치에서 처리
+
+책임명 자체가 애매한 public API rename
+-> 실제 책임 재분류가 필요할 수 있음
+-> 단순 네이밍 정리 범위에서 제외
+```

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
@@ -115,14 +115,14 @@ namespace
 
 	void RecordStateRuntimeLODTier(EAIRuntimeLODTier InTier)
 	{
-		FAIStateRuntimeLODProfiling::RecordResolvedTierForProfiling(InTier);
+		FAIStateRuntimeLODProfiling::RecordResolvedTier(InTier);
 	}
 
 	// AIIntentState
 	// Record Counter (AIIntentState)
 	void RecordAIIntentStateIntervalPreset(EBTServiceIntervalPreset InPreset)
 	{
-		FAIBehaviorTreeProfiling::RecordAIIntentIntervalPresetForProfiling(InPreset);
+		FAIBehaviorTreeProfiling::RecordAIIntentIntervalPreset(InPreset);
 	}
 
 	// Interval Enum Preset -> Interval float value (AIIntentState)

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -181,21 +181,21 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeAlertRangeContext(APawn*
 	FVector ownerLocation = InOwnerPawn->GetActorLocation();
 	FVector targetLocation = InOutAIContext.TargetActor->GetActorLocation();
 
-	float dist_target = FVector::Dist(ownerLocation, targetLocation);
+	float distanceToTarget = FVector::Dist(ownerLocation, targetLocation);
 
 	float alertOuterRange = chaseOffsetRange + chaseEnterBuffer;
 	float alertInnerRange = FMath::Max(0.f, chaseOffsetRange - chaseExitBuffer);
 
 	if (bInAlertRange)
 	{
-		if (dist_target > alertOuterRange) bInAlertRange = false;
+		if (distanceToTarget > alertOuterRange) bInAlertRange = false;
 	}
 	else
 	{
-		if (dist_target <= alertInnerRange) bInAlertRange = true;
+		if (distanceToTarget <= alertInnerRange) bInAlertRange = true;
 	}
 
-	InOutAIContext.DistanceToTarget = dist_target;
+	InOutAIContext.DistanceToTarget = distanceToTarget;
 	InOutAIContext.bInAlertRange = bInAlertRange;
 
 	return EContextBuildResult::Success;

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -159,10 +159,10 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeHomeMetricContext(APawn*
 	FVector ownerLocation = InOwnerPawn->GetActorLocation();
 	FVector homeLocation = InBlackboardComp->GetValueAsVector(CAIKey::Navigation::HomeLocation.KeyName);
 
-	float dist_home = FVector::Dist(ownerLocation, homeLocation);
+	float distanceToHome = FVector::Dist(ownerLocation, homeLocation);
 
-	InOutAIContext.DistanceToHome = dist_home;
-	InOutAIContext.bReturnHome = dist_home > MovableRange;
+	InOutAIContext.DistanceToHome = distanceToHome;
+	InOutAIContext.bReturnHome = distanceToHome > MovableRange;
 
 	return EContextBuildResult::Success;
 }

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -32,7 +32,7 @@ UCBTService_UpdateAIContext::UCBTService_UpdateAIContext()
 void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds)
 {
 	CSV_SCOPED_TIMING_STAT_GLOBAL(PortfolioAI_BT_UpdateAIContext);
-	FAIBehaviorTreeProfiling::RecordUpdateAIContextTickForProfiling();
+	FAIBehaviorTreeProfiling::RecordUpdateAIContextTick();
 	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
 
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -18,7 +18,7 @@
 #include "Core/Debug/FAICombatBTDebug.h"
 #include "Core/Profiling/CAIBehaviorTreeProfiling.h"
 #include "Type/CAIStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 UCBTService_UpdateAIContext::UCBTService_UpdateAIContext()
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
@@ -16,7 +16,7 @@
 #include "Type/CStateStructure.h"
 #include "Type/CWeaponStructure.h"
 #include "Type/CHealthStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 #include "AI/Blackboard/CAIKey.h"
 #include "AI/Blackboard/CAIBlackboardValueHelper.h"
 

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
@@ -32,7 +32,7 @@ UCBTService_UpdateAIIntentState::UCBTService_UpdateAIIntentState()
 void UCBTService_UpdateAIIntentState::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds)
 {
 	CSV_SCOPED_TIMING_STAT_GLOBAL(PortfolioAI_BT_UpdateAIIntentState);
-	FAIBehaviorTreeProfiling::RecordUpdateAIIntentStateTickForProfiling();
+	FAIBehaviorTreeProfiling::RecordUpdateAIIntentStateTick();
 	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
 
 	UWorld* world = GetWorld();

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -26,7 +26,7 @@ UCBTService_UpdateEngageContext::UCBTService_UpdateEngageContext()
 void UCBTService_UpdateEngageContext::TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds)
 {
 	CSV_SCOPED_TIMING_STAT_GLOBAL(PortfolioAI_BT_UpdateEngageContext);
-	FAIBehaviorTreeProfiling::RecordUpdateEngageContextTickForProfiling();
+	FAIBehaviorTreeProfiling::RecordUpdateEngageContextTick();
 	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
 
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -29,8 +29,8 @@ void UCBTService_UpdateEngageContext::TickNode(UBehaviorTreeComponent& OwnerComp
 	FAIBehaviorTreeProfiling::RecordUpdateEngageContextTickForProfiling();
 	Super::TickNode(OwnerComp, NodeMemory, DeltaSeconds);
 
-	UBlackboardComponent* blackBoardComp = OwnerComp.GetBlackboardComponent();
-	if (!IsValid(blackBoardComp))
+	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
+	if (!IsValid(blackboardComp))
 	{
 		FAICombatBTDebug::RecordEngageContextRejectedForAudit(nullptr, FEngageContext(), TEXT("Tick"), TEXT("MissingBlackboard"));
 		return;
@@ -41,29 +41,29 @@ void UCBTService_UpdateEngageContext::TickNode(UBehaviorTreeComponent& OwnerComp
 	if (!IsValid(ownerPawn))
 	{
 		FAICombatBTDebug::RecordEngageContextRejectedForAudit(ownerPawn, FEngageContext(), TEXT("Tick"), TEXT("MissingOwnerPawn"));
-		ClearEngageContext(blackBoardComp);
+		ClearEngageContext(blackboardComp);
 		return;
 	}
 
 	FEngageContext engageContext;
 
-	const EContextBuildResult buildResult = BuildEngageContext(ownerPawn, blackBoardComp, engageContext);
+	const EContextBuildResult buildResult = BuildEngageContext(ownerPawn, blackboardComp, engageContext);
 
 	if (buildResult != EContextBuildResult::Success)
 	{
-		ClearEngageContext(blackBoardComp);
+		ClearEngageContext(blackboardComp);
 		return;
 	}
 
-	const EContextBuildResult computeResult = ComputeEngageContext(ownerPawn, blackBoardComp, engageContext);
+	const EContextBuildResult computeResult = ComputeEngageContext(ownerPawn, blackboardComp, engageContext);
 
 	if (computeResult != EContextBuildResult::Success)
 	{
-		ClearEngageContext(blackBoardComp);
+		ClearEngageContext(blackboardComp);
 		return;
 	}
 
-	UpdateEngageContext(blackBoardComp, engageContext);
+	UpdateEngageContext(blackboardComp, engageContext);
 }
 
 void UCBTService_UpdateEngageContext::ScheduleNextTick(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
@@ -119,7 +119,7 @@ EContextBuildResult UCBTService_UpdateEngageContext::ComputeEngageContext(APawn*
 	FVector ownerLocation = InOwnerPawn->GetActorLocation();
 	FVector targetLocation = InOutEngageContext.TargetActor->GetActorLocation();
 
-	float dist_target = FVector::Dist(ownerLocation, targetLocation);
+	float distanceToTarget = FVector::Dist(ownerLocation, targetLocation);
 
 	float engageOuterRange = InOutEngageContext.EngageOffsetRange + InOutEngageContext.EngageEnterBuffer;
 	float engageInnerRange = FMath::Max(0.f, InOutEngageContext.EngageOffsetRange - InOutEngageContext.EngageExitBuffer);
@@ -128,11 +128,11 @@ EContextBuildResult UCBTService_UpdateEngageContext::ComputeEngageContext(APawn*
 
 	if (bInEngageRange)
 	{
-		if (dist_target > engageOuterRange) bInEngageRange = false;
+		if (distanceToTarget > engageOuterRange) bInEngageRange = false;
 	}
 	else
 	{
-		if (dist_target <= engageInnerRange) bInEngageRange = true;
+		if (distanceToTarget <= engageInnerRange) bInEngageRange = true;
 	}
 
 	float currentTime = InOwnerPawn->GetWorld()->GetTimeSeconds();
@@ -143,7 +143,7 @@ EContextBuildResult UCBTService_UpdateEngageContext::ComputeEngageContext(APawn*
 
 	InOutEngageContext.EngageOuterRange = engageOuterRange;
 	InOutEngageContext.EngageInnerRange = engageInnerRange;
-	InOutEngageContext.DistanceToTarget = dist_target;
+	InOutEngageContext.DistanceToTarget = distanceToTarget;
 
 	// Result
 	InOutEngageContext.bInEngageRange = bInEngageRange;

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.h
@@ -18,10 +18,10 @@ protected:
 	virtual void ScheduleNextTick(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
 
 private:
-	EContextBuildResult BuildEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext & OutEngageContext);
+	EContextBuildResult BuildEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext& OutEngageContext);
 
 private:
-	EContextBuildResult ComputeEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext & InOutEngageContext);
+	EContextBuildResult ComputeEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext& InOutEngageContext);
 
 private:
 	void UpdateEngageContext(UBlackboardComponent* InBlackboardComp, FEngageContext& InEngageContext);

--- a/Source/Portfolio/AI/Blackboard/CAIKey.h
+++ b/Source/Portfolio/AI/Blackboard/CAIKey.h
@@ -4,7 +4,7 @@
 #include "AI/Blackboard/CAIKeyFactory.h"
 #include "Type/CHealthStructure.h"
 #include "Type/CStateStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 namespace CAIKey
 {

--- a/Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.h
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Type/CStateStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 class UBlackboardComponent;
 

--- a/Source/Portfolio/Character/CAnimInstance.cpp
+++ b/Source/Portfolio/Character/CAnimInstance.cpp
@@ -118,12 +118,12 @@ float UCAnimInstance::GetReducedAnimationRefreshIntervalForProfiling() const
 
 bool UCAnimInstance::ShouldRefreshAnimationParameters(float DeltaSeconds)
 {
-	RecordAnimationRefreshAttemptForProfiling();
+	RecordAnimationRefreshAttempt();
 
 	if (!ShouldReduceEnemyAnimationRefreshForProfiling())
 	{
 		RuntimeLODAnimationRefreshElapsed = 0.f;
-		RecordAnimationRefreshExecutedForProfiling();
+		RecordAnimationRefreshExecuted();
 		return true;
 	}
 
@@ -132,12 +132,12 @@ bool UCAnimInstance::ShouldRefreshAnimationParameters(float DeltaSeconds)
 	const float refreshInterval = GetReducedAnimationRefreshIntervalForProfiling();
 	if (RuntimeLODAnimationRefreshElapsed < refreshInterval)
 	{
-		RecordAnimationRefreshSkippedForProfiling();
+		RecordAnimationRefreshSkipped();
 		return false;
 	}
 
 	RuntimeLODAnimationRefreshElapsed = 0.f;
-	RecordAnimationRefreshExecutedForProfiling();
+	RecordAnimationRefreshExecuted();
 	return true;
 }
 
@@ -148,25 +148,25 @@ bool UCAnimInstance::ShouldAuditAnimationRefreshForProfiling() const
 	return IsEnemyAnimationProfilingTarget() && FAIAnimationProfiling::ShouldAuditAnimationRefresh();
 }
 
-void UCAnimInstance::RecordAnimationRefreshAttemptForProfiling() const
+void UCAnimInstance::RecordAnimationRefreshAttempt() const
 {
 	if (!ShouldAuditAnimationRefreshForProfiling()) return;
 
-	FAIAnimationProfiling::RecordAnimationRefreshAttemptForProfiling();
+	FAIAnimationProfiling::RecordAnimationRefreshAttempt();
 }
 
-void UCAnimInstance::RecordAnimationRefreshExecutedForProfiling() const
+void UCAnimInstance::RecordAnimationRefreshExecuted() const
 {
 	if (!ShouldAuditAnimationRefreshForProfiling()) return;
 
-	FAIAnimationProfiling::RecordAnimationRefreshExecutedForProfiling();
+	FAIAnimationProfiling::RecordAnimationRefreshExecuted();
 }
 
-void UCAnimInstance::RecordAnimationRefreshSkippedForProfiling() const
+void UCAnimInstance::RecordAnimationRefreshSkipped() const
 {
 	if (!ShouldAuditAnimationRefreshForProfiling()) return;
 
-	FAIAnimationProfiling::RecordAnimationRefreshSkippedForProfiling();
+	FAIAnimationProfiling::RecordAnimationRefreshSkipped();
 }
 
 // Parameter Refresh

--- a/Source/Portfolio/Character/CAnimInstance.h
+++ b/Source/Portfolio/Character/CAnimInstance.h
@@ -82,9 +82,9 @@ private:
 	bool ShouldAuditAnimationRefreshForProfiling() const;
 
 	// Record
-	void RecordAnimationRefreshAttemptForProfiling() const;
-	void RecordAnimationRefreshExecutedForProfiling() const;
-	void RecordAnimationRefreshSkippedForProfiling() const;
+	void RecordAnimationRefreshAttempt() const;
+	void RecordAnimationRefreshExecuted() const;
+	void RecordAnimationRefreshSkipped() const;
 
 private:
 	// Parameter Refresh

--- a/Source/Portfolio/Character/Enemy/CEnemy.h
+++ b/Source/Portfolio/Character/Enemy/CEnemy.h
@@ -192,12 +192,12 @@ public:
 	FORCEINLINE UCActionFeedbackComponent* GetActionFeedbackComp() const { return ActionFeedbackComponent; }
 
 public:
-	FORCEINLINE bool GetbUsePatrol() const { return bUsePatrol; }
+	FORCEINLINE bool ShouldUsePatrol() const { return bUsePatrol; }
 	FORCEINLINE ACPatrolPath* GetPatrolPath() const { return PatrolPath; }
 	FORCEINLINE EPatrolMode GetPatrolMode() const { return PatrolMode; }
 
 public:
-	FORCEINLINE bool GetbUseInvestigate() const { return bUseInvestigate; }
+	FORCEINLINE bool ShouldUseInvestigate() const { return bUseInvestigate; }
 	FORCEINLINE float GetInvestigateDuration() const { return InvestigateDuration; }
 	FORCEINLINE int32 GetInvestigateMaxIndex() const { return InvestigateMaxIndex; }
 
@@ -207,7 +207,7 @@ public:
 	FORCEINLINE float GetChaseExitBuffer() const { return ChaseExitBuffer; }
 
 public:
-	FORCEINLINE bool GetbUseAlertStep() const { return bUseAlertStep; }
+	FORCEINLINE bool ShouldUseAlertStep() const { return bUseAlertStep; }
 	FORCEINLINE float GetStepSideDistance() const { return StepSideDistance; }
 	FORCEINLINE float GetStepForwardDistance() const { return StepForwardDistance; }
 

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -616,18 +616,18 @@ void UCActionComponent::BuildActionExecutorMap(bool bRebuildAll)
 	{
 		if (!actionData.IsValidMinimal()) continue;
 
-		UClass* executorkey = actionData.ActionExecutorKey.Get();
-		if (!IsValid(executorkey)) continue;
+		UClass* executorKey = actionData.ActionExecutorKey.Get();
+		if (!IsValid(executorKey)) continue;
 
 		// 1) Find existing cached Reaction
 		if (!bRebuildAll)
 		{
-			const UCAction* found = FindActionExecutor(executorkey);
+			const UCAction* found = FindActionExecutor(executorKey);
 			if (IsValid(found)) continue;
 		}
 
 		// 2) Add cached Reaction
-		UCAction* add = AddActionExecutor(executorkey);
+		UCAction* add = AddActionExecutor(executorKey);
 		if (!IsValid(add))
 		{
 			FActionComponentDebug::RecordActionExecutorMapBuildFailedForAudit(OwnerCharacter_Injected, actionData, TEXT("AddExecutorFailed"));

--- a/Source/Portfolio/Component/CHitFeedbackComponent.h
+++ b/Source/Portfolio/Component/CHitFeedbackComponent.h
@@ -4,7 +4,7 @@
 #include "Components/ActorComponent.h"
 #include "Type/CCharacterComponentReferenceStructure.h"
 #include "Type/CWeaponStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 #include "CHitFeedbackComponent.generated.h"
 
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )

--- a/Source/Portfolio/Component/CPlayerFeedbackComponent.h
+++ b/Source/Portfolio/Component/CPlayerFeedbackComponent.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 #include "CPlayerFeedbackComponent.generated.h"
 
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -503,18 +503,18 @@ void UCReactionComponent::BuildReactionExecutorMap(bool bRebuildAll)
 	{
 		if (!reactionData.IsValidMinimal()) continue;
 
-		UClass* executorkey = reactionData.ReactionExecutorKey.Get();
-		if (!IsValid(executorkey)) continue;
+		UClass* executorKey = reactionData.ReactionExecutorKey.Get();
+		if (!IsValid(executorKey)) continue;
 
 		// 1) Find existing cached Reaction
 		if (!bRebuildAll)
 		{
-			const UCReaction* found = FindReactionExecutor(executorkey);
+			const UCReaction* found = FindReactionExecutor(executorKey);
 			if (IsValid(found)) continue;
 		}
 
 		// 2) Add cached Reaction
-		UCReaction* add = AddReactionExecutor(executorkey);
+		UCReaction* add = AddReactionExecutor(executorKey);
 		if (!IsValid(add))
 		{
 			FReactionComponentDebug::RecordReactionExecutorMapBuildFailedForAudit(OwnerCharacter_Injected, reactionData, TEXT("AddFailed"));

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -230,12 +230,12 @@ void ACAIController::InitializeCustomBlackboardValues(UBlackboardComponent* InBl
 	if (!IsValid(enemy)) return;
 
 	// Patrol custom values
-	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::bUsePatrol, enemy->GetbUsePatrol(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::bUsePatrol, enemy->ShouldUsePatrol(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomObject(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolPath, enemy->GetPatrolPath(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomEnum(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolMode, static_cast<uint8>(enemy->GetPatrolMode()), ControlledPawn_Cached);
 
 	// Investigate custom values
-	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::bUseInvestigate, enemy->GetbUseInvestigate(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::bUseInvestigate, enemy->ShouldUseInvestigate(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateDuration, enemy->GetInvestigateDuration(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomInt(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateMaxIndex, enemy->GetInvestigateMaxIndex(), ControlledPawn_Cached);
 
@@ -245,7 +245,7 @@ void ACAIController::InitializeCustomBlackboardValues(UBlackboardComponent* InBl
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseExitBuffer, enemy->GetChaseExitBuffer(), ControlledPawn_Cached);
 
 	// Alert custom values
-	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::bUseAlertStep, enemy->GetbUseAlertStep(), ControlledPawn_Cached);
+	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::bUseAlertStep, enemy->ShouldUseAlertStep(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepForwardDistance, enemy->GetStepForwardDistance(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepSideDistance, enemy->GetStepSideDistance(), ControlledPawn_Cached);
 }

--- a/Source/Portfolio/Controller/CPlayerController.cpp
+++ b/Source/Portfolio/Controller/CPlayerController.cpp
@@ -55,14 +55,14 @@ void ACPlayerController::SetupInputComponent()
 	InputComponent->BindAction("Dodge", EInputEvent::IE_Pressed, this, &ACPlayerController::PressDodge);
 }
 
-void ACPlayerController::InputLookYaw(float inAxisValue)
+void ACPlayerController::InputLookYaw(float InAxisValue)
 {
-	AddYawInput(inAxisValue);
+	AddYawInput(InAxisValue);
 }
 
-void ACPlayerController::InputLookPitch(float inAxisValue)
+void ACPlayerController::InputLookPitch(float InAxisValue)
 {
-	AddPitchInput(inAxisValue);
+	AddPitchInput(InAxisValue);
 }
 
 void ACPlayerController::InputMoveForward(float InAxisValue)

--- a/Source/Portfolio/Core/Debug/FAICombatBTDebug.h
+++ b/Source/Portfolio/Core/Debug/FAICombatBTDebug.h
@@ -3,7 +3,7 @@
 #include "CoreMinimal.h"
 #include "Type/CAIStructure.h"
 #include "Type/CActionOrchestrationStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 class AAIController;
 class APawn;

--- a/Source/Portfolio/Core/Debug/FCombatEngageDebug.h
+++ b/Source/Portfolio/Core/Debug/FCombatEngageDebug.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 class AActor;
 class ACAIController;

--- a/Source/Portfolio/Core/Debug/FCombatFeedbackDebug.h
+++ b/Source/Portfolio/Core/Debug/FCombatFeedbackDebug.h
@@ -3,7 +3,7 @@
 #include "CoreMinimal.h"
 #include "Type/CReactionFeedbackStructure.h"
 #include "Type/CWeaponStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 class PORTFOLIO_API FCombatFeedbackDebug
 {

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
@@ -23,21 +23,21 @@ bool FAIAnimationProfiling::ShouldAuditAnimationRefresh()
 #endif
 }
 
-void FAIAnimationProfiling::RecordAnimationRefreshAttemptForProfiling()
+void FAIAnimationProfiling::RecordAnimationRefreshAttempt()
 {
 	if (!ShouldAuditAnimationRefresh()) return;
 
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Attempt, 1, ECsvCustomStatOp::Accumulate);
 }
 
-void FAIAnimationProfiling::RecordAnimationRefreshExecutedForProfiling()
+void FAIAnimationProfiling::RecordAnimationRefreshExecuted()
 {
 	if (!ShouldAuditAnimationRefresh()) return;
 
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_AnimRefresh_Executed, 1, ECsvCustomStatOp::Accumulate);
 }
 
-void FAIAnimationProfiling::RecordAnimationRefreshSkippedForProfiling()
+void FAIAnimationProfiling::RecordAnimationRefreshSkipped()
 {
 	if (!ShouldAuditAnimationRefresh()) return;
 

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h
@@ -9,7 +9,7 @@ public:
 	static bool ShouldAuditAnimationRefresh();
 
 	// Counter
-	static void RecordAnimationRefreshAttemptForProfiling();
-	static void RecordAnimationRefreshExecutedForProfiling();
-	static void RecordAnimationRefreshSkippedForProfiling();
+	static void RecordAnimationRefreshAttempt();
+	static void RecordAnimationRefreshExecuted();
+	static void RecordAnimationRefreshSkipped();
 };

--- a/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.cpp
@@ -3,28 +3,28 @@
 #include "AI/BehaviorTree/Service/CBTServiceIntervalHelper.h"
 #include "ProfilingDebugging/CsvProfiler.h"
 
-void FAIBehaviorTreeProfiling::RecordUpdateAIContextTickForProfiling()
+void FAIBehaviorTreeProfiling::RecordUpdateAIContextTick()
 {
 #if !UE_BUILD_SHIPPING
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateAIContext_Count, 1, ECsvCustomStatOp::Accumulate);
 #endif
 }
 
-void FAIBehaviorTreeProfiling::RecordUpdateAIIntentStateTickForProfiling()
+void FAIBehaviorTreeProfiling::RecordUpdateAIIntentStateTick()
 {
 #if !UE_BUILD_SHIPPING
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateAIIntentState_Count, 1, ECsvCustomStatOp::Accumulate);
 #endif
 }
 
-void FAIBehaviorTreeProfiling::RecordUpdateEngageContextTickForProfiling()
+void FAIBehaviorTreeProfiling::RecordUpdateEngageContextTick()
 {
 #if !UE_BUILD_SHIPPING
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateEngageContext_Count, 1, ECsvCustomStatOp::Accumulate);
 #endif
 }
 
-void FAIBehaviorTreeProfiling::RecordAIIntentIntervalPresetForProfiling(EBTServiceIntervalPreset InPreset)
+void FAIBehaviorTreeProfiling::RecordAIIntentIntervalPreset(EBTServiceIntervalPreset InPreset)
 {
 #if !UE_BUILD_SHIPPING
 	switch (InPreset)

--- a/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.h
@@ -8,10 +8,10 @@ class FAIBehaviorTreeProfiling
 {
 public:
 	// Service Tick Counter
-	static void RecordUpdateAIContextTickForProfiling();
-	static void RecordUpdateAIIntentStateTickForProfiling();
-	static void RecordUpdateEngageContextTickForProfiling();
+	static void RecordUpdateAIContextTick();
+	static void RecordUpdateAIIntentStateTick();
+	static void RecordUpdateEngageContextTick();
 
 	// Interval Preset Counter
-	static void RecordAIIntentIntervalPresetForProfiling(EBTServiceIntervalPreset InPreset);
+	static void RecordAIIntentIntervalPreset(EBTServiceIntervalPreset InPreset);
 };

--- a/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.cpp
@@ -23,7 +23,7 @@ bool FAIStateRuntimeLODProfiling::ShouldAuditStateRuntimeLOD()
 #endif
 }
 
-void FAIStateRuntimeLODProfiling::RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier)
+void FAIStateRuntimeLODProfiling::RecordResolvedTier(EAIRuntimeLODTier InTier)
 {
 	if (!ShouldAuditStateRuntimeLOD()) return;
 

--- a/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.h
+++ b/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.h
@@ -10,5 +10,5 @@ public:
 	static bool ShouldAuditStateRuntimeLOD();
 
 	// Counter
-	static void RecordResolvedTierForProfiling(EAIRuntimeLODTier InTier);
+	static void RecordResolvedTier(EAIRuntimeLODTier InTier);
 };

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -10,7 +10,7 @@
 #include "Core/Profiling/CCombatCollisionProfilingCounters.h"
 #include "Core/Profiling/CCombatFeedbackProfiling.h"
 
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 namespace
 {

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -95,7 +95,7 @@ FEngageAssignmentContext UCWorldSubsystem_CombatEngage::GetAssignment(const ACAI
 
 // Request
 
-void UCWorldSubsystem_CombatEngage::SubmitRequest(const FEngageRequestContext & InEngageRequestContext)
+void UCWorldSubsystem_CombatEngage::SubmitRequest(const FEngageRequestContext& InEngageRequestContext)
 {
 	if (!IsValid(InEngageRequestContext.RequestController)) return;
 

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
@@ -49,7 +49,7 @@ public:
 
 public:
 	// Request
-	void SubmitRequest(const FEngageRequestContext & InEngageRequestContext);
+	void SubmitRequest(const FEngageRequestContext& InEngageRequestContext);
 
 public:
 	// Assignment

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Subsystems/WorldSubsystem.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 #include "CWorldSubsystem_CombatEngage.generated.h"
 
 UCLASS()

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
@@ -3,7 +3,7 @@
 #include "GameFramework/Actor.h"
 
 #include "Core/Debug/FCombatFeedbackDebug.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 
 void UCWorldSubsystem_CombatFeedback::Initialize(FSubsystemCollectionBase& Collection)
 {

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Subsystems/WorldSubsystem.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 #include "CWorldSubsystem_CombatFeedback.generated.h"
 
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnCombatCameraShakeRequested, const FCameraShakeRequest& InCameraShakeRequest);

--- a/Source/Portfolio/Type/CAIStructure.h
+++ b/Source/Portfolio/Type/CAIStructure.h
@@ -3,7 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "Type/CHealthStructure.h"
-#include "Type/CWorldSubSystemStructure.h"
+#include "Type/CWorldSubsystemStructure.h"
 #include "CAIStructure.generated.h"
 
 UENUM(BlueprintType)

--- a/Source/Portfolio/Type/CWorldSubSystemStructure.cpp
+++ b/Source/Portfolio/Type/CWorldSubSystemStructure.cpp
@@ -1,1 +1,0 @@
-#include "Type/CWorldSubSystemStructure.h"

--- a/Source/Portfolio/Type/CWorldSubsystemStructure.cpp
+++ b/Source/Portfolio/Type/CWorldSubsystemStructure.cpp
@@ -1,0 +1,1 @@
+#include "Type/CWorldSubsystemStructure.h"

--- a/Source/Portfolio/Type/CWorldSubsystemStructure.h
+++ b/Source/Portfolio/Type/CWorldSubsystemStructure.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "CWorldSubSystemStructure.generated.h"
+#include "CWorldSubsystemStructure.generated.h"
 
 UENUM(BlueprintType)
 enum class ECombatRole : uint8


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P45: Naming / Typo / API Cleanup**

## 날짜

**2026.07.23**

## 상태

- [x] 네이밍 규칙 문서 분리
- [x] local naming / typo 불일치 정리
- [x] bool query public API를 `Should...` 기준으로 정리
- [x] profiling helper counter API suffix 정리
- [x] `CWorldSubsystemStructure` 파일명 / include 표기 정리
- [x] 네이밍 잔여 패턴 재확인
- [x] `PortfolioEditor Win64 Development` build 통과
- [x] PIE 확인

## 브랜치

- `refactor/naming-typo-api-cleanup`

## 요약

이번 PR은 W05 code quality cleanup의 네이밍 / 오타 / API 표기 정리 범위를 처리한다.

주석 / CVar / debug helper처럼 별도 정책이 필요한 구조 변경은 이전 PR에서 분리했고, 이번 PR에서는 기능 동작을 바꾸지 않는 이름 정합성에 집중했다.

정리 기준은 다음 문서로 고정했다.

```text
Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Typo_API_Cleanup_Work_Plan.md
```

## 주요 변경

### 1. 네이밍 규칙 문서화

다음 기준을 W05 문서로 분리했다.

```text
Public type / API
-> PascalCase

Input / output parameter
-> In / Out / InOut prefix

Reference style
-> FType& Value
-> const FType& Value

Local variable
-> lowerCamelCase

bool variable
-> bPascalCase

bool query function
-> Is / Has / Can / Should

DI / runtime cache suffix
-> _Injected / _Cached 유지
```

`Comp` / `Component` 전면 통일과 책임명이 애매한 public API rename은 구조 판단이 필요하므로 후속 범위로 남겼다.

### 2. local naming / typo 정리

단발 오타와 local-only naming 흔들림을 정리했다.

```text
CPlayerController.cpp
-> inAxisValue -> InAxisValue

CActionComponent.cpp
-> executorkey -> executorKey

CReactionComponent.cpp
-> executorkey -> executorKey

CBTService_UpdateAIContext.cpp
-> dist_target -> distanceToTarget
-> dist_home -> distanceToHome

CBTService_UpdateEngageContext.cpp
-> blackBoardComp -> blackboardComp
-> dist_target -> distanceToTarget

CBTService_UpdateEngageContext.h
-> FEngageContext & -> FEngageContext&

CWorldSubsystem_CombatEngage.h / .cpp
-> FEngageRequestContext & -> FEngageRequestContext&
```

### 3. bool query public API 정리

`Getb...` 형태의 bool getter를 query API 기준에 맞췄다.

```text
CEnemy.h
-> GetbUsePatrol() -> ShouldUsePatrol()
-> GetbUseInvestigate() -> ShouldUseInvestigate()
-> GetbUseAlertStep() -> ShouldUseAlertStep()

호출부
-> CAIController.cpp
```

### 4. profiling helper API suffix 정리

`Core/Profiling` helper class는 class 이름이 profiling 책임을 이미 드러내므로 `ForProfiling` suffix를 제거했다.

```text
CAIAnimationProfiling
-> RecordAnimationRefreshAttempt()
-> RecordAnimationRefreshExecuted()
-> RecordAnimationRefreshSkipped()

CAIBehaviorTreeProfiling
-> RecordUpdateAIContextTick()
-> RecordUpdateAIIntentStateTick()
-> RecordUpdateEngageContextTick()
-> RecordAIIntentIntervalPreset()

CAIStateRuntimeLODProfiling
-> RecordResolvedTier()
```

`UCAnimInstance`의 owner-side profiling wrapper도 같은 기준으로 suffix 없는 `Record...` 형태로 맞췄다.

### 5. World subsystem structure 표기 정리

파일명과 include 경로에 남아 있던 `SubSystem` 표기를 `Subsystem`으로 정리했다.

```text
Source/Portfolio/Type/CWorldSubSystemStructure.h
-> Source/Portfolio/Type/CWorldSubsystemStructure.h

Source/Portfolio/Type/CWorldSubSystemStructure.cpp
-> Source/Portfolio/Type/CWorldSubsystemStructure.cpp

#include "Type/CWorldSubSystemStructure.h"
-> #include "Type/CWorldSubsystemStructure.h"

#include "CWorldSubSystemStructure.generated.h"
-> #include "CWorldSubsystemStructure.generated.h"
```

내부 `USTRUCT` / `UENUM` 타입명은 변경하지 않았다.

## 변경 파일 범위

```text
Docs/01_Work_List/W05_Code_Quality_Plan/*
Docs/04_Pull_Request/P45_UE5_Portfolio_Pull_Request.md
Docs/04_Pull_Request/00_Pull_Request_Index.md

Source/Portfolio/AI/BehaviorTree/Service/*
Source/Portfolio/AI/Blackboard/*
Source/Portfolio/AI/RuntimeLOD/*
Source/Portfolio/Character/*
Source/Portfolio/Component/*
Source/Portfolio/Controller/*
Source/Portfolio/Core/Debug/*
Source/Portfolio/Core/Profiling/*
Source/Portfolio/System/Combat/*
Source/Portfolio/Type/*
```

## 검증

### Branch scan

```text
Branch:
refactor/naming-typo-api-cleanup

main 대비 변경:
36 files changed, 483 insertions(+), 92 deletions(-)
```

### Static check

다음 잔여 패턴을 확인했다.

```powershell
rg -n "inAxisValue|executorkey|dist_target|dist_home|blackBoardComp|FEngageContext &|FEngageRequestContext &" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
Result: 0

rg -n "GetbUse|Record[A-Za-z0-9]+ForProfiling|CWorldSubSystemStructure" ..\Source\Portfolio --glob "*.h" --glob "*.cpp"
Result: 0

git diff --check main...HEAD
Result: Pass
```

### Build

```text
PortfolioEditor Win64 Development
Result: Pass
```

### PIE

```text
PIE
Result: Pass
```

## 후속 작업

이번 PR에서 처리하지 않는 항목:

```text
Comp vs Component 전면 통일
-> public getter, injected/cache member, local variable까지 영향
-> Unreal engine / parent API collision 회피 이름도 같이 봐야 하므로 별도 브랜치에서 처리

책임명 자체가 애매한 public API rename
-> 실제 책임 재분류가 필요할 수 있음
-> 단순 네이밍 정리 범위에서 제외
```
