### PR TITLE
P49: API Const Consistency

### DIFF
--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
@@ -15,8 +15,9 @@
 - [x] 1차 후보 영역 분류
 - [x] 코드 전수 감사
 - [x] ReadOnly / Non-ReadOnly / 보류 후보 분류
-- [ ] ReadOnly API const 적용
-- [ ] build / PIE 검증
+- [x] ReadOnly API const 적용 1차
+- [x] build 검증
+- [ ] PIE 검증
 
 ---
 
@@ -91,6 +92,26 @@
 
 다음 항목은 현재 구현 기준으로 내부 상태를 바꾸지 않는 조회 / 조립 성격이므로 다음 const 적용 pass의 1차 후보로 둔다.
 
+적용 상태:
+
+```text
+완료:
+-> UCWeaponComponent::GetCurrentWeaponType
+-> UCWeaponComponent::GetWeaponActor
+-> UCCombatSignalTargetComponent::CanReceiveCombatSignal
+-> UCBTService_UpdateAIContext::ComputeHomeMetricContext
+-> UCBTService_UpdateAIContext::ComputeAlertRangeContext
+-> UCBTService_UpdateAIContext::ComputeReactionContext
+-> UCBTService_UpdateAIContext::ComputeDeadContext
+-> ACAIController::SelectTopPriority
+
+검증:
+-> PortfolioEditor Win64 Development build 통과
+
+남은 검증:
+-> PIE smoke
+```
+
 ### Component
 
 ```text
@@ -101,6 +122,7 @@ Source/Portfolio/Component/CWeaponComponent.h / .cpp
 판정:
 -> CurrentWeaponType 또는 WeaponActor 유효성 확인 후 값을 반환한다.
 -> member field 변경이 없으므로 ReadOnly const 후보로 둔다.
+-> 1차 적용 완료.
 ```
 
 ### CombatSignal
@@ -112,6 +134,7 @@ Source/Portfolio/Component/CCombatSignalTargetComponent.h / .cpp
 판정:
 -> target context를 판정 / 채우지만 component owner 상태는 바꾸지 않는다.
 -> DefenseComp_Injected->CanParry()가 const query로 유지되는지 함께 확인한 뒤 적용한다.
+-> 1차 적용 완료.
 ```
 
 ### AI / BehaviorTree service
@@ -126,6 +149,7 @@ Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h / .cpp
 판정:
 -> service member 상태를 바꾸지 않고, 입력 pawn / blackboard / component에서 값을 읽어 context를 채운다.
 -> debug / audit 기록이 없는 함수부터 1차 후보로 둔다.
+-> 1차 적용 완료.
 ```
 
 ### AI / Controller
@@ -138,6 +162,7 @@ Source/Portfolio/Controller/CAIController.h / .cpp
 -> TargetPerceptionStateMap을 조회해 top state를 Out parameter에 채운다.
 -> 단독 함수 기준 member mutation은 없으므로 ReadOnly const 후보로 둔다.
 -> 적용 시 loop variable을 const reference로 정리하고, BuildPerceptionContext와 분리해서 검증한다.
+-> 1차 적용 완료.
 ```
 
 ### 이미 const 정합성이 높은 영역

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
@@ -17,7 +17,7 @@
 - [x] ReadOnly / Non-ReadOnly / 보류 후보 분류
 - [x] ReadOnly API const 적용 1차
 - [x] build 검증
-- [ ] PIE 검증
+- [x] PIE 검증
 
 ---
 
@@ -108,8 +108,8 @@
 검증:
 -> PortfolioEditor Win64 Development build 통과
 
-남은 검증:
--> PIE smoke
+추가 검증:
+-> PIE smoke 정상 작동 확인
 ```
 
 ### Component

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
@@ -299,6 +299,117 @@ Source/Portfolio/Core/Profiling/*
 -> ShouldAudit / Get CVar 계열은 유지하고, Record / Print / Report 계열은 const 후보에서 제외한다.
 ```
 
+### 3.4 1차 적용 후 잔여 재스캔
+
+```text
+재스캔 기준:
+-> Get / Is / Has / Can / Should / Find / Resolve / Build / Make / Calculate / Compute 계열 header 선언
+
+결과:
+-> 명확한 member ReadOnly API const 후보는 1차 적용 완료.
+-> 남은 member 함수는 상태 변경, audit / profiling 기록, cache mutation, lazy 생성, Blueprint / override signature, 또는 현재 비-const로 남긴 pointer graph 보류 항목이다.
+-> static policy / helper 함수는 member const 대상이 아니므로 이번 pass에서 제외한다.
+-> CMovementComponent::CalculateSpeed / CalculateDirection은 movement runtime state 계산 / 갱신 흐름으로 보아 ReadOnly API가 아니다.
+
+다음 조건 전까지 추가 const 적용은 보류:
+-> audit 기록 함수를 ReadOnly 예외로 허용할지 정책 변경
+-> 현재 비-const FCharacterComponentReferences builder의 pointer graph 계약 변경
+-> Blueprint / override signature를 별도 pass에서 검증하기로 결정
+```
+
+### 3.5 local const / Others 전수 검토
+
+`const` 사용 현황을 다음 기준으로 재분류했다.
+
+```text
+ReadOnly API
+-> 함수 뒤 const: Foo(...) const
+
+ReadOnly Param
+-> parameter 내부 const: const FType& / const UObject* / const TCHAR*
+
+Others
+-> 위 둘이 아닌 const: local const, static / namespace const, pointer const form 등
+```
+
+전체 현황:
+
+```text
+ReadOnly API   : 731
+ReadOnly Param : 1073
+Others         : 415
+const 포함 라인 : 1902
+```
+
+`Others` 세부 분류:
+
+```text
+132  Local const struct/value snapshot
+77   Local const bool gate
+52   Local const scalar
+47   Static/namespace constant
+42   Local const enum
+32   Local pointer-to-const UObject/Actor
+18   Local const UE value
+6    Pointer const form
+4    Container of pointer-to-const
+2    Local const template value
+2    Static local container cache
+1    Unclassified
+```
+
+검토 결론:
+
+```text
+허용 / 권장:
+-> Static / namespace constant
+-> Static local lookup table
+-> 의미 있는 struct / value snapshot
+-> UE value snapshot
+-> Container of pointer-to-const
+-> const TCHAR* reason / literal
+
+선별 허용:
+-> local bool gate
+-> local enum
+-> local scalar
+-> snapshot / 판단 기준 / 이전 상태 / 복잡한 조건식 이름 부여일 때만 유지
+
+지양:
+-> 모든 local bool / int / enum에 기계적으로 const 붙이기
+-> UObject / AActor pointer-to-const 대량 적용
+-> AActor* const 같은 포인터 자체 const 남용
+```
+
+현재 프로젝트 판정:
+
+```text
+-> local const는 전면 제거 대상이 아니다.
+-> 기존 Others 대부분은 snapshot / branch gate / static key / debug reason / lookup table 성격이라 유지 가능하다.
+-> local bool / scalar / enum 중 의미 없는 단순 임시값만 선별 정리한다.
+-> UObject / AActor pointer-to-const는 새로 대량 적용하지 않는다.
+```
+
+선별 cleanup 결과:
+
+```text
+정리 완료:
+-> 단순 bool result 임시값: bStarted / bReserved / bRequested / bApplied
+-> Notify trigger 비교용 단순 active type / index 임시값
+-> Investigate index 증가용 단순 int32 임시값
+
+유지:
+-> previous state / threshold / cooldown / latency / match tier
+-> guard phase / reaction type / execution state snapshot
+-> 복잡한 조건식에 이름을 붙인 branch gate
+-> static / namespace constant
+-> UObject / AActor pointer-to-const 기존 사용
+
+판정:
+-> local const 정책 검증용 선별 정리만 수행했다.
+-> 의미가 있는 snapshot / gate까지 기계적으로 제거하지 않는다.
+```
+
 ---
 
 ## 4. 보류 / 제외 후보

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
@@ -1,0 +1,286 @@
+# W05 API Const Consistency Work Plan
+
+## 제목
+
+**W05: ReadOnly API const 정합성 작업 계획**
+
+## 날짜
+
+**2026.07.24**
+
+## 상태
+
+- [x] ReadOnly API const 사용 규칙 정리
+- [x] 적용 대상 / 제외 대상 기준 정리
+- [x] 1차 후보 영역 분류
+- [ ] 코드 전수 감사
+- [ ] ReadOnly API const 적용
+- [ ] build / PIE 검증
+
+---
+
+## 1. 목적
+
+이 문서는 `refactor/api-const-consistency` 작업에서 처리할 실제 후보와 보류 기준을 기록한다.
+
+규칙 본문은 `W05_Naming_Rules.md`의 `ReadOnly API const 사용` 섹션을 따른다. 이 문서는 현재 프로젝트 코드 기준의 후보 목록과 적용 순서를 관리한다.
+
+목표는 모든 함수에 기계적으로 `const`를 붙이는 것이 아니다. 외부에서 내부 상태를 조회하는 ReadOnly API에만 `const`를 붙여, 호출자가 해당 API를 상태 변경 없는 조회로 믿을 수 있게 만드는 것이다.
+
+---
+
+## 2. 적용 원칙
+
+### 2.1 1차 적용 범위
+
+```text
+대상:
+-> public / protected / private member API 중 조회 / 판정 / 계산 성격이 명확한 함수
+-> Get / Is / Has / Can / Should / Find / Resolve / Build / Calculate / Compute 계열
+-> owner 상태를 바꾸지 않는 Out / InOut result 채움 함수
+
+제외:
+-> local variable const cleanup
+-> parameter const 전면 정리
+-> return type const 전면 정리
+-> UFUNCTION / Blueprint 노출 API signature
+-> delegate signature
+-> engine override signature
+-> UPROPERTY / serialized USTRUCT field
+```
+
+### 2.2 ReadOnly 탈락 조건
+
+다음 중 하나라도 있으면 1차 const 적용 대상에서 제외한다.
+
+```text
+-> member field 변경
+-> member TArray / TMap add / remove / update
+-> _Cached 값 갱신
+-> Blackboard Set / Clear
+-> owned component / actor / subsystem 상태 변경
+-> delegate broadcast / bind / unbind
+-> timer start / stop
+-> montage play / stop
+-> collision / movement 변경
+-> gameplay request 전송
+-> debug / audit / profiling 기록
+-> lazy initialization
+-> component lookup 결과 cache
+-> const_cast 필요
+```
+
+---
+
+## 3. 1차 감사 후보
+
+### Component
+
+```text
+Source/Portfolio/Component/CActionComponent.h / .cpp
+-> ResolveActionData
+-> ResolveActionExecutor
+-> Find / Get / Can / Has 계열 조회 API
+
+Source/Portfolio/Component/CReactionComponent.h / .cpp
+-> ResolveReactionData
+-> ResolveReactionExecutor
+-> Find / Get / Can / Has 계열 조회 API
+
+Source/Portfolio/Component/CActionOrchestratorComponent.h / .cpp
+-> BuildDecisionQuery
+-> BuildDecisionResult
+-> BuildActionExecutionResult
+-> Can / Should / Resolve 계열 중 상태 변경 없는 함수
+
+Source/Portfolio/Component/CReactionOrchestratorComponent.h / .cpp
+-> BuildDecisionQuery
+-> BuildDecisionResult
+-> BuildReactionExecutionResult
+-> Can / Should / Resolve 계열 중 상태 변경 없는 함수
+```
+
+### Action / Reaction
+
+```text
+Source/Portfolio/Action/CAction.h / .cpp
+-> Is / Has / Can 계열 조회 API
+-> BuildFeedbackRequest
+-> ResolveExecutionDecision 계열 override는 base signature 기준 확인 후 처리
+
+Source/Portfolio/Reaction/CReaction.h / .cpp
+-> Is / Has / Can 계열 조회 API
+-> BuildFeedbackRequest
+-> ResolveExecutionDecision 계열 override는 base signature 기준 확인 후 처리
+```
+
+### CombatSignal
+
+```text
+Source/Portfolio/Component/CCombatSignalSourceComponent.h / .cpp
+-> Validate / Build / Resolve / IsDuplicateHit / IsFriendlyTarget 계열
+-> Request / Send / Cache / Commit 계열은 제외
+
+Source/Portfolio/Component/CCombatSignalTargetComponent.h / .cpp
+-> Validate / Build / CanReceiveCombatSignal / Compute 계열
+-> Handle / Commit / Dispatch / Request 계열은 제외
+```
+
+### AI / Controller
+
+```text
+Source/Portfolio/Controller/CAIController.h / .cpp
+-> Get / Has / Build / Select 계열 조회 API
+-> Blackboard write, perception state map update, audit record 함수는 제외
+
+Source/Portfolio/AI/RuntimeLOD/*
+-> policy / resolver의 read-only query 함수 우선 확인
+
+Source/Portfolio/AI/Blackboard/*
+-> key registry / value helper 중 write helper와 read helper 분리 확인
+```
+
+### Weapon / Character
+
+```text
+Source/Portfolio/Component/CWeaponComponent.h / .cpp
+-> GetCurrentWeaponType
+-> GetWeaponActor
+-> BuildWeaponContext
+
+Source/Portfolio/Weapon/CWeaponActor.h / .cpp
+-> GetLastOverlapContext
+-> GetLastWeaponContext
+-> GetLastActionDataKey
+-> BuildHitContext / BuildOverlapContext 계열
+
+Source/Portfolio/Character/Player/CPlayer.h / .cpp
+Source/Portfolio/Character/Enemy/CEnemy.h / .cpp
+-> Get component accessor 계열
+-> Handle / TakeDamage / delegate callback 계열은 제외
+```
+
+### Core Debug / Profiling
+
+```text
+Source/Portfolio/Core/Debug/*
+Source/Portfolio/Core/Profiling/*
+-> ShouldAudit / ShouldPrint / Get CVar 계열만 후보
+-> Record / Print / Report 계열은 audit / debug / profiling 기록이므로 제외
+```
+
+---
+
+## 4. 보류 / 제외 후보
+
+### UHT / Blueprint / delegate / override
+
+```text
+UFUNCTION
+BlueprintCallable
+BlueprintPure
+BlueprintNativeEvent
+BlueprintImplementableEvent
+DECLARE_DYNAMIC...
+engine override
+AnimNotify / BehaviorTree override
+TakeDamage override
+```
+
+판정:
+-> signature 변경 위험이 있으므로 1차 const pass에서 제외한다.
+-> 필요한 경우 별도 검증 pass에서 Blueprint compile / Editor load / PIE smoke와 함께 처리한다.
+
+### 상태 변경 이름 계열
+
+```text
+Set...
+Update...
+Reset...
+Clear...
+Initialize...
+Inject...
+Recover...
+Cache...
+Refresh...
+Record...
+Report...
+Request...
+Submit...
+Handle...
+Apply...
+Execute...
+Start...
+Stop...
+Tick...
+Commit...
+Dispatch...
+Broadcast...
+```
+
+판정:
+-> 기본적으로 ReadOnly API가 아니므로 const 후보에서 제외한다.
+-> 이름과 실제 역할이 충돌하면 const 적용이 아니라 이름 / 책임 재검토 후보로 분류한다.
+
+### local const cleanup
+
+```text
+Type* const local
+const float localValue
+const FActionRequestResult result
+for (const FType& item : Items)
+```
+
+판정:
+-> 유효한 code hygiene 후보지만 이번 ReadOnly API const pass와 분리한다.
+-> 필요하면 `refactor/local-const-cleanup` 별도 pass에서 처리한다.
+
+---
+
+## 5. 감사 명령
+
+### ReadOnly 후보 선언 조회
+
+```powershell
+rg -n "\b(Get|Is|Has|Can|Should|Find|Resolve|Build|Make|Calculate|Compute)[A-Z]\w*\s*\([^;{]*\)\s*;" Source/Portfolio --glob "*.h"
+```
+
+### 이미 const가 붙은 후보 기준선 확인
+
+```powershell
+rg -n "\b(Get|Is|Has|Can|Should|Find|Resolve|Build|Calculate|Compute)[A-Z]\w*\s*\([^;{]*\)\s*const" Source/Portfolio --glob "*.h" --glob "*.cpp"
+```
+
+### const 제외 후보 조회
+
+```powershell
+rg -n "\b(Set|Update|Reset|Clear|Initialize|Inject|Recover|Cache|Refresh|Record|Report|Request|Submit|Handle|Apply|Execute|Start|Stop|Tick|Commit|Dispatch|Broadcast)\w*\s*\(" Source/Portfolio --glob "*.h" --glob "*.cpp"
+```
+
+### 위험 신호 조회
+
+```powershell
+rg -n "\bmutable\b|const_cast<" Source/Portfolio --glob "*.h" --glob "*.cpp"
+```
+
+---
+
+## 6. 검증 기준
+
+```text
+1. 후보 함수 선언 / 정의 const 일치 확인
+2. const 적용 함수 내부에서 member mutation 없음 확인
+3. const 적용 함수가 호출하는 하위 함수 const 호출 가능 여부 확인
+4. UFUNCTION / delegate / override signature 변경 없음 확인
+5. git diff --check
+6. PortfolioEditor Win64 Development build
+7. PIE smoke
+```
+
+Blueprint-facing API 또는 UHT signature를 건드린 경우에는 다음을 추가한다.
+
+```text
+Editor load
+Blueprint compile
+PIE log에서 Error / Fatal / Ensure / Blueprint compile 실패 여부 확인
+```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
@@ -13,7 +13,8 @@
 - [x] ReadOnly API const 사용 규칙 정리
 - [x] 적용 대상 / 제외 대상 기준 정리
 - [x] 1차 후보 영역 분류
-- [ ] 코드 전수 감사
+- [x] 코드 전수 감사
+- [x] ReadOnly / Non-ReadOnly / 보류 후보 분류
 - [ ] ReadOnly API const 적용
 - [ ] build / PIE 검증
 
@@ -72,101 +73,205 @@
 
 ---
 
-## 3. 1차 감사 후보
+## 3. 전수 감사 결과
+
+감사 기준:
+
+```text
+검색 대상:
+-> Get / Is / Has / Can / Should / Find / Resolve / Build / Make / Calculate / Compute 계열 선언
+
+판정 기준:
+-> ReadOnly 후보: owner member 상태를 바꾸지 않고, 결과를 조회 / 계산 / 조립만 하는 API
+-> Non-ReadOnly: member mutation, cache cleanup, lazy creation, Blackboard write, subsystem request, audit 기록이 있는 API
+-> 보류: UFUNCTION / delegate / override / Blueprint 노출 signature 또는 하위 호출 const 정합성 확인이 필요한 API
+```
+
+### 3.1 ReadOnly const 적용 후보
+
+다음 항목은 현재 구현 기준으로 내부 상태를 바꾸지 않는 조회 / 조립 성격이므로 다음 const 적용 pass의 1차 후보로 둔다.
 
 ### Component
 
 ```text
-Source/Portfolio/Component/CActionComponent.h / .cpp
--> ResolveActionData
--> ResolveActionExecutor
--> Find / Get / Can / Has 계열 조회 API
+Source/Portfolio/Component/CWeaponComponent.h / .cpp
+-> GetCurrentWeaponType
+-> GetWeaponActor
 
-Source/Portfolio/Component/CReactionComponent.h / .cpp
--> ResolveReactionData
--> ResolveReactionExecutor
--> Find / Get / Can / Has 계열 조회 API
-
-Source/Portfolio/Component/CActionOrchestratorComponent.h / .cpp
--> BuildDecisionQuery
--> BuildDecisionResult
--> BuildActionExecutionResult
--> Can / Should / Resolve 계열 중 상태 변경 없는 함수
-
-Source/Portfolio/Component/CReactionOrchestratorComponent.h / .cpp
--> BuildDecisionQuery
--> BuildDecisionResult
--> BuildReactionExecutionResult
--> Can / Should / Resolve 계열 중 상태 변경 없는 함수
-```
-
-### Action / Reaction
-
-```text
-Source/Portfolio/Action/CAction.h / .cpp
--> Is / Has / Can 계열 조회 API
--> BuildFeedbackRequest
--> ResolveExecutionDecision 계열 override는 base signature 기준 확인 후 처리
-
-Source/Portfolio/Reaction/CReaction.h / .cpp
--> Is / Has / Can 계열 조회 API
--> BuildFeedbackRequest
--> ResolveExecutionDecision 계열 override는 base signature 기준 확인 후 처리
+판정:
+-> CurrentWeaponType 또는 WeaponActor 유효성 확인 후 값을 반환한다.
+-> member field 변경이 없으므로 ReadOnly const 후보로 둔다.
 ```
 
 ### CombatSignal
 
 ```text
-Source/Portfolio/Component/CCombatSignalSourceComponent.h / .cpp
--> Validate / Build / Resolve / IsDuplicateHit / IsFriendlyTarget 계열
--> Request / Send / Cache / Commit 계열은 제외
-
 Source/Portfolio/Component/CCombatSignalTargetComponent.h / .cpp
--> Validate / Build / CanReceiveCombatSignal / Compute 계열
--> Handle / Commit / Dispatch / Request 계열은 제외
+-> CanReceiveCombatSignal
+
+판정:
+-> target context를 판정 / 채우지만 component owner 상태는 바꾸지 않는다.
+-> DefenseComp_Injected->CanParry()가 const query로 유지되는지 함께 확인한 뒤 적용한다.
+```
+
+### AI / BehaviorTree service
+
+```text
+Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h / .cpp
+-> ComputeHomeMetricContext
+-> ComputeAlertRangeContext
+-> ComputeReactionContext
+-> ComputeDeadContext
+
+판정:
+-> service member 상태를 바꾸지 않고, 입력 pawn / blackboard / component에서 값을 읽어 context를 채운다.
+-> debug / audit 기록이 없는 함수부터 1차 후보로 둔다.
 ```
 
 ### AI / Controller
 
 ```text
 Source/Portfolio/Controller/CAIController.h / .cpp
--> Get / Has / Build / Select 계열 조회 API
--> Blackboard write, perception state map update, audit record 함수는 제외
+-> SelectTopPriority
 
-Source/Portfolio/AI/RuntimeLOD/*
--> policy / resolver의 read-only query 함수 우선 확인
-
-Source/Portfolio/AI/Blackboard/*
--> key registry / value helper 중 write helper와 read helper 분리 확인
+판정:
+-> TargetPerceptionStateMap을 조회해 top state를 Out parameter에 채운다.
+-> 단독 함수 기준 member mutation은 없으므로 ReadOnly const 후보로 둔다.
+-> 적용 시 loop variable을 const reference로 정리하고, BuildPerceptionContext와 분리해서 검증한다.
 ```
 
-### Weapon / Character
+### 이미 const 정합성이 높은 영역
 
 ```text
-Source/Portfolio/Component/CWeaponComponent.h / .cpp
--> GetCurrentWeaponType
--> GetWeaponActor
--> BuildWeaponContext
+Source/Portfolio/Component/CActionOrchestratorComponent.h / .cpp
+Source/Portfolio/Component/CReactionOrchestratorComponent.h / .cpp
+Source/Portfolio/Component/CCombatSignalSourceComponent.h / .cpp
+Source/Portfolio/Component/CCombatSignalTargetComponent.h / .cpp
+Source/Portfolio/Action/CAction.h / .cpp
+Source/Portfolio/Reaction/CReaction.h / .cpp
+Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h / .cpp
+Source/Portfolio/Type/*.h
 
-Source/Portfolio/Weapon/CWeaponActor.h / .cpp
--> GetLastOverlapContext
--> GetLastWeaponContext
--> GetLastActionDataKey
--> BuildHitContext / BuildOverlapContext 계열
+판정:
+-> Get / Is / Has / Can / Should / Resolve / Build 계열 상당수가 이미 const로 선언되어 있다.
+-> 다음 pass에서는 신규 const 적용보다 signature 일치 / 누락 여부 확인 위주로 본다.
+```
+
+### 3.2 Non-ReadOnly / const 적용 제외
+
+다음 항목은 이름상 ReadOnly처럼 보일 수 있으나 실제 구현에서 상태 변경이 있으므로 const 적용 대상에서 제외한다.
+
+```text
+Source/Portfolio/Component/CActionComponent.h / .cpp
+-> ResolveActionExecutor
+-> FindActionExecutor
+-> BuildActionRuntimeMaps
+-> BuildActionDataMap
+-> BuildActionExecutorMap
+-> AddActionExecutor
+
+판정:
+-> ResolveActionExecutor는 executor가 없으면 AddActionExecutor로 생성 / 캐시한다.
+-> FindActionExecutor는 invalid cached executor를 ActionExecutorMap에서 Remove한다.
+-> BuildAction* 계열은 ActionDataMap / ActionExecutorMap을 Reset / Add / update한다.
+
+Source/Portfolio/Component/CReactionComponent.h / .cpp
+-> ResolveReactionExecutor
+-> FindReactionExecutor
+-> BuildReactionRuntimeMaps
+-> BuildReactionDataMap
+-> BuildReactionExecutorMap
+-> AddReactionExecutor
+
+판정:
+-> ResolveReactionExecutor는 executor가 없으면 AddReactionExecutor로 생성 / 캐시한다.
+-> FindReactionExecutor는 invalid cached executor를 ReactionExecutorMap에서 Remove한다.
+-> BuildReaction* 계열은 ReactionDataMap / ReactionExecutorMap을 Reset / Add / update한다.
+
+Source/Portfolio/Controller/CAIController.h / .cpp
+-> BuildPerceptionContext
+-> UpdateTargetPerceptionStateMap
+-> RefreshRuntimeLODTierFromBlackboard
+
+판정:
+-> BuildPerceptionContext는 UpdateTargetPerceptionStateMap을 호출한다.
+-> UpdateTargetPerceptionStateMap은 TargetPerceptionStateMap 값을 갱신 / 제거하고 audit을 기록한다.
+-> RefreshRuntimeLODTierFromBlackboard는 CurrentRuntimeLODTier를 변경한다.
+
+Source/Portfolio/Character/CAnimInstance.h / .cpp
+-> ShouldRefreshAnimationParameters
+
+판정:
+-> RuntimeLODAnimationRefreshElapsed를 갱신하고 animation refresh audit을 기록한다.
+-> Should prefix지만 runtime state gate 함수이므로 const 대상이 아니다.
+
+Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h / .cpp
+-> BuildPerceptionContext
+-> ComputeEngageAssignmentContext
+
+판정:
+-> BuildPerceptionContext는 ACAIController::BuildPerceptionContext를 통해 perception state map 갱신과 audit 기록을 수행한다.
+-> ComputeEngageAssignmentContext는 CombatEngage subsystem에 SubmitRequest를 보내고 AIController audit을 기록한다.
+
+Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.h / .cpp
+-> BuildEngageContext
+-> ComputeEngageContext
+
+판정:
+-> BuildEngageContext는 실패 경로에서 FAICombatBTDebug audit 기록을 수행한다.
+-> ComputeEngageContext는 context 계산 외에 FAICombatBTDebug audit 기록을 수행한다.
+-> audit 기록을 ReadOnly 제외 조건으로 유지하는 한 const 적용 대상에서 제외한다.
+```
+
+### 3.3 보류 / 별도 검증 후보
+
+다음 항목은 의미상 조회 / 판정 API일 수 있으나, signature 리스크 또는 하위 호출 정합성 때문에 이번 후보표에서는 보류한다.
+
+```text
+UFUNCTION / Blueprint 노출 API
+DECLARE_DYNAMIC... delegate signature
+engine override
+AnimNotify / BehaviorTree override
+TakeDamage override
+
+판정:
+-> 1차 const 적용 pass에서 제외한다.
+-> 필요한 경우 Blueprint compile / Editor load / PIE smoke를 포함한 별도 pass에서 처리한다.
+
+Source/Portfolio/Component/CActionComponent.h / .cpp
+-> ResolveActionData
+
+Source/Portfolio/Component/CReactionComponent.h / .cpp
+-> ResolveReactionData
+
+판정:
+-> map 조회와 result 채움 자체는 ReadOnly 성격이다.
+-> 실패 / 성공 경로에서 debug audit 기록을 수행하므로, audit 기록을 ReadOnly 제외 조건으로 유지할지 먼저 결정한 뒤 적용한다.
+
+Source/Portfolio/Component/CActionComponent.h / .cpp
+-> BuildActionExecutorReferences
+
+Source/Portfolio/Component/CReactionComponent.h / .cpp
+-> BuildReactionExecutorReferences
 
 Source/Portfolio/Character/Player/CPlayer.h / .cpp
+-> BuildReferences
+
 Source/Portfolio/Character/Enemy/CEnemy.h / .cpp
--> Get component accessor 계열
--> Handle / TakeDamage / delegate callback 계열은 제외
-```
+-> BuildReferences
 
-### Core Debug / Profiling
+판정:
+-> 함수 본문은 component pointer graph를 조립하는 읽기성 함수다.
+-> 다만 OutReferences에 non-const owner / component pointer를 담는 계약이므로 const 적용 시 this pointer 변환과 참조 구조체 계약 전파를 별도로 검토한다.
 
-```text
+Source/Portfolio/AI/RuntimeLOD/*
+Source/Portfolio/AI/Blackboard/*
 Source/Portfolio/Core/Debug/*
 Source/Portfolio/Core/Profiling/*
--> ShouldAudit / ShouldPrint / Get CVar 계열만 후보
--> Record / Print / Report 계열은 audit / debug / profiling 기록이므로 제외
+
+판정:
+-> static policy / helper 함수가 많아 member const 적용 범위와 다르다.
+-> ShouldAudit / Get CVar 계열은 유지하고, Record / Print / Report 계열은 const 후보에서 제외한다.
 ```
 
 ---

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_API_Const_Consistency_Work_Plan.md
@@ -317,7 +317,31 @@ Source/Portfolio/Core/Profiling/*
 -> Blueprint / override signature를 별도 pass에서 검증하기로 결정
 ```
 
-### 3.5 local const / Others 전수 검토
+### 3.5 ReadOnly Param const 적용 1차 재스캔
+
+ReadOnly Param const 적용 1차는 다음 기준으로 재스캔했다.
+
+```text
+검색 기준:
+-> Component / Action / Reaction / Weapon / CombatSignal / AI / System / Core
+-> FString / FText / TArray / TMap / project FStruct by-value input
+-> UFUNCTION / delegate / override / Blueprint 노출 signature 제외
+-> FName / enum / scalar 값 전달은 이번 pass에서 const& 강제 대상에서 제외
+
+결과:
+-> 1차 범위에서 새로 const&로 바꿀 대형 by-value 입력 후보는 발견되지 않았다.
+-> TArray / TMap / FString / FText 계열 입력은 이미 const&이거나 Out / InOut 참조로 분류되어 있다.
+-> project FStruct 입력은 대부분 이미 const&이며, FDamageEvent는 UE TakeDamage 계열 signature와 CombatSignal damage forwarding 경로라 현 상태를 유지한다.
+-> FAIStimulus는 perception UFUNCTION callback signature이므로 제외한다.
+-> FName 입력은 작은 값 타입이고 현재 delegate / notify / trigger / collision key 경로에 넓게 사용되므로 이번 pass에서 변경하지 않는다.
+
+판정:
+-> 이번 pass는 코드 signature 변경 없이 감사 완료로 처리한다.
+-> ReadOnly Param 정책 위반으로 볼 명확한 내부/private helper 후보는 남기지 않았다.
+-> 다음 pass는 parameter const가 아니라 ReadOnly member function const 누락 / 보류 후보 재검증 중심으로 진행한다.
+```
+
+### 3.6 local const / Others 전수 검토
 
 `const` 사용 현황을 다음 기준으로 재분류했다.
 
@@ -408,6 +432,32 @@ const 포함 라인 : 1902
 판정:
 -> local const 정책 검증용 선별 정리만 수행했다.
 -> 의미가 있는 snapshot / gate까지 기계적으로 제거하지 않는다.
+```
+
+### 3.7 ReadOnly member function const 보류 후보 재검증
+
+ReadOnly member function const 잔여 후보를 다음 기준으로 재스캔했다.
+
+```text
+검색 기준:
+-> Get / Is / Has / Can / Should / Find / Resolve / Build / Make / Calculate / Compute 계열 header 선언
+-> const가 붙지 않은 member function 후보
+-> static function / free function / override / UFUNCTION / delegate signature 제외
+
+재스캔 결과:
+-> 명확한 신규 ReadOnly member function const 적용 후보는 발견되지 않았다.
+-> static policy / debug / profiling helper는 member const 적용 대상이 아니다.
+-> free function helper는 member const 적용 대상이 아니다.
+-> CAnimInstance::ShouldRefreshAnimationParameters는 RuntimeLODAnimationRefreshElapsed를 갱신하고 profiling / audit 조건에 걸리므로 Non-ReadOnly로 유지한다.
+-> UCActionComponent::ResolveActionData / UCReactionComponent::ResolveReactionData는 data map 조회 자체는 ReadOnly 성격이지만 실패 경로에서 audit 기록을 수행하므로 현재 정책에서는 보류한다.
+-> UCActionComponent::ResolveActionExecutor / UCReactionComponent::ResolveReactionExecutor는 executor lazy 생성 / cache mutation 경로가 있으므로 Non-ReadOnly로 유지한다.
+-> UCActionComponent::FindActionExecutor / UCReactionComponent::FindReactionExecutor는 invalid cached executor 제거 경로가 있으므로 Non-ReadOnly로 유지한다.
+-> UCActionComponent::BuildActionExecutorReferences / UCReactionComponent::BuildReactionExecutorReferences는 non-const FCharacterComponentReferences pointer graph를 조립하므로 현재 계약에서는 보류한다.
+-> ACPlayer::BuildReferences / ACEnemy::BuildReferences는 non-const owner / component pointer graph를 OutReferences에 채우므로 현재 계약에서는 보류한다.
+
+판정:
+-> 이번 pass는 코드 signature 변경 없이 감사 완료로 처리한다.
+-> 추가 const 적용은 audit 기록 정책 변경, FCharacterComponentReferences pointer graph 계약 변경, Blueprint / override signature 별도 검증 결정 전까지 보류한다.
 ```
 
 ---

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
@@ -172,3 +172,124 @@ Comp vs Component 전면 통일
 책임명 자체가 애매한 public API rename
 -> 실제 책임 재분류가 필요할 수 있음
 ```
+
+---
+
+## 10. ReadOnly API const 사용
+
+`const` member function은 외부에서 내부 상태를 조회하는 ReadOnly API에만 사용한다.
+
+ReadOnly API는 호출해도 다음 상태가 바뀌지 않는 함수다.
+
+```text
+- this 객체의 member field
+- _Cached / _Injected / runtime state
+- owned component / actor / subsystem 상태
+- Blackboard 값
+- delegate / timer / montage / collision / movement 상태
+- debug / audit / profiling counter
+- lazy cache / lookup repair 결과
+```
+
+즉 `const`는 단순히 C++ 문법상 붙일 수 있다는 표시가 아니라, 호출자가 이 API를 상태 변경 없는 조회로 믿어도 된다는 계약이다.
+
+다음 이름 계열은 우선 ReadOnly 후보로 본다.
+
+```text
+Get...
+Is...
+Has...
+Can...
+Should...
+Find...
+Resolve...
+Build...
+Make...
+Calculate...
+Compute...
+```
+
+단, 이름만으로 확정하지 않는다. 본문을 확인해서 내부 상태 변경이 없을 때만 `const`를 붙인다.
+
+```cpp
+bool IsActive() const;
+bool CanMove() const;
+EActionType GetActiveActionType() const;
+FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const;
+FActionFeedbackRequest BuildFeedbackRequest(EActionFeedbackTiming InTiming, FName InTriggerKey = NAME_None) const;
+```
+
+출력 매개변수를 채우는 함수도 owner 상태를 바꾸지 않는다면 `const` 대상이다.
+
+```cpp
+bool ResolveActionData(const FActionDataKey& InKey, FActionData& OutData) const;
+```
+
+`InOut` 매개변수를 수정하더라도 caller-owned 임시 계산값을 보정하는 함수이고 owner 상태를 바꾸지 않으면 `const`를 허용한다.
+
+```cpp
+float ComputeMitigatedDamage(FCombatSignalTargetContext& InOutContext) const;
+```
+
+다음 동작 중 하나라도 수행하면 ReadOnly API가 아니므로 `const`를 붙이지 않는다.
+
+```text
+- member field 대입
+- TArray / TMap member add / remove / update
+- _Cached 값 갱신
+- Blackboard Set / Clear
+- component / actor / subsystem 상태 변경
+- delegate broadcast / bind / unbind
+- timer start / stop
+- montage play / stop
+- collision / movement 변경
+- gameplay request 전송
+- debug / audit / profiling 기록
+- lazy initialization
+- component lookup 결과 cache
+- const_cast 사용 필요
+```
+
+이름 계열별 판단 기준은 다음과 같다.
+
+```text
+Get
+-> 읽고 반환하면 const
+-> cache init / repair / lazy load가 있으면 non-const
+
+Is / Has
+-> predicate only면 const
+-> 상태 갱신 후 판단하면 non-const
+
+Can / Should
+-> 정책 판단만 하면 const
+-> cooldown 소비, attempt 기록, audit counter 기록이면 non-const
+
+Build / Make / Calculate / Compute
+-> transient value 생성이면 const
+-> object 등록, spawn, cache 저장, 입력 object mutation이면 non-const
+
+Resolve / Find
+-> lookup / select / derive면 const
+-> reserve / consume / commit / find-or-add / repair면 non-const
+```
+
+Unreal / UHT 경계는 별도 주의한다.
+
+```text
+UFUNCTION / Blueprint 노출 API
+-> 일괄 변경하지 않는다. Blueprint pin / generated binding 영향 확인 후 별도 처리한다.
+
+delegate signature
+-> 일괄 변경하지 않는다. 바인딩 함수와 정확히 맞아야 한다.
+
+override
+-> 부모 signature 기준을 따른다. 임의로 const를 추가하지 않는다.
+
+UPROPERTY / serialized USTRUCT field
+-> const 정리 대상이 아니다.
+
+UObject pointer
+-> const AActor* 같은 pointer-to-const 대량 적용을 하지 않는다.
+-> ReadOnly API const 정리와 local pointer const 정리는 별도 pass로 분리한다.
+```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Naming_Rules.md
@@ -293,3 +293,69 @@ UObject pointer
 -> const AActor* 같은 pointer-to-const 대량 적용을 하지 않는다.
 -> ReadOnly API const 정리와 local pointer const 정리는 별도 pass로 분리한다.
 ```
+
+### 10.1 내부 local const 사용
+
+local variable의 `const`는 기본값으로 강제하지 않는다.
+
+프로젝트에서 `const`의 1차 용도는 다음 두 가지다.
+
+```text
+ReadOnly API
+-> owner 상태를 바꾸지 않는 member function 계약
+
+ReadOnly Param
+-> caller-owned 입력값을 수정하지 않는 parameter 계약
+```
+
+다만 함수 내부 local value에서도 값의 의미를 고정하는 경우에는 `const`를 허용한다. 이때 기준은 “값이 바뀌지 않으므로 const를 붙인다”가 아니라, “이 값은 이 시점의 snapshot / 판단 기준 / 내부 상수라서 이후 코드에서 바뀌면 오해나 버그가 된다”이다.
+
+허용 / 권장:
+
+```text
+파일 내부 상수
+-> namespace 내부 const FName / static constexpr / static const
+-> tag, key, collision profile name, magic number 대체값
+
+static local lookup table
+-> 함수 내부에서 한 번 구성되고 읽기 전용으로 쓰이는 static const TArray / TMap
+
+의미 있는 snapshot
+-> 이전 상태
+-> trace / overlap 시점의 위치, 회전, hit result
+-> 이후 로직의 기준점이 되는 context / payload / result 복사본
+
+문자열 literal reason
+-> const TCHAR* reason = TEXT("Cooldown");
+```
+
+선별 허용:
+
+```text
+local bool
+-> 복잡한 조건식에 이름을 붙이는 gate면 허용
+-> 단순 null check / 한 줄 임시값이면 생략 가능
+
+local enum / scalar
+-> 이전 상태, 시작 시점 값, 계산 기준이면 허용
+-> 단순 중간 계산값이면 생략 가능
+
+UE value type
+-> FVector / FRotator / FTransform / FName / FString 등은 snapshot 의미가 있으면 허용
+-> 계속 보정 / 누적 / 수정할 값이면 non-const
+```
+
+지양:
+
+```text
+모든 local bool / int / enum에 기계적으로 const 붙이기
+-> 코드가 시끄러워지고 의미 신호가 약해진다.
+
+UObject / AActor pointer-to-const 대량 적용
+-> Unreal API 호환성과 reflection 관례를 우선한다.
+-> 읽기 전용 계약은 우선 API const와 const parameter에서 표현한다.
+
+포인터 자체 const 남용
+-> AActor* const Target 같은 형태는 로컬 재대입만 막는다.
+-> 객체 불변성이 아니므로 일반 정책으로 강제하지 않는다.
+```

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_UE5_Portfolio_Work_List.md
@@ -373,11 +373,14 @@ refactor/api-const-consistency
 **코드 스캔에서 확인한 내용**
 
 - getter / query / resolver 계열 API 전수 점검이 필요하다.
+- 규칙은 `W05_Naming_Rules.md`의 `ReadOnly API const 사용` 섹션에 기록한다.
+- 실제 후보 / 보류 목록은 `W05_API_Const_Consistency_Work_Plan.md`에 기록한다.
 
 **완료 조건**
 
 - read-only API에 `const` 적용 기준을 맞춘다.
 - 내부 상태 변경이 필요한 함수는 이름 / 역할을 확인한다.
+- UFUNCTION / Blueprint / delegate / override signature 변경 여부를 분리 확인한다.
 - 빌드 성공.
 
 ---

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -6,6 +6,7 @@
 
 | ID | 제목 | 파일 | 브랜치 | GitHub PR | 관련 문서 |
 | --- | --- | --- | --- | --- | --- |
+| P49 | API Const Consistency | `P49_UE5_Portfolio_Pull_Request.md` | `refactor/api-const-consistency` |  | W05 |
 | P48 | CPP Include Order Cleanup | `P48_UE5_Portfolio_Pull_Request.md` | `refactor/include-order-cleanup` |  | W05 |
 | P47 | Type Rename and Feedback Key Cleanup | `P47_UE5_Portfolio_Pull_Request.md` | `refactor/type-rename-feedback-key-cleanup` |  | W05 |
 | P46 | Type Header Organization | `P46_UE5_Portfolio_Pull_Request.md` | `refactor/type-header-organization` |  | W05 |

--- a/Docs/04_Pull_Request/P49_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P49_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,350 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P49: API Const Consistency**
+
+## 날짜
+
+**2026.07.25**
+
+## 상태
+
+- [x] ReadOnly API const 사용 규칙 정리
+- [x] ReadOnly / Non-ReadOnly / 보류 후보 전수 감사
+- [x] 명확한 ReadOnly member API const 1차 적용
+- [x] ReadOnly Param const 1차 재스캔
+- [x] local const / Others 사용 정책 정리
+- [x] 의미 없는 local bool / scalar / enum const 선별 정리
+- [x] ReadOnly member function const 잔여 / 보류 후보 재검증
+- [x] `git diff --check` 통과
+- [x] `PortfolioEditor Win64 Development` build 통과
+- [x] PIE smoke 확인
+
+## 브랜치
+
+- `refactor/api-const-consistency`
+
+## 요약
+
+이번 PR은 `Source/Portfolio`의 C++ API에서 ReadOnly 성격이 명확한 함수와 읽기 전용 입력 파라미터의 `const` 사용 기준을 정리한다.
+
+목표는 모든 곳에 기계적으로 `const`를 붙이는 것이 아니라, 호출자가 "이 API는 owner 상태를 바꾸지 않는 조회 / 계산 / 조립 함수"라고 신뢰할 수 있는 범위에만 `const` 계약을 부여하는 것이다.
+
+작업은 세 단계로 나누었다.
+
+```text
+1. 규칙 정리
+-> ReadOnly API / ReadOnly Param / local const 사용 기준 문서화
+
+2. 코드 적용
+-> 명확한 ReadOnly member API에 const 적용
+-> 의미 없는 local const 임시값 정리
+
+3. 보류 후보 재검증
+-> ReadOnly Param / member function 잔여 후보를 다시 스캔
+-> 정책 변경이 필요한 항목은 코드 변경 없이 보류 사유 문서화
+```
+
+## 변경 배경
+
+ReadOnly 성격의 getter / query / compute API에 `const`가 일관되게 붙어 있지 않으면, 외부 리뷰에서 함수의 side effect 여부를 코드만 보고 판단하기 어렵다.
+
+반대로 `const`를 무리하게 넓히면 UE reflection, Blueprint 노출 signature, delegate, override, runtime cache, audit 기록, non-const UObject pointer graph 같은 영역에서 불필요한 리스크가 생긴다.
+
+이번 PR에서는 다음 원칙을 고정했다.
+
+```text
+ReadOnly API
+-> owner member 상태를 바꾸지 않는 조회 / 계산 / 조립 API에만 member const를 사용한다.
+
+ReadOnly Param
+-> TArray / TMap / FString / FText / 큰 project struct 입력이 읽기 전용이면 const&를 사용한다.
+
+local const
+-> 단순 임시값에는 남발하지 않는다.
+-> snapshot / decision basis / static key / literal reason처럼 스코프 안에서 의미가 고정되는 값에만 허용한다.
+```
+
+## 변경 범위
+
+### 1. ReadOnly API const 규칙 문서화
+
+왜
+
+`const` 적용 기준이 코드 관례로만 남아 있으면 이후 pass에서 UFUNCTION, override, delegate, audit 기록 함수까지 무리하게 확장될 수 있다.
+
+어떻게
+
+`W05_Naming_Rules.md`에 ReadOnly API, ReadOnly Param, local const 사용 기준을 기록했다.
+
+결과
+
+const 적용 범위와 제외 범위가 다음 기준으로 분리됐다.
+
+```text
+적용:
+-> 외부에서 내부 상태를 조회하는 ReadOnly API
+-> 읽기 전용 큰 입력 파라미터
+-> 의미가 고정되는 local snapshot / gate / static constant
+
+제외:
+-> UFUNCTION / Blueprint 노출 signature
+-> delegate signature
+-> override signature
+-> UPROPERTY / serialized USTRUCT field
+-> audit / debug / profiling 기록 함수
+-> lazy initialization / cache mutation 함수
+-> const_cast가 필요한 변경
+-> UObject pointer-to-const 대량 적용
+```
+
+### 2. ReadOnly member API const 적용
+
+왜
+
+일부 query / compute 계열 함수가 owner 상태를 바꾸지 않는데 member `const`가 빠져 있었다.
+
+어떻게
+
+명확한 ReadOnly 함수에만 선언 / 정의 `const`를 맞췄다.
+
+```text
+UCWeaponComponent
+-> GetCurrentWeaponType
+-> GetWeaponActor
+
+UCCombatSignalTargetComponent
+-> CanReceiveCombatSignal
+
+UCBTService_UpdateAIContext
+-> ComputeHomeMetricContext
+-> ComputeAlertRangeContext
+-> ComputeReactionContext
+-> ComputeDeadContext
+
+ACAIController
+-> SelectTopPriority
+```
+
+결과
+
+ReadOnly query / compute API의 호출 계약이 명확해졌고, 하위 호출 const 정합성도 함께 맞췄다.
+
+### 3. local const 정책 정리와 선별 cleanup
+
+왜
+
+local `const`가 단순 임시 bool / int / enum까지 퍼지면 "정말 의미가 고정되는 값"과 "그냥 한 번 쓰는 임시값"이 구분되지 않는다.
+
+어떻게
+
+프로젝트 전체 const 사용을 다음 기준으로 재분류했다.
+
+```text
+ReadOnly API
+ReadOnly Param
+Others
+```
+
+`Others` 중 단순 임시값만 선별 정리했다.
+
+```text
+정리:
+-> 단순 bool result 임시값: bStarted / bReserved / bRequested / bApplied
+-> Notify trigger 비교용 단순 active type / index 임시값
+-> Investigate index 증가용 단순 int32 임시값
+
+유지:
+-> previous state / threshold / cooldown / latency / match tier
+-> guard phase / reaction type / execution state snapshot
+-> 복잡한 조건식에 이름을 붙인 branch gate
+-> static / namespace constant
+-> UObject / AActor pointer-to-const 기존 사용
+```
+
+결과
+
+local `const`는 전면 제거 대상이 아니라, 의미 고정이 있는 값에만 남기는 기준으로 정리됐다.
+
+### 4. ReadOnly Param const 재스캔
+
+왜
+
+TArray / TMap / FString / FText / project struct 입력이 by-value로 남아 있는지 확인해야 했다.
+
+어떻게
+
+Component / Action / Reaction / Weapon / CombatSignal / AI / System / Core 범위를 재스캔했다.
+
+결과
+
+```text
+-> 새로 const&로 바꿀 대형 by-value 입력 후보 없음
+-> TArray / TMap / FString / FText 계열 입력은 이미 const&이거나 Out / InOut 참조
+-> FDamageEvent는 UE TakeDamage 계열 signature와 CombatSignal damage forwarding 경로라 유지
+-> FAIStimulus는 perception UFUNCTION callback signature라 제외
+-> FName은 작은 값 타입이고 넓은 notify / trigger / collision key 경로라 이번 pass에서 변경하지 않음
+```
+
+### 5. ReadOnly member function 보류 후보 재검증
+
+왜
+
+이름상 ReadOnly처럼 보이는 `Resolve*`, `Find*`, `Build*` 계열 중 일부는 실제로는 audit 기록, cache mutation, pointer graph 조립 책임이 있다.
+
+어떻게
+
+비-const로 남은 Get / Is / Has / Can / Should / Find / Resolve / Build / Make / Calculate / Compute 계열 header 선언을 재스캔했다.
+
+결과
+
+```text
+신규 명확한 ReadOnly member const 적용 후보:
+-> 없음
+
+보류:
+-> UCActionComponent::ResolveActionData
+-> UCReactionComponent::ResolveReactionData
+   사유: data map 조회 성격은 있지만 실패 경로 audit 기록 수행
+
+-> UCActionComponent::BuildActionExecutorReferences
+-> UCReactionComponent::BuildReactionExecutorReferences
+-> ACPlayer::BuildReferences
+-> ACEnemy::BuildReferences
+   사유: non-const FCharacterComponentReferences pointer graph 조립 계약
+
+Non-ReadOnly 유지:
+-> ResolveActionExecutor / ResolveReactionExecutor
+   사유: executor lazy 생성 / cache mutation
+
+-> FindActionExecutor / FindReactionExecutor
+   사유: invalid cached executor 제거
+
+-> CAnimInstance::ShouldRefreshAnimationParameters
+   사유: RuntimeLODAnimationRefreshElapsed 갱신 및 profiling / audit 조건
+```
+
+## 주요 처리 흐름
+
+```text
+ReadOnly API 후보 스캔
+-> ReadOnly / Non-ReadOnly / 보류 분류
+-> 명확한 ReadOnly member API const 적용
+-> build 검증
+-> local const 사용 현황 재분류
+-> 의미 없는 단순 local const 선별 정리
+-> ReadOnly Param const 재스캔
+-> ReadOnly member function 보류 후보 재검증
+-> 보류 정책 문서화
+```
+
+## 구현 결과
+
+```text
+main...HEAD
+-> 20 files changed, 804 insertions(+), 37 deletions(-)
+
+commit range
+-> 60d05407 docs(w05): define readonly api const rules
+-> 2cbe3877 docs(code-quality): audit readonly api const candidates
+-> 89bb0d78 refactor(api): const readonly component queries
+-> 5b1dfed6 refactor(api): const readonly ai context queries
+-> 98b681e7 docs(code-quality): record readonly api const pass
+-> e61c2c2c refactor(api): trim noisy local const temporaries
+-> 65364f9f docs(api): record readonly param const audit
+```
+
+변경함:
+
+```text
+-> ReadOnly API const 규칙 문서화
+-> API const 후보표 작성
+-> 명확한 ReadOnly member API const 적용
+-> local const 사용 정책 문서화
+-> 의미 없는 local const 임시값 선별 정리
+-> ReadOnly Param / member const 잔여 후보 재스캔 결과 문서화
+```
+
+변경하지 않음:
+
+```text
+-> UFUNCTION / Blueprint 노출 API signature
+-> delegate signature
+-> override signature
+-> UPROPERTY / serialized USTRUCT field
+-> audit 기록 함수를 ReadOnly 예외로 허용하는 정책 변경
+-> FCharacterComponentReferences non-const pointer graph 계약 변경
+-> UObject pointer-to-const 대량 적용
+-> const_cast 사용
+```
+
+## 테스트 방법
+
+```text
+1. Get / Is / Has / Can / Should / Find / Resolve / Build 계열 API 스캔
+2. ReadOnly Param by-value 후보 재스캔
+3. local const / Others 분류 재스캔
+4. git diff --check
+5. PortfolioEditor Win64 Development build
+6. PIE smoke 실행
+```
+
+## 검증 결과
+
+### Static check
+
+```text
+git diff --check
+Result: Pass
+```
+
+### Build
+
+```text
+PortfolioEditor Win64 Development
+Result: Pass
+```
+
+### Scans
+
+```text
+ReadOnly API candidate scan
+Result: Completed
+
+ReadOnly Param by-value scan
+Result: No new large by-value input candidate
+
+ReadOnly member function follow-up scan
+Result: No new clear const candidate
+
+local const / Others scan
+Result: Meaningless simple temporaries cleaned up selectively
+```
+
+### PIE
+
+```text
+PIE smoke
+Result: Pass
+```
+
+## 비고 / 후속 작업
+
+- audit 기록 함수를 ReadOnly 예외로 허용할지는 현재 정책상 보류한다.
+- `FCharacterComponentReferences` pointer graph 계약 변경은 const pass가 아니라 별도 설계 검토로 분리한다.
+- Blueprint / override signature 변경은 이번 PR에서 제외한다.
+- 다음 코드 품질 작업 후보는 tuning constants cleanup이다.
+
+## 관련 문서
+
+- Work List: `W05_UE5_Portfolio_Work_List.md`
+- Naming Rules: `W05_Naming_Rules.md`
+- API Const Work Plan: `W05_API_Const_Consistency_Work_Plan.md`
+- Previous PR: `P48_UE5_Portfolio_Pull_Request.md`
+
+## 정리
+
+이번 PR은 ReadOnly API / Param / local const 사용 기준을 정리하고, 명확한 ReadOnly API에만 `const` 계약을 적용했다.
+
+남은 후보는 단순 누락이 아니라 audit 기록, runtime cache mutation, pointer graph 계약, UE signature 안정성처럼 정책 결정이 필요한 항목이므로 이번 PR에서는 코드 변경 없이 보류 사유를 문서화했다.

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -152,7 +152,7 @@ EContextBuildResult UCBTService_UpdateAIContext::BuildPerceptionContext(APawn* I
 	return EContextBuildResult::Success;
 }
 
-EContextBuildResult UCBTService_UpdateAIContext::ComputeHomeMetricContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext)
+EContextBuildResult UCBTService_UpdateAIContext::ComputeHomeMetricContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 
@@ -167,7 +167,7 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeHomeMetricContext(APawn*
 	return EContextBuildResult::Success;
 }
 
-EContextBuildResult UCBTService_UpdateAIContext::ComputeAlertRangeContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext)
+EContextBuildResult UCBTService_UpdateAIContext::ComputeAlertRangeContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 	if (!IsValid(InOutAIContext.TargetActor)) return EContextBuildResult::NoData;
@@ -257,7 +257,7 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeEngageAssignmentContext(
 	return EContextBuildResult::Success;
 }
 
-EContextBuildResult UCBTService_UpdateAIContext::ComputeReactionContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext)
+EContextBuildResult UCBTService_UpdateAIContext::ComputeReactionContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 
@@ -269,7 +269,7 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeReactionContext(APawn* I
 	return EContextBuildResult::Success;
 }
 
-EContextBuildResult UCBTService_UpdateAIContext::ComputeDeadContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext)
+EContextBuildResult UCBTService_UpdateAIContext::ComputeDeadContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp)) return EContextBuildResult::Error;
 

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h
@@ -25,11 +25,11 @@ private:
 	EContextBuildResult BuildPerceptionContext(class APawn* InOwnerPawn, FAIBlackboardUpdateContext& OutAIContext);
 
 private:
-	EContextBuildResult ComputeHomeMetricContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext);
-	EContextBuildResult ComputeAlertRangeContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext);
+	EContextBuildResult ComputeHomeMetricContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const;
+	EContextBuildResult ComputeAlertRangeContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const;
 	EContextBuildResult ComputeEngageAssignmentContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext);
-	EContextBuildResult ComputeReactionContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext);
-	EContextBuildResult ComputeDeadContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext);
+	EContextBuildResult ComputeReactionContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const;
+	EContextBuildResult ComputeDeadContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const;
 
 private:
 	void UpdatePerceptionContext(class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InAIContext);

--- a/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_AdvanceInvestigateIndex.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Task/CBTTask_AdvanceInvestigateIndex.cpp
@@ -16,9 +16,9 @@ EBTNodeResult::Type UCBTTask_AdvanceInvestigateIndex::ExecuteTask(UBehaviorTreeC
 	UBlackboardComponent* blackboardComp = OwnerComp.GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return EBTNodeResult::Failed;
 
-	const int32 maxIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateMaxIndex.KeyName);
-	const int32 currentIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName);
-	const int32 nextIndex = currentIndex + 1;
+	int32 maxIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateMaxIndex.KeyName);
+	int32 currentIndex = blackboardComp->GetValueAsInt(CAIKey::Investigate::InvestigateIndex.KeyName);
+	int32 nextIndex = currentIndex + 1;
 
 	if (nextIndex > maxIndex)
 	{

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -383,7 +383,7 @@ bool ACEnemy::TryRequestParryStaggerReaction(const FCombatResultPacket& InCombat
 	request.ReactionType = EReactionType::Stagger;
 
 	const FReactionRequestResult result = ReactionOrchestratorComponent->RequestCombatResultReaction(request);
-	const bool bStarted = result.IsAccepted();
+	bool bStarted = result.IsAccepted();
 
 	FCombatResultDebug::RecordParryStaggerReactionRequestedForAudit(this, InCombatResultPacket, result);
 

--- a/Source/Portfolio/Character/Player/CPlayer.cpp
+++ b/Source/Portfolio/Character/Player/CPlayer.cpp
@@ -275,7 +275,7 @@ bool ACPlayer::TryRequestParryStaggerReaction(const FCombatResultPacket& InComba
 	request.ReactionType = EReactionType::Stagger;
 
 	const FReactionRequestResult result = ReactionOrchestratorComponent->RequestCombatResultReaction(request);
-	const bool bStarted = result.IsAccepted();
+	bool bStarted = result.IsAccepted();
 
 	FCombatResultDebug::RecordParryStaggerReactionRequestedForAudit(this, InCombatResultPacket, result);
 

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -267,7 +267,7 @@ bool UCActionComponent::ApplyActionDecision(const FActionExecutionResult& InResu
 			return false;
 		}
 
-		const bool bStarted = StartAction(InResult.ResolvedContext);
+		bool bStarted = StartAction(InResult.ResolvedContext);
 		if (bStarted)
 		{
 			FActionComponentDebug::RecordActionDecisionAppliedForAudit(OwnerCharacter_Injected, InResult, TEXT("Start"));
@@ -277,7 +277,7 @@ bool UCActionComponent::ApplyActionDecision(const FActionExecutionResult& InResu
 
 	case EExecutionApplyMode::Reserve:
 	{
-		const bool bReserved = ReserveAction(InResult.ResolvedContext);
+		bool bReserved = ReserveAction(InResult.ResolvedContext);
 		if (bReserved)
 		{
 			FActionComponentDebug::RecordActionDecisionAppliedForAudit(OwnerCharacter_Injected, InResult, TEXT("Reserve"));
@@ -299,7 +299,7 @@ bool UCActionComponent::ApplyActionDecision(const FActionExecutionResult& InResu
 			return false;
 		}
 
-		const bool bStarted = StartAction(InResult.ResolvedContext);
+		bool bStarted = StartAction(InResult.ResolvedContext);
 		if (bStarted)
 		{
 			FActionComponentDebug::RecordActionDecisionAppliedForAudit(OwnerCharacter_Injected, InResult, TEXT("Intervene"));
@@ -525,7 +525,7 @@ bool UCActionComponent::HandleActionCombatSignalCue(FName InCueTag)
 		return false;
 	}
 
-	const bool bRequested = CombatSignalSourceComp_Injected->RequestAICombatSignalCue(resolution.CueTag);
+	bool bRequested = CombatSignalSourceComp_Injected->RequestAICombatSignalCue(resolution.CueTag);
 	FActionComponentDebug::RecordActionCombatSignalCueForAudit(OwnerCharacter_Injected, activeExecutor, resolution.CueTag, bRequested ? TEXT("Accepted") : TEXT("Rejected"), bRequested ? nullptr : TEXT("SourceRejectedCue"));
 	return bRequested;
 }
@@ -773,7 +773,7 @@ bool UCActionComponent::ReserveAction(const FActionExecutionContext& InContext)
 
 	const FActionData& incomingData = InContext.ActionData;
 
-	const bool bReserved = activeExecutor->ReserveChain(incomingData);
+	bool bReserved = activeExecutor->ReserveChain(incomingData);
 	if (!bReserved)
 	{
 		FActionComponentDebug::RecordActionRuntimeRejectedForAudit(OwnerCharacter_Injected, InContext, TEXT("ReserveAction"), TEXT("ExecutorReserveFailed"));

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -301,7 +301,7 @@ bool UCCombatSignalTargetComponent::ValidateContext(FCombatSignalTargetContext& 
 	return true;
 }
 
-bool UCCombatSignalTargetComponent::CanReceiveCombatSignal(FCombatSignalTargetContext& InOutCombatSignalTargetContext)
+bool UCCombatSignalTargetComponent::CanReceiveCombatSignal(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const
 {
 	// Gate 1: already dead
 	if (InOutCombatSignalTargetContext.DeadState_Before != EDeadState::Alive)

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.h
@@ -61,7 +61,7 @@ private:
 private:
 	// Evaluate
 	bool ValidateContext(FCombatSignalTargetContext& InOutCombatSignalTargetContext);
-	bool CanReceiveCombatSignal(FCombatSignalTargetContext& InOutCombatSignalTargetContext);
+	bool CanReceiveCombatSignal(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const;
 	void ComputeTargetDamage(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const;
 	float ComputeMitigatedDamage(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const;
 	float ComputeFinalTakenDamage(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const;

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -238,7 +238,7 @@ bool UCReactionComponent::ApplyReactionDecision(const FReactionExecutionResult& 
 			return false;
 		}
 
-		const bool bStarted = StartReaction(InResult.ResolvedContext);
+		bool bStarted = StartReaction(InResult.ResolvedContext);
 		if (bStarted)
 		{
 			FReactionComponentDebug::RecordReactionDecisionAppliedForAudit(OwnerCharacter_Injected, InResult, TEXT("Start"));
@@ -271,7 +271,7 @@ bool UCReactionComponent::ApplyReactionDecision(const FReactionExecutionResult& 
 			return false;
 		}
 
-		const bool bStarted = StartReaction(InResult.ResolvedContext);
+		bool bStarted = StartReaction(InResult.ResolvedContext);
 		if (bStarted)
 		{
 			FReactionComponentDebug::RecordReactionDecisionAppliedForAudit(OwnerCharacter_Injected, InResult, TEXT("Intervene"));
@@ -621,7 +621,7 @@ bool UCReactionComponent::ApplyExecutionInterventionDirective(const FExecutionIn
 	{
 	case EExecutionDomain::Action:
 	{
-		const bool bApplied = IsValid(ActionComp_Injected) && ActionComp_Injected->RequestInterruptActiveAction(InDirective);
+		bool bApplied = IsValid(ActionComp_Injected) && ActionComp_Injected->RequestInterruptActiveAction(InDirective);
 		if (!bApplied)
 		{
 			FReactionComponentDebug::RecordReactionRuntimeRejectedForAudit(OwnerCharacter_Injected, FReactionExecutionContext(), TEXT("ApplyIntervention"), TEXT("ActionInterventionFailed"));

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -72,7 +72,7 @@ void UCWeaponComponent::UninitializeWeaponRuntime()
 	DestroyWeaponActor();
 }
 
-ACWeaponActor* UCWeaponComponent::GetWeaponActor()
+ACWeaponActor* UCWeaponComponent::GetWeaponActor() const
 {
 	return IsValid(WeaponActor) ? WeaponActor : nullptr;
 }

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -62,10 +62,10 @@ public:
 
 public:
 	// Query
-	FORCEINLINE EWeaponType GetCurrentWeaponType() { return CurrentWeaponType; }
+	FORCEINLINE EWeaponType GetCurrentWeaponType() const { return CurrentWeaponType; }
 
 public:
-	class ACWeaponActor* GetWeaponActor();
+	class ACWeaponActor* GetWeaponActor() const;
 
 public:
 	void AttachWeaponToHand();

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -388,11 +388,11 @@ void ACAIController::ClearTargetPerceptionStateMap()
 	TargetPerceptionStateMap.Reset();
 }
 
-EPerceptionBuildResult ACAIController::SelectTopPriority(FTargetPerceptionState& OutTargetPerceptionState)
+EPerceptionBuildResult ACAIController::SelectTopPriority(FTargetPerceptionState& OutTargetPerceptionState) const
 {
 	OutTargetPerceptionState = FTargetPerceptionState();
 
-	UBlackboardComponent* blackboardComp = GetBlackboardComponent();
+	const UBlackboardComponent* blackboardComp = GetBlackboardComponent();
 	if (!IsValid(blackboardComp)) return EPerceptionBuildResult::Error;
 
 	if (TargetPerceptionStateMap.IsEmpty()) return EPerceptionBuildResult::NoData;
@@ -400,10 +400,10 @@ EPerceptionBuildResult ACAIController::SelectTopPriority(FTargetPerceptionState&
 	int bestPriority = INT_MAX;
 	FTargetPerceptionState topState;
 
-	for (TPair<AActor*, FTargetPerceptionState>& pair : TargetPerceptionStateMap)
+	for (const TPair<AActor*, FTargetPerceptionState>& pair : TargetPerceptionStateMap)
 	{
 		AActor* actorKey = pair.Key;
-		FTargetPerceptionState& data = pair.Value;
+		const FTargetPerceptionState& data = pair.Value;
 
 		if (!IsValid(actorKey) || !data.IsValidData()) continue;
 

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -126,7 +126,7 @@ private:
 	// Target Data
 	void UpdateTargetPerceptionStateMap();
 	void ClearTargetPerceptionStateMap();
-	EPerceptionBuildResult SelectTopPriority(FTargetPerceptionState& OutTargetPerceptionState);
+	EPerceptionBuildResult SelectTopPriority(FTargetPerceptionState& OutTargetPerceptionState) const;
 
 private:
 	// Runtime LOD Snapshot

--- a/Source/Portfolio/Notify/CAnimNotifyState_ActionBase.cpp
+++ b/Source/Portfolio/Notify/CAnimNotifyState_ActionBase.cpp
@@ -22,8 +22,8 @@ bool UCAnimNotifyState_ActionBase::CanProcessActionNotify(const UCActionComponen
 		return false;
 	}
 
-	const EActionType actionType = InActionComp->GetActiveActionType();
-	const int32 actionIndex = InActionComp->GetActiveActionIndex();
+	EActionType actionType = InActionComp->GetActiveActionType();
+	int32 actionIndex = InActionComp->GetActiveActionIndex();
 
 	if (TriggerActionType != EActionType::All && actionType != TriggerActionType) return false;
 	if (TriggerActionIndex != INDEX_NONE && actionIndex != TriggerActionIndex) return false;

--- a/Source/Portfolio/Notify/CAnimNotifyState_ReactionBase.cpp
+++ b/Source/Portfolio/Notify/CAnimNotifyState_ReactionBase.cpp
@@ -22,7 +22,7 @@ bool UCAnimNotifyState_ReactionBase::CanProcessReactionNotify(const UCReactionCo
 		return false;
 	}
 
-	const EReactionType reactionType = InReactionComp->GetActiveReactionType();
+	EReactionType reactionType = InReactionComp->GetActiveReactionType();
 
 	if (TriggerReactionType != EReactionType::All && reactionType != TriggerReactionType) return false;
 

--- a/Source/Portfolio/Notify/CAnimNotify_ActionBase.cpp
+++ b/Source/Portfolio/Notify/CAnimNotify_ActionBase.cpp
@@ -22,8 +22,8 @@ bool UCAnimNotify_ActionBase::CanProcessActionNotify(const UCActionComponent* In
 		return false;
 	}
 
-	const EActionType actionType = InActionComp->GetActiveActionType();
-	const int32 actionIndex = InActionComp->GetActiveActionIndex();
+	EActionType actionType = InActionComp->GetActiveActionType();
+	int32 actionIndex = InActionComp->GetActiveActionIndex();
 
 	if (TriggerActionType != EActionType::All && actionType != TriggerActionType) return false;
 	if (TriggerActionIndex != INDEX_NONE && actionIndex != TriggerActionIndex) return false;

--- a/Source/Portfolio/Notify/CAnimNotify_ReactionBase.cpp
+++ b/Source/Portfolio/Notify/CAnimNotify_ReactionBase.cpp
@@ -22,7 +22,7 @@ bool UCAnimNotify_ReactionBase::CanProcessReactionNotify(const UCReactionCompone
 		return false;
 	}
 
-	const EReactionType reactionType = InReactionComp->GetActiveReactionType();
+	EReactionType reactionType = InReactionComp->GetActiveReactionType();
 
 	if (TriggerReactionType != EReactionType::All && reactionType != TriggerReactionType) return false;
 


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P49: API Const Consistency**

## 날짜

**2026.07.25**

## 상태

- [x] ReadOnly API const 사용 규칙 정리
- [x] ReadOnly / Non-ReadOnly / 보류 후보 전수 감사
- [x] 명확한 ReadOnly member API const 1차 적용
- [x] ReadOnly Param const 1차 재스캔
- [x] local const / Others 사용 정책 정리
- [x] 의미 없는 local bool / scalar / enum const 선별 정리
- [x] ReadOnly member function const 잔여 / 보류 후보 재검증
- [x] `git diff --check` 통과
- [x] `PortfolioEditor Win64 Development` build 통과
- [x] PIE smoke 확인

## 브랜치

- `refactor/api-const-consistency`

## 요약

이번 PR은 `Source/Portfolio`의 C++ API에서 ReadOnly 성격이 명확한 함수와 읽기 전용 입력 파라미터의 `const` 사용 기준을 정리한다.

목표는 모든 곳에 기계적으로 `const`를 붙이는 것이 아니라, 호출자가 "이 API는 owner 상태를 바꾸지 않는 조회 / 계산 / 조립 함수"라고 신뢰할 수 있는 범위에만 `const` 계약을 부여하는 것이다.

작업은 세 단계로 나누었다.

```text
1. 규칙 정리
-> ReadOnly API / ReadOnly Param / local const 사용 기준 문서화

2. 코드 적용
-> 명확한 ReadOnly member API에 const 적용
-> 의미 없는 local const 임시값 정리

3. 보류 후보 재검증
-> ReadOnly Param / member function 잔여 후보를 다시 스캔
-> 정책 변경이 필요한 항목은 코드 변경 없이 보류 사유 문서화
```

## 변경 배경

ReadOnly 성격의 getter / query / compute API에 `const`가 일관되게 붙어 있지 않으면, 외부 리뷰에서 함수의 side effect 여부를 코드만 보고 판단하기 어렵다.

반대로 `const`를 무리하게 넓히면 UE reflection, Blueprint 노출 signature, delegate, override, runtime cache, audit 기록, non-const UObject pointer graph 같은 영역에서 불필요한 리스크가 생긴다.

이번 PR에서는 다음 원칙을 고정했다.

```text
ReadOnly API
-> owner member 상태를 바꾸지 않는 조회 / 계산 / 조립 API에만 member const를 사용한다.

ReadOnly Param
-> TArray / TMap / FString / FText / 큰 project struct 입력이 읽기 전용이면 const&를 사용한다.

local const
-> 단순 임시값에는 남발하지 않는다.
-> snapshot / decision basis / static key / literal reason처럼 스코프 안에서 의미가 고정되는 값에만 허용한다.
```

## 변경 범위

### 1. ReadOnly API const 규칙 문서화

왜

`const` 적용 기준이 코드 관례로만 남아 있으면 이후 pass에서 UFUNCTION, override, delegate, audit 기록 함수까지 무리하게 확장될 수 있다.

어떻게

`W05_Naming_Rules.md`에 ReadOnly API, ReadOnly Param, local const 사용 기준을 기록했다.

결과

const 적용 범위와 제외 범위가 다음 기준으로 분리됐다.

```text
적용:
-> 외부에서 내부 상태를 조회하는 ReadOnly API
-> 읽기 전용 큰 입력 파라미터
-> 의미가 고정되는 local snapshot / gate / static constant

제외:
-> UFUNCTION / Blueprint 노출 signature
-> delegate signature
-> override signature
-> UPROPERTY / serialized USTRUCT field
-> audit / debug / profiling 기록 함수
-> lazy initialization / cache mutation 함수
-> const_cast가 필요한 변경
-> UObject pointer-to-const 대량 적용
```

### 2. ReadOnly member API const 적용

왜

일부 query / compute 계열 함수가 owner 상태를 바꾸지 않는데 member `const`가 빠져 있었다.

어떻게

명확한 ReadOnly 함수에만 선언 / 정의 `const`를 맞췄다.

```text
UCWeaponComponent
-> GetCurrentWeaponType
-> GetWeaponActor

UCCombatSignalTargetComponent
-> CanReceiveCombatSignal

UCBTService_UpdateAIContext
-> ComputeHomeMetricContext
-> ComputeAlertRangeContext
-> ComputeReactionContext
-> ComputeDeadContext

ACAIController
-> SelectTopPriority
```

결과

ReadOnly query / compute API의 호출 계약이 명확해졌고, 하위 호출 const 정합성도 함께 맞췄다.

### 3. local const 정책 정리와 선별 cleanup

왜

local `const`가 단순 임시 bool / int / enum까지 퍼지면 "정말 의미가 고정되는 값"과 "그냥 한 번 쓰는 임시값"이 구분되지 않는다.

어떻게

프로젝트 전체 const 사용을 다음 기준으로 재분류했다.

```text
ReadOnly API
ReadOnly Param
Others
```

`Others` 중 단순 임시값만 선별 정리했다.

```text
정리:
-> 단순 bool result 임시값: bStarted / bReserved / bRequested / bApplied
-> Notify trigger 비교용 단순 active type / index 임시값
-> Investigate index 증가용 단순 int32 임시값

유지:
-> previous state / threshold / cooldown / latency / match tier
-> guard phase / reaction type / execution state snapshot
-> 복잡한 조건식에 이름을 붙인 branch gate
-> static / namespace constant
-> UObject / AActor pointer-to-const 기존 사용
```

결과

local `const`는 전면 제거 대상이 아니라, 의미 고정이 있는 값에만 남기는 기준으로 정리됐다.

### 4. ReadOnly Param const 재스캔

왜

TArray / TMap / FString / FText / project struct 입력이 by-value로 남아 있는지 확인해야 했다.

어떻게

Component / Action / Reaction / Weapon / CombatSignal / AI / System / Core 범위를 재스캔했다.

결과

```text
-> 새로 const&로 바꿀 대형 by-value 입력 후보 없음
-> TArray / TMap / FString / FText 계열 입력은 이미 const&이거나 Out / InOut 참조
-> FDamageEvent는 UE TakeDamage 계열 signature와 CombatSignal damage forwarding 경로라 유지
-> FAIStimulus는 perception UFUNCTION callback signature라 제외
-> FName은 작은 값 타입이고 넓은 notify / trigger / collision key 경로라 이번 pass에서 변경하지 않음
```

### 5. ReadOnly member function 보류 후보 재검증

왜

이름상 ReadOnly처럼 보이는 `Resolve*`, `Find*`, `Build*` 계열 중 일부는 실제로는 audit 기록, cache mutation, pointer graph 조립 책임이 있다.

어떻게

비-const로 남은 Get / Is / Has / Can / Should / Find / Resolve / Build / Make / Calculate / Compute 계열 header 선언을 재스캔했다.

결과

```text
신규 명확한 ReadOnly member const 적용 후보:
-> 없음

보류:
-> UCActionComponent::ResolveActionData
-> UCReactionComponent::ResolveReactionData
   사유: data map 조회 성격은 있지만 실패 경로 audit 기록 수행

-> UCActionComponent::BuildActionExecutorReferences
-> UCReactionComponent::BuildReactionExecutorReferences
-> ACPlayer::BuildReferences
-> ACEnemy::BuildReferences
   사유: non-const FCharacterComponentReferences pointer graph 조립 계약

Non-ReadOnly 유지:
-> ResolveActionExecutor / ResolveReactionExecutor
   사유: executor lazy 생성 / cache mutation

-> FindActionExecutor / FindReactionExecutor
   사유: invalid cached executor 제거

-> CAnimInstance::ShouldRefreshAnimationParameters
   사유: RuntimeLODAnimationRefreshElapsed 갱신 및 profiling / audit 조건
```

## 주요 처리 흐름

```text
ReadOnly API 후보 스캔
-> ReadOnly / Non-ReadOnly / 보류 분류
-> 명확한 ReadOnly member API const 적용
-> build 검증
-> local const 사용 현황 재분류
-> 의미 없는 단순 local const 선별 정리
-> ReadOnly Param const 재스캔
-> ReadOnly member function 보류 후보 재검증
-> 보류 정책 문서화
```

## 구현 결과

```text
main...HEAD
-> 20 files changed, 804 insertions(+), 37 deletions(-)

commit range
-> 60d05407 docs(w05): define readonly api const rules
-> 2cbe3877 docs(code-quality): audit readonly api const candidates
-> 89bb0d78 refactor(api): const readonly component queries
-> 5b1dfed6 refactor(api): const readonly ai context queries
-> 98b681e7 docs(code-quality): record readonly api const pass
-> e61c2c2c refactor(api): trim noisy local const temporaries
-> 65364f9f docs(api): record readonly param const audit
```

변경함:

```text
-> ReadOnly API const 규칙 문서화
-> API const 후보표 작성
-> 명확한 ReadOnly member API const 적용
-> local const 사용 정책 문서화
-> 의미 없는 local const 임시값 선별 정리
-> ReadOnly Param / member const 잔여 후보 재스캔 결과 문서화
```

변경하지 않음:

```text
-> UFUNCTION / Blueprint 노출 API signature
-> delegate signature
-> override signature
-> UPROPERTY / serialized USTRUCT field
-> audit 기록 함수를 ReadOnly 예외로 허용하는 정책 변경
-> FCharacterComponentReferences non-const pointer graph 계약 변경
-> UObject pointer-to-const 대량 적용
-> const_cast 사용
```

## 테스트 방법

```text
1. Get / Is / Has / Can / Should / Find / Resolve / Build 계열 API 스캔
2. ReadOnly Param by-value 후보 재스캔
3. local const / Others 분류 재스캔
4. git diff --check
5. PortfolioEditor Win64 Development build
6. PIE smoke 실행
```

## 검증 결과

### Static check

```text
git diff --check
Result: Pass
```

### Build

```text
PortfolioEditor Win64 Development
Result: Pass
```

### Scans

```text
ReadOnly API candidate scan
Result: Completed

ReadOnly Param by-value scan
Result: No new large by-value input candidate

ReadOnly member function follow-up scan
Result: No new clear const candidate

local const / Others scan
Result: Meaningless simple temporaries cleaned up selectively
```

### PIE

```text
PIE smoke
Result: Pass
```

## 비고 / 후속 작업

- audit 기록 함수를 ReadOnly 예외로 허용할지는 현재 정책상 보류한다.
- `FCharacterComponentReferences` pointer graph 계약 변경은 const pass가 아니라 별도 설계 검토로 분리한다.
- Blueprint / override signature 변경은 이번 PR에서 제외한다.
- 다음 코드 품질 작업 후보는 tuning constants cleanup이다.

## 관련 문서

- Work List: `W05_UE5_Portfolio_Work_List.md`
- Naming Rules: `W05_Naming_Rules.md`
- API Const Work Plan: `W05_API_Const_Consistency_Work_Plan.md`
- Previous PR: `P48_UE5_Portfolio_Pull_Request.md`

## 정리

이번 PR은 ReadOnly API / Param / local const 사용 기준을 정리하고, 명확한 ReadOnly API에만 `const` 계약을 적용했다.

남은 후보는 단순 누락이 아니라 audit 기록, runtime cache mutation, pointer graph 계약, UE signature 안정성처럼 정책 결정이 필요한 항목이므로 이번 PR에서는 코드 변경 없이 보류 사유를 문서화했다.
