### PR TITLE
P50: Section Comment Consistency

### DIFF
--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -503,6 +503,19 @@ FObservableTargetRef targetRef;
 
 ## 13.1 Section Comment Follow-up Rules
 
+### Rule / Work Plan Boundary
+
+W05 문서는 코드 품질 정리의 정책 기준과 현재 프로젝트 적용 계획을 함께 기록한다.
+AI 작업 시스템에는 반복 적용해야 하는 실행 체크리스트만 반영하고, 프로젝트의 세부 후보 판단은 W05 Work Plan에 남긴다.
+
+```text
+역할 분리:
+-> W05 Work Plan: 현재 branch에서 적용할 정책, 후보, 완료 / 보류 판단을 기록한다.
+-> AI Workflow Prompt: 이후 작업 세션에서 반복 적용할 실행 체크리스트를 제공한다.
+-> .agents: 현재 repo에는 별도 agent rule 파일이 없으므로 이번 반영 대상에서 제외한다.
+-> .codex: 현재 repo에는 별도 Codex rule 파일이 없으므로 이번 반영 대상에서 제외한다.
+```
+
 ### Header / Source Section Synchronization
 
 `.h`가 API 책임 단위로 섹션을 나누면 `.cpp`도 같은 책임 그룹 기준으로 섹션을 둔다.

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -579,6 +579,332 @@ Type 헤더에서 타입 역할이 3개 이상으로 나뉘면 아래 taxonomy�
 pipeline 단계가 type taxonomy보다 더 명확한 파일은 `Request`, `Candidate`, `Payload`, `Resolution`, `Result`, `Packet`을 우선 사용한다.
 feedback / playback처럼 domain 의미가 필요한 경우 `Runtime Key / Playback Key`처럼 구체적인 섹션명을 허용한다.
 
+### File Family Section Policy
+
+섹션 주석은 모든 파일에 같은 모양으로 강제하지 않는다.
+같은 성격 / 책임 / 파일 패턴을 가진 파일군끼리 같은 섹션 체계를 우선 사용한다.
+파일 고유 책임은 고유 섹션으로 허용한다.
+
+```text
+공통 판단 기준:
+-> 같은 계열 파일은 같은 책임명 섹션을 우선 사용한다.
+-> 파일 고유 책임은 고유 섹션으로 허용한다.
+-> .h와 .cpp는 함수 1:1이 아니라 책임 그룹 기준으로 동기화한다.
+-> 로컬 흐름 설명은 섹션이 아니라 문장형 주석으로 작성한다.
+-> 짧고 단일 책임인 UE adapter / Interface / Type cpp는 섹션을 생략할 수 있다.
+-> 섹션은 같은 책임의 함수가 2개 이상 있거나, 파일 내 책임 그룹이 2개 이상일 때 우선 둔다.
+-> 단, 프로젝트 계열 일관성을 위해 단일 함수라도 명시 섹션을 둘 수 있다.
+```
+
+#### Action / Reaction Base
+
+```text
+대상:
+-> CAction.h / .cpp
+-> CReaction.h / .cpp
+
+권장 섹션:
+-> Component Reference
+-> Tick
+-> Query
+-> Decision
+-> Observable Overlay
+-> Notify
+-> Intervention
+-> State Transition
+-> Intervention Match Helper
+
+판단:
+-> base class는 파생 클래스가 따르는 공통 책임 기준점이다.
+-> Idle && No ActivePart, Default Action Case 같은 case 설명은 섹션이 아니라 문장형 로컬 설명으로 둔다.
+```
+
+#### Action / Reaction Derived
+
+```text
+대상:
+-> CAction_*
+-> CReaction_*
+
+권장 공통 섹션:
+-> Decision
+-> Lifecycle
+-> Notify
+-> Observable Overlay
+-> Intervention
+
+파일 고유 섹션 예:
+-> Chain Reservation
+-> Chain Window
+-> Weapon
+-> Guard State Cleanup
+
+판단:
+-> 파생 클래스는 base와 공통 책임명을 맞춘다.
+-> 파일 고유 로직은 고유 섹션으로 둔다.
+-> Case 1, Another Case, GuardState Case 같은 라벨은 섹션으로 쓰지 않고 조건 설명 문장으로 둔다.
+```
+
+#### Component
+
+```text
+대상:
+-> Component/*
+
+권장 공통 섹션:
+-> Component Reference
+-> Lifecycle
+-> Runtime Lifecycle
+-> Query
+-> Mutation
+-> Runtime State
+-> State Transition
+-> Request / Entry
+-> Receive
+-> Resolve
+-> Apply
+-> Packet
+-> Notify
+-> Helper
+
+도메인별 고유 섹션 예:
+-> Data Resolve
+-> Execution Entry
+-> Decision Apply
+-> Execution Operations
+-> Matching
+-> Runtime Key / Playback Key
+-> Playback
+-> Runtime LOD
+-> Movement Arbitration
+-> Movement Input
+-> Movement Policy
+-> Hit Window
+-> AI Entry
+-> Cue Helper
+
+판단:
+-> Component는 public / private API 책임이 섞이기 쉬우므로 섹션을 적극 적용한다.
+-> Check / Query는 Query로 통일한다.
+-> 단독 Mutation은 허용 가능하지만 더 구체적인 책임명이 있으면 구체명을 우선한다.
+```
+
+#### Controller
+
+```text
+대상:
+-> CAIController
+-> CPlayerController
+
+권장 공통 섹션:
+-> Lifecycle
+
+PlayerController 권장 섹션:
+-> Look Input
+-> Move Input
+-> Movement Dispatch
+-> Action Input
+
+AIController 권장 섹션:
+-> Team
+-> Config Setup
+-> Blackboard Setup
+-> Blackboard Runtime Value
+-> Behavior Tree Runtime
+-> Perception Event Callback
+-> Runtime LOD Snapshot
+-> Perception Candidate Audit
+-> Blackboard / Engage Latency Audit
+
+판단:
+-> Controller는 UE lifecycle + input / perception / blackboard 책임이 분명하면 섹션을 둔다.
+-> 짧은 controller라도 .h / .cpp가 같은 책임으로 나뉘면 같은 섹션명을 유지한다.
+-> 큰 controller는 공통명보다 실제 책임을 드러내는 구체 섹션명을 우선한다.
+```
+
+#### Behavior Tree Service / Task / Decorator
+
+```text
+BT Service 권장 섹션:
+-> Lifecycle
+-> Context Build
+-> Context Compute
+-> Blackboard Update
+-> Blackboard Clear
+-> Intent Decision
+-> Intent Transition
+-> Interval Defaults
+-> Interval Selection
+-> Profiling
+-> Public API
+
+BT Task / Decorator 판단:
+-> 대체로 짧은 UE node adapter이므로 섹션 생략을 기본 허용한다.
+-> ExecuteTask, CalculateRawConditionValue 같은 override 하나가 중심이면 함수 자체가 구조 역할을 한다.
+-> 파일이 커지고 책임이 나뉘면 Execution, Validation, Blackboard Update, Request, Result 정도의 최소 섹션만 둔다.
+```
+
+#### AI RuntimeLOD Policy
+
+```text
+대상:
+-> AI/RuntimeLOD/*Policy*
+
+권장 섹션:
+-> Policy Resolve
+-> Runtime LOD
+-> Query
+-> Helper
+
+판단:
+-> RuntimeLOD policy 파일은 resolver보다 짧고 단일 정책 판단에 집중하는 경우가 많다.
+-> 함수가 1~2개뿐이면 섹션 생략을 허용한다.
+-> policy가 여러 입력을 조합하거나 CVar / config / tier decision을 함께 다루면 Runtime LOD / Policy Resolve 섹션을 둔다.
+-> CAIRuntimeLODTierResolver처럼 context build와 tier resolve가 분리되면 Context Build / Tier Resolve / String Conversion처럼 책임을 더 구체화한다.
+```
+
+#### Character
+
+```text
+대상:
+-> Character/*
+-> Character/Player/*
+-> Character/Enemy/*
+
+권장 섹션:
+-> Lifecycle
+-> Component Reference
+-> Input
+-> Query
+-> Component Query
+-> AI Config Query
+-> Runtime LOD
+-> Tick
+-> Damage
+-> Combat Result
+-> Movement Intent
+-> Action Intent
+-> Runtime State
+-> Action Event Routing
+
+판단:
+-> Character 계열은 gameplay owner / actor 책임을 기준으로 섹션을 둔다.
+-> Player와 Enemy가 공유하는 책임은 같은 섹션명을 사용한다.
+-> Enemy처럼 AI config / Runtime LOD / intent routing이 추가되면 고유 섹션을 허용한다.
+-> CAnimInstance는 Character 하위지만 animation refresh / gate / record 고유 구조가 강하므로 파일 고유 섹션을 유지한다.
+```
+
+#### System
+
+```text
+대상:
+-> System/*
+-> System/Combat/*
+
+권장 섹션:
+-> Lifecycle
+-> Tick
+-> Query
+-> Request
+-> Assignment
+-> Assignment Build
+-> Assignment Warmup
+-> Assignment Apply
+-> Assignment Lease
+-> Runtime State
+-> HitStop
+-> Camera Shake
+
+판단:
+-> System / Subsystem 계열은 actor/component보다 runtime service 책임에 가깝다.
+-> Request / Assignment / Runtime State처럼 외부 요청과 내부 상태 처리를 분리한다.
+-> CombatFeedback처럼 feedback dispatch 책임이면 HitStop / Camera Shake 같은 도메인 섹션을 허용한다.
+```
+
+#### Weapon
+
+```text
+대상:
+-> Weapon/*
+
+권장 섹션:
+-> Component Reference
+-> Initial State
+-> Lifecycle
+-> Collision Component
+-> Trail
+-> Hit Context Provider Query
+-> Hit Context Provider Mutation
+-> Query
+-> Mutation
+-> Equip Notify Events
+-> Collision Notify Events
+-> Engine Delegate Events
+-> Helper
+
+판단:
+-> Weapon actor는 combat collision / notify / hit context provider 책임이 섞이므로 섹션을 둔다.
+-> WeaponComponent는 Component 계열 정책을 따르되 Weapon Actor / Runtime Lifecycle / Profiling 같은 고유 섹션을 허용한다.
+-> Equip / Unequip action의 Weapon 섹션은 Action derived의 파일 고유 섹션으로 허용한다.
+```
+
+#### Type
+
+```text
+Type 헤더:
+-> Type Header Section Taxonomy를 따른다.
+
+Type cpp:
+-> IsValidMinimal, hash/helper만 있는 짧은 cpp는 섹션 생략을 허용한다.
+-> 구현 함수가 늘거나 helper 성격이 섞이면 Helper API, Data / Config, Runtime State 등 헤더 taxonomy와 맞춘다.
+```
+
+#### Core Debug / Profiling
+
+```text
+Core / Debug 권장 섹션:
+-> Gate
+-> Diagnostic Hook
+-> Debug Dump
+-> 도메인 고유 Diagnostic Hook
+
+Core / Profiling 권장 섹션:
+-> Gate
+-> Counter
+-> Service Tick Counter
+-> Interval Preset Counter
+-> Flush
+
+판단:
+-> Debug / Profiling 파일은 gameplay component식 Lifecycle / Query / Mutation을 강제하지 않는다.
+-> 이미 Gate / Diagnostic Hook / Debug Dump 체계가 있으면 그 체계를 유지한다.
+-> 짧은 helper / type 파일은 섹션 생략을 허용한다.
+```
+
+#### Notify / Interface / Blackboard / Patrol / Module
+
+```text
+Notify:
+-> UE Notify adapter 성격이 강하면 섹션 생략을 기본 허용한다.
+-> 길어지면 Notify Entry, Validation, Command Dispatch, Payload Build 정도만 사용한다.
+
+Interface:
+-> UInterface 계약 자체가 구조이므로 API가 적으면 섹션 생략을 허용한다.
+-> 여러 계약 그룹이 생기면 Query, Request, Result, Event 정도로 최소화한다.
+
+AI / Blackboard:
+-> key namespace / registry / helper 구조 자체가 섹션 역할을 한다.
+-> helper가 커지면 Key Lookup, Value Apply, Value Clear 정도를 사용한다.
+
+AI / Patrol:
+-> actor / data 책임이 작으면 섹션 생략을 허용한다.
+-> 커지면 Lifecycle, Query, Patrol Point, Path Resolve, Debug 같은 도메인 섹션을 사용한다.
+
+Module / Global:
+-> Portfolio.cpp / .h, ProjectGlobal.h는 gameplay section policy 대상이 아니다.
+-> include grouping, module macro, global dependency 관리가 우선이다.
+```
+
 ### Step Comment Style
 
 단계형 주석은 fallback 순서, policy gate, priority matching처럼 순서 자체가 의미를 가질 때만 사용한다.
@@ -602,6 +928,388 @@ feedback / playback처럼 domain 의미가 필요한 경우 `Runtime Key / Playb
 // 2-3-1) Case 03-01
 // [Policy] ...
 // NOTE: ...
+```
+
+---
+
+## 13.2 Section Consistency Full Audit
+
+섹션 주석 통일성 기준으로 `Source/Portfolio` 전체를 재스캔한 결과다.
+이 목록은 PR 마감 전에 보완할 후보를 빠뜨리지 않기 위한 감사표이며, 실제 수정 여부는 파일별 책임 구조와 가독성 기준으로 다시 판단한다.
+
+### Audit 기준
+
+```text
+기본:
+-> 같은 책임이면 .h / .cpp 섹션명은 동일하게 둔다.
+-> Lifecycle / Query / Component Reference / Runtime State / Request / Result 등 공통 책임은 공통 섹션명을 사용한다.
+-> 파일 고유 책임은 고유 섹션으로 허용한다.
+
+예외:
+-> .cpp-only helper / anonymous namespace / local helper / 아주 작은 단일 책임 파일은 예외로 둘 수 있다.
+-> include-only Type .cpp는 섹션화하지 않는다.
+-> 로컬 분기 설명은 섹션처럼 보이지 않게 문장형 주석으로 둔다.
+```
+
+### 1) 큰 `.cpp`인데 섹션이 없는 후보
+
+```text
+Source/Portfolio/Component/CStateComponent.cpp
+Source/Portfolio/Reaction/CReaction_BlockHit.cpp
+Source/Portfolio/Type/CExecutionRuleTypes.cpp
+Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.cpp
+```
+
+### 2) `.h / .cpp` 섹션 불일치 또는 한쪽 누락 후보
+
+```text
+Source/Portfolio/Action/CAction.h / .cpp
+Source/Portfolio/Action/CAction_ComboAttack.h / .cpp
+Source/Portfolio/Reaction/CReaction.h / .cpp
+Source/Portfolio/Reaction/CReaction_BlockHit.h / .cpp
+Source/Portfolio/Character/CAnimInstance.h / .cpp
+Source/Portfolio/Character/Enemy/CEnemy.h / .cpp
+Source/Portfolio/Character/Player/CPlayer.h / .cpp
+Source/Portfolio/Component/CActionComponent.h / .cpp
+Source/Portfolio/Component/CActionOrchestratorComponent.h / .cpp
+Source/Portfolio/Component/CDefenseComponent.h / .cpp
+Source/Portfolio/Component/CMovementComponent.h / .cpp
+Source/Portfolio/Component/CReactionComponent.h / .cpp
+Source/Portfolio/Component/CReactionFeedbackComponent.h / .cpp
+Source/Portfolio/Component/CReactionOrchestratorComponent.h / .cpp
+Source/Portfolio/Component/CStateComponent.h / .cpp
+Source/Portfolio/Component/CWeaponComponent.h / .cpp
+Source/Portfolio/Controller/CAIController.h / .cpp
+Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.h / .cpp
+Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h / .cpp
+Source/Portfolio/Weapon/CWeaponActor.h / .cpp
+```
+
+### 3) AI / BehaviorTree 후보
+
+```text
+Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h / .cpp
+Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.h / .cpp
+Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.h / .cpp
+Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateInvestigateContext.h / .cpp
+Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.h / .cpp
+Source/Portfolio/AI/BehaviorTree/Task/CBTTask_SelectPatrolPoint.h / .cpp
+Source/Portfolio/AI/BehaviorTree/Task/*.h / .cpp
+Source/Portfolio/AI/BehaviorTree/Decorator/*.h / .cpp
+Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.h / .cpp
+```
+
+### 4) Core / Debug / Profiling 후보
+
+```text
+Source/Portfolio/Core/Debug/FAIPerceptionDebugTypes.h
+Source/Portfolio/Core/Debug/FCombatEngageDebugTypes.h
+Source/Portfolio/Core/Debug/FComponentReferenceHelper.h
+Source/Portfolio/Core/Debug/FReferenceValidation.h
+Source/Portfolio/Core/Profiling/CAIAnimationProfiling.h / .cpp
+Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.h / .cpp
+Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.h / .cpp
+Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.h / .cpp
+Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.h / .cpp
+Source/Portfolio/Core/Profiling/CCombatCollisionProfilingCounters.h / .cpp
+Source/Portfolio/Core/Profiling/CCombatFeedbackProfiling.h / .cpp
+```
+
+### 5) Type 구현 `.cpp` 후보
+
+```text
+Source/Portfolio/Type/CExecutionRuleTypes.cpp
+Source/Portfolio/Type/CExecutionTypes.cpp
+Source/Portfolio/Type/CActionDataTypes.cpp
+Source/Portfolio/Type/CReactionDataTypes.cpp
+Source/Portfolio/Type/CActionKeyTypes.cpp
+Source/Portfolio/Type/CReactionKeyTypes.cpp
+Source/Portfolio/Type/CCombatHitTypes.cpp
+```
+
+include-only Type `.cpp`는 섹션화 실익이 낮으므로 기본 예외 후보로 둔다.
+
+### 6) 공통명 흔들림 후보
+
+```text
+Check / Query vs Query
+State Query vs Query
+CameraShake vs Camera Shake
+Delegate / Legacy delegate / Engine Delegate Events
+Condition 단독 섹션
+Mutation 단독 섹션
+Profiling Event Sink
+HitWindow
+Entry for AI
+```
+
+### 7) 섹션처럼 잡히는 로컬 설명 후보
+
+```text
+Sync with ActionComponent
+Based OwnerPawn
+Based Perception
+Based TargetActor
+Absolute States
+Context
+Result
+Reroll
+determine left or right
+Internal linkage
+Candidate SpecKey
+Resolve Executor
+Delay for Warmup
+Flag Toggle
+Slow InActor
+Restore InActor
+Early-Return
+Invalid
+Legacy delegate
+```
+
+### 8) 단계형 / Case 주석 후보
+
+```text
+CAction.cpp: Idle && No ActivePart / No Idle && Has ActivePart
+CAction.cpp: Default Action Case
+CAction_Guard.cpp: Case 1 / Case 2 / Case Guard-in / Case Guard-out
+CAction_Dodge.cpp: GuardState Case / Another Case
+CReaction.cpp: Idle && No ActivePart / No Idle && Has ActivePart / Default Reaction Case
+CReaction_Hit.cpp: GuardState Case / Another Case
+CReaction_Dead.cpp: GuardState Case / Another Case
+CReaction_Stagger.cpp: GuardState Case / Another Case
+CReaction_BlockHit.cpp: Another Case
+CBTTask_SelectPatrolPoint.cpp: Reroll / Reverse...
+CBTService_UpdateAIIntentState.cpp: Engage -> Non-Engage / Investigate -> Non-Investigate
+CCombatSignalTargetComponent.cpp: V1 hook only
+```
+
+### 9) 우선 검토 묶음
+
+```text
+1. CStateComponent.h / .cpp
+2. CAIController.h / .cpp
+3. CMovementComponent.h / .cpp
+4. CWeaponActor.h / .cpp
+5. CAnimInstance.h / .cpp
+6. BT Service 계열
+7. Core / Profiling 계열
+8. Type 구현 .cpp 일부
+9. CAction_ComboAttack.h / .cpp
+10. CReaction_BlockHit.h / .cpp
+```
+
+### 10) 보완 판정표
+
+아래 판정은 13.2 감사표를 기준으로 에이전트 교차 검토 후 정리한 실행 계획이다.
+코드 수정 시 함수명, 시그니처, 접근 권한, 동작은 변경하지 않고 섹션 주석과 로컬 설명 주석만 정리한다.
+
+#### Fix Now
+
+```text
+Action / Reaction:
+-> CAction_ComboAttack.h / .cpp
+-> CReaction_BlockHit.h / .cpp
+-> CAction.h / .cpp
+-> CReaction.h / .cpp
+
+Component / Character / Controller / Weapon / System:
+-> CStateComponent.h / .cpp
+-> CMovementComponent.h / .cpp
+-> CWeaponComponent.h / .cpp
+-> CAIController.h / .cpp
+-> CCombatSignalSourceComponent.h / .cpp
+-> CWorldSubsystem_CombatFeedback.h / .cpp
+-> CWeaponActor.h / .cpp
+
+AI / RuntimeLOD / Profiling / Type:
+-> CBTService_UpdateAIContext.h / .cpp
+-> CBTService_UpdateEngageContext.h / .cpp
+-> CBTService_UpdateAIIntentState.h / .cpp
+-> CBTServiceIntervalHelper.h / .cpp
+-> CAIRuntimeLODTierResolver.h / .cpp
+-> CAIAnimationProfiling.h / .cpp
+-> CAIBehaviorTreeProfiling.h / .cpp
+-> CAIPerceptionProfiling.h / .cpp
+-> CAIStateRuntimeLODProfiling.h / .cpp
+-> CCombatCollisionProfiling.h / .cpp
+-> CExecutionRuleTypes.cpp
+-> CExecutionTypes.cpp
+```
+
+#### Optional
+
+```text
+-> CAction_Dodge.h / .cpp
+-> CAction_Equip.h / .cpp
+-> CAction_Unequip.h / .cpp
+-> CReaction_Hit.h / .cpp
+-> CReaction_Dead.h / .cpp
+-> CReaction_Stagger.h / .cpp
+-> CReaction_Parry.h / .cpp
+-> CAnimInstance.h / .cpp
+-> CEnemy.h / .cpp
+-> CActionComponent.h / .cpp
+-> CReactionComponent.h / .cpp
+-> CActionOrchestratorComponent.h / .cpp
+-> CBTService_UpdateInvestigateContext.h / .cpp
+-> CBTTask_SelectPatrolPoint.h / .cpp
+-> CCombatCollisionProfilingCounters.h / .cpp
+-> CCombatFeedbackProfiling.h / .cpp
+-> FAIPerceptionDebugTypes.h
+-> Type 구현이 매우 짧은 CActionDataTypes.cpp / CReactionDataTypes.cpp / CActionKeyTypes.cpp / CReactionKeyTypes.cpp / CCombatHitTypes.cpp
+```
+
+#### Leave Justified
+
+```text
+-> CPlayer.h / .cpp
+-> CDefenseComponent.h / .cpp
+-> CReactionFeedbackComponent.h / .cpp
+-> CReactionOrchestratorComponent.h / .cpp
+-> CWorldSubsystem_CombatEngage.h / .cpp
+-> 작은 BT Task / Decorator 단일 책임 파일
+-> include-only Type .cpp
+-> FCombatEngageDebugTypes.h
+-> FComponentReferenceHelper.h
+-> FReferenceValidation.h
+```
+
+### 11) 파일별 보완 방향
+
+```text
+CAction_ComboAttack.h / .cpp
+-> .h / .cpp에 Decision, Chain Reservation, Lifecycle, Notify, Chain Window, Chain Consume, Chain Query 섹션 추가
+-> Sync with ActionComponent는 섹션이 아니라 로컬 설명으로 유지하거나 제거
+
+CReaction_BlockHit.h / .cpp
+-> Decision, Lifecycle, Intervention, Observable Overlay 섹션 추가
+-> Another Case 주석은 문장형 로컬 설명으로 변경
+
+CAction.h / .cpp
+-> .h에 Intervention Match Helper 섹션을 추가해 .cpp와 대응
+-> Idle / Default Action Case 주석은 문장형 로컬 설명 후보
+
+CReaction.h / .cpp
+-> .h에 Intervention Match Helper 섹션을 추가해 .cpp와 대응
+-> Idle / Default Reaction Case 주석은 문장형 로컬 설명 후보
+
+CStateComponent.h / .cpp
+-> Check / Query와 Query를 Query로 통합
+-> Component Reference, Health State Sync, Query, State Transition 섹션으로 .h / .cpp 동기화
+
+CMovementComponent.h / .cpp
+-> Check / Query는 Query로 통합
+-> Dispatch / Movement Mode / Mutation은 실제 책임에 맞춰 Runtime LOD, Movement State, Query, Runtime State 쪽으로 흡수
+-> determine left or right는 문장형 로컬 주석으로 변경
+
+CWeaponComponent.h / .cpp
+-> Check / Query를 Query로 통일
+
+CAIController.h / .cpp
+-> API 순서 재배치 없이 섹션명만 보정
+-> Runtime LOD Query / Runtime LOD State / Perception Profiling / Perception Candidate Audit / Blackboard / Engage Latency Audit 기준으로 정리
+-> Init AIPerceptionComp는 Perception Component Setup으로 변경
+
+CCombatSignalSourceComponent.h / .cpp
+-> HitWindow를 Hit Window로 표기
+-> Entry for AI는 Entry로 흡수하거나, AI Entry처럼 짧은 명사구로 통일
+
+CWorldSubsystem_CombatFeedback.h / .cpp
+-> CameraShake를 Camera Shake로 통일
+-> Slow InActor / Restore InActor는 문장형 로컬 설명으로 변경
+
+CWeaponActor.h / .cpp
+-> Early-Return / Invalid / Legacy delegate는 섹션처럼 보이지 않게 로컬 설명으로 낮춤
+-> Delegate 계열 섹션명은 Engine Delegate Events 기준으로 유지
+
+BT Service 계열
+-> UpdateAIContext: Lifecycle, Config, Context Build, Context Compute, Blackboard Write, Blackboard Clear
+-> UpdateEngageContext: Lifecycle, Context Build, Context Compute, Blackboard Write, Blackboard Clear
+-> UpdateAIIntentState: Lifecycle, Intent Decision, State Transition
+-> IntervalHelper: Console Variable, Mode Query, Runtime LOD, Interval Preset, Profiling, Public API
+
+CAIRuntimeLODTierResolver.h / .cpp
+-> Enum, Runtime Context, Runtime LOD Resolve, String Conversion 섹션 추가
+
+Core / Profiling 짧은 .cpp
+-> .h의 Gate / Counter / Service Tick Counter / Interval Preset Counter 섹션을 .cpp에도 그대로 반영
+
+Type 구현 .cpp
+-> CExecutionRuleTypes.cpp: Helper API, Validation, Match
+-> CExecutionTypes.cpp: Validation, Query
+```
+
+### 12) 적용 순서
+
+```text
+1. 공통명 표기 흔들림 정리
+   -> Check / Query, CameraShake, HitWindow, Entry for AI
+
+2. 섹션 없는 중간 크기 파일 정리
+   -> CStateComponent, CAction_ComboAttack, CReaction_BlockHit, CExecutionRuleTypes, CAIRuntimeLODTierResolver
+
+3. 큰 파일 섹션명 보정
+   -> CAIController, CMovementComponent, CWeaponActor
+
+4. BT Service 계열 정리
+
+5. Core / Profiling .h / .cpp 동기화
+
+6. Type 구현 .cpp 섹션 보강
+
+7. Optional 후보 선별
+```
+
+### 13) Applied Result
+
+```text
+Fix Now applied:
+-> CAction.h / .cpp, CReaction.h / .cpp
+-> CAction_ComboAttack.h / .cpp
+-> CReaction_BlockHit.h / .cpp
+-> CStateComponent.h / .cpp
+-> CMovementComponent.h / .cpp
+-> CWeaponComponent.h
+-> CAIController.h / .cpp
+-> CCombatSignalSourceComponent.h / .cpp
+-> CCombatSignalTargetComponent.cpp
+-> CWorldSubsystem_CombatEngage.cpp
+-> CWorldSubsystem_CombatFeedback.h / .cpp
+-> CWeaponActor.cpp
+-> BT Service: UpdateAIContext, UpdateEngageContext, UpdateAIIntentState, IntervalHelper
+-> CAIRuntimeLODTierResolver.h / .cpp
+-> Core/Profiling: CAIAnimation, CAIBehaviorTree, CAIPerception, CAIStateRuntimeLOD, CCombatCollision
+-> Type implementation: CExecutionRuleTypes.cpp, CExecutionTypes.cpp
+
+Optional applied:
+-> CAction_Dodge.h / .cpp
+-> CReaction_Hit.h / .cpp
+-> CReaction_Dead.h / .cpp
+-> CReaction_Stagger.h / .cpp
+-> CReaction_Parry.h / .cpp
+-> CEnemy.h / .cpp repeated section meaning clarified
+-> CActionComponent.cpp / CReactionComponent.cpp / CReactionOrchestratorComponent.cpp local section-like comments clarified
+-> CPlayerController.h / .cpp reviewed and retained: Lifecycle / Look Input / Move Input / Movement Dispatch / Action Input already match.
+
+Build blocker fixed:
+-> CHealthComponent.h had duplicate InitializeHealth(float, float, EMaxHPUpdatePolicy) declarations around the State Transition section.
+-> The duplicate declaration outside the section was removed; the section-owned declaration remains.
+
+Explicitly left unchanged:
+-> CAnimInstance.h / .cpp: file-specific Condition / Query / Gate / Record structure is retained.
+-> CBTService_UpdateInvestigateContext.h / .cpp: excluded by implementation decision.
+-> CBTTask_SelectPatrolPoint.h / .cpp: excluded by implementation decision.
+-> CCombatCollisionProfilingCounters.h / .cpp: excluded by implementation decision.
+-> CCombatFeedbackProfiling.h / .cpp: excluded by implementation decision.
+-> FAIPerceptionDebugTypes.h: excluded by implementation decision.
+-> Short Type implementation .cpp files are excluded.
+
+Applied policy:
+-> Shared responsibility sections use shared names such as Query, Lifecycle, Component Reference, Runtime LOD, Request, Result, Packet, Helper.
+-> File-specific sections remain allowed when they express a responsibility unique to that file.
+-> .h and .cpp use matching responsibility names where both sides expose the same responsibility.
+-> Local flow explanations are written as sentences, not section labels.
 ```
 
 ---

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -530,7 +530,8 @@ AI 작업 시스템에는 반복 적용해야 하는 실행 체크리스트만 �
 -> 파일 고유 책임 섹션은 허용하되, .h와 .cpp 양쪽에 대응되는 구현이 있으면 같은 이름을 쓴다.
 -> 구현 전용 helper / local namespace / static helper / 세부 pipeline 단계는 .cpp 전용 섹션으로 둘 수 있다.
 -> 함수가 1~2개뿐인 작은 파일은 섹션 주석을 생략할 수 있다.
--> Unreal lifecycle / callback / 구현 흐름이 더 중요한 경우 구현 흐름을 우선한다.
+-> Unreal lifecycle / callback 순서처럼 호출 순서가 이해에 직접 영향을 주는 경우에만 구현 흐름을 우선한다.
+-> 이 경우에도 같은 책임을 다루는 섹션명은 가능한 한 .h / .cpp에서 동일하게 유지한다.
 ```
 
 공통 책임 섹션명은 아래 이름을 우선 사용한다.
@@ -551,7 +552,7 @@ AI 작업 시스템에는 반복 적용해야 하는 실행 체크리스트만 �
 // Result
 ```
 
-파일 고유 책임은 짧은 명사구로 둔다. 예를 들어 `Animation Refresh Audit`, `Movement Arbitration`, `Camera Shake`, `Overlay Snapshot`, `CombatSignal Receive / Resolve / Send`처럼 해당 파일의 실제 책임을 드러내는 이름은 허용한다.
+파일 고유 책임은 짧은 명사구로 둔다. 예를 들어 CombatSignal 파일의 `Receive`, `Resolve`, `Send`, `Animation Refresh Audit`, `Movement Arbitration`, `Camera Shake`, `Overlay Snapshot`처럼 해당 파일의 실제 책임을 드러내는 이름은 허용한다.
 
 ### Type Header Section Taxonomy
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -523,12 +523,35 @@ AI 작업 시스템에는 반복 적용해야 하는 실행 체크리스트만 �
 
 ```text
 기본 원칙:
+-> 공통 책임 섹션명은 프로젝트 전체에서 같은 이름을 사용한다.
+-> .h와 .cpp에서 같은 책임을 다루면 같은 섹션명을 사용한다.
 -> .cpp 섹션명과 순서는 가능하면 .h를 따른다.
 -> 완전한 함수 단위 1:1 매칭은 강제하지 않는다.
+-> 파일 고유 책임 섹션은 허용하되, .h와 .cpp 양쪽에 대응되는 구현이 있으면 같은 이름을 쓴다.
 -> 구현 전용 helper / local namespace / static helper / 세부 pipeline 단계는 .cpp 전용 섹션으로 둘 수 있다.
 -> 함수가 1~2개뿐인 작은 파일은 섹션 주석을 생략할 수 있다.
 -> Unreal lifecycle / callback / 구현 흐름이 더 중요한 경우 구현 흐름을 우선한다.
 ```
+
+공통 책임 섹션명은 아래 이름을 우선 사용한다.
+
+```text
+// Lifecycle
+// Runtime Lifecycle
+// Component Reference
+// Query
+// Mutation
+// State Transition
+// Runtime State
+// Request
+// Entry
+// Notify
+// Notify Routing
+// Feedback
+// Result
+```
+
+파일 고유 책임은 짧은 명사구로 둔다. 예를 들어 `Animation Refresh Audit`, `Movement Arbitration`, `Camera Shake`, `Overlay Snapshot`, `CombatSignal Receive / Resolve / Send`처럼 해당 파일의 실제 책임을 드러내는 이름은 허용한다.
 
 ### Type Header Section Taxonomy
 

--- a/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
+++ b/Docs/01_Work_List/W05_Code_Quality_Plan/W05_Comment_Section_Cleanup_Work_Plan.md
@@ -501,6 +501,74 @@ FObservableTargetRef targetRef;
 
 ---
 
+## 13.1 Section Comment Follow-up Rules
+
+### Header / Source Section Synchronization
+
+`.h`가 API 책임 단위로 섹션을 나누면 `.cpp`도 같은 책임 그룹 기준으로 섹션을 둔다.
+목표는 선언 파일에서 본 책임 구조를 구현 파일에서도 빠르게 찾을 수 있게 하는 것이다.
+
+```text
+기본 원칙:
+-> .cpp 섹션명과 순서는 가능하면 .h를 따른다.
+-> 완전한 함수 단위 1:1 매칭은 강제하지 않는다.
+-> 구현 전용 helper / local namespace / static helper / 세부 pipeline 단계는 .cpp 전용 섹션으로 둘 수 있다.
+-> 함수가 1~2개뿐인 작은 파일은 섹션 주석을 생략할 수 있다.
+-> Unreal lifecycle / callback / 구현 흐름이 더 중요한 경우 구현 흐름을 우선한다.
+```
+
+### Type Header Section Taxonomy
+
+Type 헤더에서 타입 역할이 3개 이상으로 나뉘면 아래 taxonomy를 우선 사용한다.
+타입이 1~2개뿐인 작은 Type 헤더는 섹션 주석을 생략할 수 있다.
+
+```text
+// Enum
+// Key / Identifier
+// Data / Config
+// Runtime State
+// Runtime Context
+// Request
+// Candidate
+// Payload
+// Resolution
+// Result
+// Packet
+// Runtime Key / Playback Key
+// Reserved Pipeline Scaffold
+// Helper API
+```
+
+pipeline 단계가 type taxonomy보다 더 명확한 파일은 `Request`, `Candidate`, `Payload`, `Resolution`, `Result`, `Packet`을 우선 사용한다.
+feedback / playback처럼 domain 의미가 필요한 경우 `Runtime Key / Playback Key`처럼 구체적인 섹션명을 허용한다.
+
+### Step Comment Style
+
+단계형 주석은 fallback 순서, policy gate, priority matching처럼 순서 자체가 의미를 가질 때만 사용한다.
+번호 깊이는 한 단계까지만 허용하고, `2-3-1` 같은 중첩 번호는 의미 있는 문장형 주석으로 바꾼다.
+
+```cpp
+// Gate: already dead.
+// Gate: parry intercept.
+// Gate: target-side defense policy.
+```
+
+```cpp
+// Preferred: engine-provided instigator.
+// Fallback: causer-provided instigator.
+// Final fallback: causer owner as instigator.
+```
+
+피하는 형태:
+
+```cpp
+// 2-3-1) Case 03-01
+// [Policy] ...
+// NOTE: ...
+```
+
+---
+
 ## 14. P3 Final Decision
 
 P3 항목은 이번 브랜치에서 코드 수정하지 않고, 유지 또는 후속 작업으로 이관한다.

--- a/Docs/04_Pull_Request/00_Pull_Request_Index.md
+++ b/Docs/04_Pull_Request/00_Pull_Request_Index.md
@@ -6,6 +6,7 @@
 
 | ID | 제목 | 파일 | 브랜치 | GitHub PR | 관련 문서 |
 | --- | --- | --- | --- | --- | --- |
+| P50 | Section Comment Consistency | `P50_UE5_Portfolio_Pull_Request.md` | `refactor/section-comment-consistency` |  | W05 |
 | P49 | API Const Consistency | `P49_UE5_Portfolio_Pull_Request.md` | `refactor/api-const-consistency` |  | W05 |
 | P48 | CPP Include Order Cleanup | `P48_UE5_Portfolio_Pull_Request.md` | `refactor/include-order-cleanup` |  | W05 |
 | P47 | Type Rename and Feedback Key Cleanup | `P47_UE5_Portfolio_Pull_Request.md` | `refactor/type-rename-feedback-key-cleanup` |  | W05 |

--- a/Docs/04_Pull_Request/P50_UE5_Portfolio_Pull_Request.md
+++ b/Docs/04_Pull_Request/P50_UE5_Portfolio_Pull_Request.md
@@ -1,0 +1,395 @@
+# UE5 Portfolio Pull Request
+
+## 제목
+
+**P50: Section Comment Consistency**
+
+## 날짜
+
+**2026.07.25**
+
+## 상태
+
+- [x] 섹션 주석 판단 규칙 문서화
+- [x] 파일군별 section policy 정리
+- [x] `.h / .cpp` 책임 섹션 동기화 기준 반영
+- [x] Action / Reaction / Component / Controller / System / Weapon 섹션 정리
+- [x] BT Service / RuntimeLOD / Core Profiling / Type 구현 cpp 섹션 정리
+- [x] 단계형 / Case / 로컬 설명형 주석 정리
+- [x] 예외 파일군 판단 기준 문서화
+- [x] 큰 파일 무섹션 후보 재스캔 완료
+- [x] `git diff --check` 통과
+- [x] `PortfolioEditor Win64 Development` build 통과
+- [x] PIE smoke 확인
+
+## 브랜치
+
+- `refactor/section-comment-consistency`
+
+## 요약
+
+이번 PR은 W05 코드 품질 정리 흐름의 후속 작업으로, `Source/Portfolio`의 섹션 주석 체계와 파일군별 판단 기준을 정리한다.
+
+핵심 기준은 모든 파일에 같은 섹션을 강제하는 것이 아니라, 같은 성격 / 책임 / 파일 패턴을 가진 파일군끼리 같은 섹션 체계를 쓰는 것이다. 짧은 UE adapter, Interface, Type helper처럼 함수 자체가 구조를 설명하는 파일은 섹션 생략을 허용하고, Component / Controller / Action / Reaction / BT Service처럼 책임이 반복되는 파일군은 공통 섹션명을 우선 사용한다.
+
+코드 동작, 타입명, 함수명, 시그니처, UPROPERTY, UFUNCTION, Blueprint 노출 계약은 변경하지 않았다.
+
+## 변경 배경
+
+기존 코드에는 다음 문제가 섞여 있었다.
+
+```text
+-> 같은 책임인데 파일마다 섹션명이 다름
+-> .h에는 섹션이 있지만 .cpp에는 대응 섹션이 없음
+-> .cpp에는 구현 흐름 섹션이 있지만 .h 책임 구조와 연결이 약함
+-> Case 1, Another Case, Result, Context 같은 로컬 설명이 섹션처럼 보임
+-> 짧은 파일과 큰 파일에 같은 기준을 적용할지 판단 기준이 불명확함
+```
+
+이번 PR에서는 이를 한 번에 같은 규칙으로 정리했다.
+
+```text
+1. 같은 파일군은 같은 책임 섹션을 사용한다.
+2. 파일 고유 책임은 고유 섹션으로 허용한다.
+3. .h / .cpp는 함수 1:1이 아니라 책임 그룹 기준으로 동기화한다.
+4. 로컬 흐름 설명은 섹션이 아니라 문장형 주석으로 작성한다.
+5. 짧고 단일 책임인 UE adapter / Interface / Type cpp는 섹션을 생략할 수 있다.
+```
+
+## 변경 범위
+
+### 1. 섹션 주석 정책 문서화
+
+무엇
+
+W05 comment / section cleanup 문서에 파일군별 section policy를 추가했다.
+
+어떻게
+
+다음 파일군을 독립 판단 대상으로 정리했다.
+
+```text
+-> Action / Reaction Base
+-> Action / Reaction Derived
+-> Component
+-> Controller
+-> Behavior Tree Service / Task / Decorator
+-> AI RuntimeLOD Policy
+-> Character
+-> System
+-> Weapon
+-> Type
+-> Core Debug / Profiling
+-> Notify / Interface / Blackboard / Patrol / Module
+```
+
+결과
+
+`Source/Portfolio` 상위 계열 전체가 섹션 주석 판단 규칙 안에 들어왔다.
+
+### 2. Action / Reaction 계열 섹션 정리
+
+무엇
+
+Action / Reaction base와 파생 클래스의 섹션명을 계열 기준으로 맞췄다.
+
+어떻게
+
+공통 책임은 아래 이름을 우선 사용했다.
+
+```text
+-> Decision
+-> Lifecycle
+-> Notify
+-> Observable Overlay
+-> Intervention
+-> State Transition
+```
+
+파일 고유 책임은 고유 섹션으로 유지했다.
+
+```text
+-> Chain Reservation
+-> Chain Window
+-> Chain Query
+-> Weapon
+-> Guard State Cleanup
+```
+
+결과
+
+`CAction_ComboAttack`, `CAction_Dodge`, `CAction_Guard`, `CAction_Equip`, `CAction_Unequip`, `CReaction_Hit`, `CReaction_Dead`, `CReaction_Stagger`, `CReaction_Parry`, `CReaction_BlockHit`의 책임 구분이 base class와 같은 기준으로 정리됐다.
+
+### 3. Component / Controller / Character / System / Weapon 섹션 정리
+
+무엇
+
+큰 gameplay 파일과 runtime service 파일의 `.h / .cpp` 책임 섹션을 동기화했다.
+
+어떻게
+
+Component 계열은 다음 공통 섹션을 우선 사용했다.
+
+```text
+-> Component Reference
+-> Lifecycle
+-> Runtime Lifecycle
+-> Query
+-> Mutation
+-> Runtime State
+-> State Transition
+-> Request / Entry
+-> Receive
+-> Resolve
+-> Apply
+-> Packet
+-> Notify
+-> Helper
+```
+
+도메인 고유 섹션은 유지했다.
+
+```text
+-> Movement Arbitration
+-> Movement Input
+-> Movement Policy
+-> Hit Window
+-> AI Entry
+-> Camera Shake
+-> Assignment Build
+-> Assignment Warmup
+-> Engine Delegate Events
+```
+
+결과
+
+Component / Controller / Character / System / Weapon 계열의 공통 책임 섹션이 같은 이름으로 정리됐고, 파일 고유 책임은 필요한 곳에만 남았다.
+
+### 4. BT Service / RuntimeLOD / Core Profiling / Type cpp 정리
+
+무엇
+
+BT Service, RuntimeLOD resolver, Core Profiling, Type implementation cpp의 섹션 기준을 보강했다.
+
+어떻게
+
+BT Service는 context / blackboard 흐름 기준으로 정리했다.
+
+```text
+-> Lifecycle
+-> Context Build
+-> Context Compute
+-> Blackboard Update
+-> Blackboard Clear
+-> Intent Decision
+-> Intent Transition
+```
+
+Core Profiling은 profiling 책임 기준으로 정리했다.
+
+```text
+-> Gate
+-> Counter
+-> Service Tick Counter
+-> Interval Preset Counter
+```
+
+Type cpp는 헤더 taxonomy와 맞는 최소 섹션만 추가했다.
+
+```text
+-> Helper API
+-> Data / Config
+-> Runtime State
+```
+
+결과
+
+BT Service / RuntimeLOD / Core Profiling / Type 구현 파일의 책임 구분이 문서 규칙과 코드 양쪽에서 맞춰졌다.
+
+### 5. 단계형 / Case / 로컬 설명 주석 정리
+
+무엇
+
+섹션처럼 보이던 로컬 설명 주석을 문장형 설명으로 바꿨다.
+
+어떻게
+
+다음 패턴을 정리했다.
+
+```text
+-> Case 1 / Case 2
+-> GuardState Case / Another Case
+-> Default Action Case / Default Reaction Case
+-> Idle && No ActivePart / No Idle && Has ActivePart
+-> Based OwnerPawn / Based Perception / Based TargetActor
+-> Absolute States / Context / Result
+-> Resolve Executor / Candidate SpecKey
+-> Delay for Warmup / Flag Toggle
+-> Slow InActor / Restore InActor
+-> Early-Return / Invalid / Legacy delegate
+-> V1 hook only
+```
+
+결과
+
+섹션 주석과 로컬 흐름 설명의 경계가 분리됐다.
+
+### 6. 예외 파일군 기준 정리
+
+무엇
+
+무조건 섹션을 넣지 않아도 되는 파일군을 명시했다.
+
+어떻게
+
+다음 파일군은 짧거나, framework adapter 성격이 강하거나, 자체 구조가 명확하면 섹션 생략을 허용한다.
+
+```text
+-> BT Task / Decorator
+-> Notify
+-> Interface
+-> AI Blackboard
+-> AI Patrol
+-> 짧은 Type cpp
+-> Module / Global
+```
+
+결과
+
+일관성과 파일 고유성 사이의 판단 기준이 문서화됐다.
+
+## 주요 처리 흐름
+
+```text
+섹션 주석 정책 문서화
+-> 파일군별 판단 기준 정리
+-> Type header taxonomy 재확인
+-> Action / Reaction 계열 섹션 정리
+-> Component / Controller / Character / System / Weapon 섹션 정리
+-> BT Service / RuntimeLOD / Core Profiling / Type cpp 섹션 정리
+-> 단계형 / Case / 로컬 설명 주석 정리
+-> 예외 파일군 기준 정리
+-> 큰 파일 무섹션 후보 재스캔
+-> git diff --check
+-> PortfolioEditor Win64 Development build
+-> PIE smoke
+```
+
+## 구현 결과
+
+```text
+main...HEAD
+-> 107 files changed, 1626 insertions(+), 195 deletions(-)
+
+commit range
+-> 5fd828bf docs(style): define section comment consistency rules
+-> d7c6e9a8b docs(style): define section comment workflow rules
+-> d0cc14ce style(type): add section taxonomy comments
+-> 2903361a style(combat): sync source section comments
+-> 85e4f83f style(feedback): sync header and source sections
+-> 24d7b073 style(combat): normalize signal step comments
+-> d82750d3 style(core): sync remaining header and source sections
+-> 5480b14f style(component): normalize remaining step comments
+-> 06fce7c3 style(comments): align controller blackboard section label
+-> c20b2107 style(comments): standardize section comment layout
+-> ee6f1b86 docs(comments): clarify section synchronization rules
+-> ca6c7cf8 refactor(style): align section comment policy
+-> 10c68dc3 refactor(style): align section comment policy
+```
+
+변경함:
+
+```text
+-> 섹션 주석 정책 문서화
+-> 파일군별 section policy 추가
+-> .h / .cpp 책임 섹션 동기화
+-> Action / Reaction / Component / Controller / Character / System / Weapon 섹션 정리
+-> BT Service / RuntimeLOD / Core Profiling / Type cpp 섹션 보강
+-> 단계형 / Case / 로컬 설명 주석 정리
+-> AI Blackboard helper 섹션 보강
+-> CHealthComponent.h 중복 InitializeHealth 선언 제거
+```
+
+변경하지 않음:
+
+```text
+-> 타입명
+-> 함수명
+-> enum entry
+-> UPROPERTY
+-> UFUNCTION / Blueprint 노출 signature
+-> delegate signature
+-> override signature
+-> gameplay logic
+-> CombatSignal reserved scaffold
+-> Feedback key model
+```
+
+## 테스트 방법
+
+```text
+1. 파일군별 section policy 문서 확인
+2. 단계형 / Case / 흔들리는 로컬 라벨 패턴 재스캔
+3. 큰 파일 무섹션 후보 재스캔
+4. git diff --check
+5. PortfolioEditor Win64 Development build
+6. PIE smoke 실행
+```
+
+## 검증 결과
+
+### Static check
+
+```text
+git diff --check
+Result: Pass
+```
+
+### Pattern scan
+
+```text
+단계형 / Case / 흔들리는 로컬 라벨 후보
+Result: 0건
+
+큰 파일 무섹션 후보
+Result: 0건
+
+남은 Condition / Record
+Result: CAnimInstance 유지 결정 범위
+
+남은 Result
+Result: Type taxonomy 섹션
+```
+
+### Build
+
+```text
+PortfolioEditor Win64 Development
+Result: Pass
+```
+
+### PIE
+
+```text
+PIE smoke
+Result: Pass
+```
+
+## 비고 / 후속 작업
+
+- 이번 PR은 주석 / 섹션 / 문서 정책 정리이며 gameplay behavior 변경 PR이 아니다.
+- Notify / Interface / BT Task / Decorator / 짧은 Type cpp는 파일이 커지거나 책임이 나뉘는 시점에만 섹션을 추가한다.
+- 향후 AI 작업 시스템은 `File Family Section Policy`를 기준으로 같은 파일군의 섹션명을 우선 맞춘다.
+
+## 관련 문서
+
+- Work List: `W05_UE5_Portfolio_Work_List.md`
+- Section Cleanup Work Plan: `W05_Comment_Section_Cleanup_Work_Plan.md`
+- AI Workflow Rule: `02_Project_Stella_Working_Rule_Prompt (KR).md`
+- Previous PR: `P49_UE5_Portfolio_Pull_Request.md`
+
+## 정리
+
+이번 PR은 파일군별 섹션 주석 판단 기준을 문서화하고, 주요 코드 파일의 섹션명을 같은 책임 단위로 정리했다.
+
+결과적으로 `Source/Portfolio`의 모든 상위 파일군은 section policy 안에서 판단 가능해졌고, 섹션 주석과 로컬 흐름 설명의 경계도 분리됐다.

--- a/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
+++ b/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
@@ -31,10 +31,17 @@ Project Stella 작업 세션에서 반복 적용할 실행 규칙을 제공한�
 
 .h / .cpp 섹션 동기화
 -> .h가 API 책임 단위로 섹션을 나누면 .cpp도 같은 책임 그룹 기준으로 섹션을 둔다.
+-> 공통 책임 섹션명은 프로젝트 전체에서 같은 이름을 사용한다.
+-> .h와 .cpp에서 같은 책임을 다루면 같은 섹션명을 사용한다.
 -> .cpp 섹션명과 순서는 가능하면 .h를 따른다.
+-> 파일 고유 책임 섹션은 허용하되, .h와 .cpp 양쪽에 대응되는 구현이 있으면 같은 이름을 쓴다.
 -> 구현 전용 helper / local namespace / static helper / 세부 pipeline 단계는 .cpp 전용 섹션으로 둘 수 있다.
 -> 작은 파일이나 함수 수가 적은 파일은 섹션을 생략할 수 있다.
 -> Unreal lifecycle / callback / 구현 흐름이 더 중요한 경우 구현 흐름을 우선한다.
+
+공통 책임 섹션명
+-> Lifecycle, Runtime Lifecycle, Component Reference, Query, Mutation, State Transition, Runtime State, Request, Entry, Notify, Notify Routing, Feedback, Result를 우선 사용한다.
+-> 파일 고유 책임은 Animation Refresh Audit, Movement Arbitration, Camera Shake, Overlay Snapshot처럼 짧은 명사구로 둔다.
 
 Type 헤더 섹션
 -> Type 헤더 섹션명은 W05 Comment Section Cleanup Work Plan의 taxonomy를 따른다.

--- a/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
+++ b/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
@@ -40,6 +40,12 @@ Type 헤더 섹션
 -> Type 헤더 섹션명은 W05 Comment Section Cleanup Work Plan의 taxonomy를 따른다.
 -> Enum, Key / Identifier, Data / Config, Runtime State, Runtime Context, Request, Candidate, Payload, Resolution, Result, Packet, Runtime Key / Playback Key, Reserved Pipeline Scaffold, Helper API를 우선 사용한다.
 
+작업 체크리스트
+-> Type 헤더가 taxonomy를 따르는지 확인한다.
+-> .h / .cpp의 책임 섹션이 큰 그룹 기준으로 동기화되어 있는지 확인한다.
+-> 단계형 주석이 fallback / policy gate / priority matching처럼 순서 의미를 가지는지 확인한다.
+-> 주석 정리 중 타입명 / 필드명 / API signature / include / 동작 변경이 섞이지 않았는지 확인한다.
+
 단계형 주석
 -> fallback 순서, policy gate, priority matching처럼 순서 자체가 의미 있을 때만 사용한다.
 -> 번호 깊이는 한 단계까지만 허용한다.
@@ -80,6 +86,12 @@ Project Stella 작업을 진행해줘.
    - 건드리지 않을 범위
    - 검증 방법
    - 사용자 확인이 필요한 항목
+
+2-1. 주석 / 섹션 정리 작업이면 아래 체크리스트를 먼저 적용해줘.
+   - Type 헤더 섹션은 W05 taxonomy를 기준으로 확인해줘.
+   - `.h`가 API 책임 단위로 나뉘면 `.cpp`도 같은 책임 그룹 기준으로 섹션을 동기화해줘.
+   - 단계형 주석은 fallback / policy gate / priority matching처럼 순서 자체가 의미 있을 때만 남겨줘.
+   - 주석 정리 중 타입명 / 필드명 / API signature / include / 동작 변경을 함께 처리하지 말아줘.
 
 3. Project Stella 작업 맥락을 유지해줘.
    - Stella Blade 액션 시스템 분석 / 구현 포트폴리오라는 맥락을 유지해줘.

--- a/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
+++ b/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
@@ -37,7 +37,8 @@ Project Stella 작업 세션에서 반복 적용할 실행 규칙을 제공한�
 -> 파일 고유 책임 섹션은 허용하되, .h와 .cpp 양쪽에 대응되는 구현이 있으면 같은 이름을 쓴다.
 -> 구현 전용 helper / local namespace / static helper / 세부 pipeline 단계는 .cpp 전용 섹션으로 둘 수 있다.
 -> 작은 파일이나 함수 수가 적은 파일은 섹션을 생략할 수 있다.
--> Unreal lifecycle / callback / 구현 흐름이 더 중요한 경우 구현 흐름을 우선한다.
+-> Unreal lifecycle / callback 순서처럼 호출 순서가 이해에 직접 영향을 주는 경우에만 구현 흐름을 우선한다.
+-> 이 경우에도 같은 책임을 다루는 섹션명은 가능한 한 .h / .cpp에서 동일하게 유지한다.
 
 공통 책임 섹션명
 -> Lifecycle, Runtime Lifecycle, Component Reference, Query, Mutation, State Transition, Runtime State, Request, Entry, Notify, Notify Routing, Feedback, Result를 우선 사용한다.

--- a/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
+++ b/Docs/08_AI_Workflow/05_Prompt_Library/01_Prompt_Files/01_Working_Rules/02_Project_Stella_Working_Rule_Prompt (KR).md
@@ -20,6 +20,39 @@ Project Stella 작업 세션에서 반복 적용할 실행 규칙을 제공한�
 
 ---
 
+## 2.1 코드 주석 / 섹션 규칙
+
+```yaml
+섹션 구분 주석
+-> 파일 구조 탐색을 돕는 경우에만 둔다.
+-> 함수 그룹 / 타입 그룹 / 구현 책임이 3개 이상으로 나뉠 때 우선 사용한다.
+-> 짧은 명사구를 사용하고 장식성 separator, [NOTE], [Policy], [Pass] 태그는 사용하지 않는다.
+-> 변수 / UPROPERTY 구간은 섹션 주석보다 Category / 변수명 / struct 이름으로 의미를 표현한다.
+
+.h / .cpp 섹션 동기화
+-> .h가 API 책임 단위로 섹션을 나누면 .cpp도 같은 책임 그룹 기준으로 섹션을 둔다.
+-> .cpp 섹션명과 순서는 가능하면 .h를 따른다.
+-> 구현 전용 helper / local namespace / static helper / 세부 pipeline 단계는 .cpp 전용 섹션으로 둘 수 있다.
+-> 작은 파일이나 함수 수가 적은 파일은 섹션을 생략할 수 있다.
+-> Unreal lifecycle / callback / 구현 흐름이 더 중요한 경우 구현 흐름을 우선한다.
+
+Type 헤더 섹션
+-> Type 헤더 섹션명은 W05 Comment Section Cleanup Work Plan의 taxonomy를 따른다.
+-> Enum, Key / Identifier, Data / Config, Runtime State, Runtime Context, Request, Candidate, Payload, Resolution, Result, Packet, Runtime Key / Playback Key, Reserved Pipeline Scaffold, Helper API를 우선 사용한다.
+
+단계형 주석
+-> fallback 순서, policy gate, priority matching처럼 순서 자체가 의미 있을 때만 사용한다.
+-> 번호 깊이는 한 단계까지만 허용한다.
+-> 2-3-1 같은 중첩 번호는 의미 있는 문장형 주석으로 바꾼다.
+-> Gate / Preferred / Fallback / Final fallback 같은 prefix를 일관되게 사용한다.
+
+금지
+-> 주석 정리 작업에서 타입명 / 필드명 / 함수명 / 동작을 함께 변경하지 않는다.
+-> include 변경, DataAsset 전환, serialized field 변경을 주석 정리와 묶지 않는다.
+```
+
+---
+
 ## 3. 사용 방법
 
 작업 요청과 함께 `복사용 Prompt`를 전달한다.

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.cpp
@@ -18,15 +18,11 @@ namespace
 		TEXT("Controls AI BT service update interval Runtime LOD mode. 0: default, 1: reduced, 2: aggressive reduced."),
 		ECVF_Default);
 
-	// AIContext
+	// Interval Defaults
 	constexpr float DefaultAIContextInterval = 0.1f;
-
-	// AIIntentState
 	constexpr float DefaultAIIntentStateInterval = 0.2f;
 	constexpr float ReducedAIIntentStateInterval = 0.3f;
 	constexpr float AggressiveAIIntentStateInterval = 0.5f;
-
-	// EngageContext
 	constexpr float DefaultEngageContextInterval = 0.1f;
 
 	// Mode Query
@@ -62,7 +58,7 @@ namespace
 		return ResolveRuntimeLODTierFallback(InOwnerComp);
 	}
 
-	// Mode + Runtime LOD Tier -> Interval Enum Preset
+	// Interval Preset Selection
 	EBTServiceIntervalPreset SelectIntervalPreset(int32 InMode, EAIRuntimeLODTier InTier)
 	{
 		switch (InMode)
@@ -117,14 +113,13 @@ namespace
 		FAIStateRuntimeLODProfiling::RecordResolvedTier(InTier);
 	}
 
-	// AIIntentState
-	// Record Counter (AIIntentState)
+	// Profiling
 	void RecordAIIntentStateIntervalPreset(EBTServiceIntervalPreset InPreset)
 	{
 		FAIBehaviorTreeProfiling::RecordAIIntentIntervalPreset(InPreset);
 	}
 
-	// Interval Enum Preset -> Interval float value (AIIntentState)
+	// Interval Value
 	float GetAIIntentStateIntervalByPreset(EBTServiceIntervalPreset InPreset)
 	{
 		switch (InPreset)
@@ -141,7 +136,7 @@ namespace
 		}
 	}
 
-	// Interval Select (AIIntentState)
+	// Interval Selection
 	float SelectAIIntentStateInterval(const UBehaviorTreeComponent& InOwnerComp)
 	{
 		const EAIRuntimeLODTier runtimeLODTier = GetRuntimeLODTierForIntervalSelection(InOwnerComp);
@@ -149,13 +144,15 @@ namespace
 			GetBTUpdateIntervalMode(),
 			runtimeLODTier);
 
-		// Profiling
+		// Record the selected Runtime LOD tier and interval preset.
 		RecordStateRuntimeLODTier(runtimeLODTier);
 		RecordAIIntentStateIntervalPreset(intervalPreset);
 
 		return GetAIIntentStateIntervalByPreset(intervalPreset);
 	}
 }
+
+// Public API
 
 float CBTServiceIntervalHelper::GetAIContextInterval(const UBehaviorTreeComponent& /*InOwnerComp*/)
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTServiceIntervalHelper.h
@@ -7,6 +7,7 @@ class UBehaviorTreeComponent;
 
 namespace CBTServiceIntervalHelper
 {
+	// Public API
 	float GetAIContextInterval(const UBehaviorTreeComponent& InOwnerComp);
 	float GetAIIntentStateInterval(const UBehaviorTreeComponent& InOwnerComp);
 	float GetEngageContextInterval();

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.cpp
@@ -20,6 +20,8 @@
 #include "BehaviorTree/BehaviorTreeComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
+// Lifecycle
+
 UCBTService_UpdateAIContext::UCBTService_UpdateAIContext()
 {
 	NodeName = "Update AIContext";
@@ -68,7 +70,7 @@ void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, ui
 
 	FAIBlackboardUpdateContext aiContext;
 
-	// Based OwnerPawn
+	// Compute owner-pawn based context first.
 	EContextBuildResult deadResult = ComputeDeadContext(ownerPawn, blackboardComp, aiContext);
 
 	if (deadResult == EContextBuildResult::Success)
@@ -91,7 +93,7 @@ void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, ui
 	else
 		ClearHomeMetricContext(blackboardComp);
 
-	// Based Perception
+	// Build perception-based target context before target-dependent metrics.
 	EContextBuildResult buildResult = BuildPerceptionContext(ownerPawn, aiContext);
 
 	if (buildResult != EContextBuildResult::Success)
@@ -110,7 +112,7 @@ void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, ui
 	UpdatePerceptionContext(blackboardComp, aiContext);
 	aiOwner->RecordBlackboardTargetSetForAudit(aiContext.TargetActor);
 
-	// Based TargetActor
+	// Compute target-actor based context after perception succeeds.
 	EContextBuildResult engageMetricResult = ComputeAlertRangeContext(ownerPawn, blackboardComp, aiContext);
 
 	if (engageMetricResult == EContextBuildResult::Success)
@@ -129,6 +131,8 @@ void UCBTService_UpdateAIContext::TickNode(UBehaviorTreeComponent& OwnerComp, ui
 
 	aiOwner->RefreshRuntimeLODTierFromBlackboard();
 }
+
+// Context Build
 
 EContextBuildResult UCBTService_UpdateAIContext::BuildPerceptionContext(APawn* InOwnerPawn, FAIBlackboardUpdateContext& OutAIContext)
 {
@@ -151,6 +155,8 @@ EContextBuildResult UCBTService_UpdateAIContext::BuildPerceptionContext(APawn* I
 
 	return EContextBuildResult::Success;
 }
+
+// Context Compute
 
 EContextBuildResult UCBTService_UpdateAIContext::ComputeHomeMetricContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const
 {
@@ -281,6 +287,8 @@ EContextBuildResult UCBTService_UpdateAIContext::ComputeDeadContext(APawn* InOwn
 	return EContextBuildResult::Success;
 }
 
+// Blackboard Update
+
 void UCBTService_UpdateAIContext::UpdatePerceptionContext(UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InAIContext)
 {
 	if (!IsValid(InBlackboardComp)) return;
@@ -332,6 +340,8 @@ void UCBTService_UpdateAIContext::UpdateDeadContext(UBlackboardComponent* InBlac
 	CAIBlackboardValueHelper::SetEnumIfChanged(InBlackboardComp, CAIKey::Dead::DeadState.KeyName, static_cast<uint8>(InAIContext.DeadState));
 }
 
+// Blackboard Clear
+
 void UCBTService_UpdateAIContext::ClearPerceptionContext(UBlackboardComponent* InBlackboardComp)
 {
 	if (!IsValid(InBlackboardComp)) return;
@@ -376,6 +386,8 @@ void UCBTService_UpdateAIContext::ClearDeadContext(UBlackboardComponent* InBlack
 {
 	CAIBlackboardValueHelper::SetEnumIfChanged(InBlackboardComp, CAIKey::Dead::DeadState.KeyName, static_cast<uint8>(EDeadState::Alive));
 }
+
+// Lifecycle
 
 void UCBTService_UpdateAIContext::ScheduleNextTick(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIContext.h
@@ -18,13 +18,16 @@ private:
 	float MovableRange = 1000.f;
 
 protected:
+	// Lifecycle
 	virtual void TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds) override;
 	virtual void ScheduleNextTick(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
 
 private:
+	// Context Build
 	EContextBuildResult BuildPerceptionContext(class APawn* InOwnerPawn, FAIBlackboardUpdateContext& OutAIContext);
 
 private:
+	// Context Compute
 	EContextBuildResult ComputeHomeMetricContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const;
 	EContextBuildResult ComputeAlertRangeContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const;
 	EContextBuildResult ComputeEngageAssignmentContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext);
@@ -32,6 +35,7 @@ private:
 	EContextBuildResult ComputeDeadContext(class APawn* InOwnerPawn, class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InOutAIContext) const;
 
 private:
+	// Blackboard Update
 	void UpdatePerceptionContext(class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InAIContext);
 	void UpdateHomeMetricContext(class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InAIContext);
 	void UpdateAlertRangeContext(class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InAIContext);
@@ -40,6 +44,7 @@ private:
 	void UpdateDeadContext(class UBlackboardComponent* InBlackboardComp, FAIBlackboardUpdateContext& InAIContext);
 
 private:
+	// Blackboard Clear
 	void ClearPerceptionContext(class UBlackboardComponent* InBlackboardComp);
 	void ClearHomeMetricContext(class UBlackboardComponent* InBlackboardComp);
 	void ClearAlertRangeContext(class UBlackboardComponent* InBlackboardComp);

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.cpp
@@ -15,6 +15,8 @@
 #include "AIController.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
+// Lifecycle
+
 UCBTService_UpdateAIIntentState::UCBTService_UpdateAIIntentState()
 {
 	NodeName = "Update AI Intent State";
@@ -50,9 +52,11 @@ void UCBTService_UpdateAIIntentState::TickNode(UBehaviorTreeComponent& OwnerComp
 	}
 }
 
+// Intent Decision
+
 EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackboardComponent* InBlackboard, float InCurrentTime)
 {
-	// Absolute States
+	// Absolute states override contextual intent decisions.
 	const EDeadState deadState = static_cast<EDeadState>(InBlackboard->GetValueAsEnum(CAIKey::Dead::DeadState.KeyName));
 	const bool bIsActiveReaction = InBlackboard->GetValueAsBool(CAIKey::Reaction::bIsActiveReaction.KeyName);
 	const bool bIsCombatAction = InBlackboard->GetValueAsBool(CAIKey::Engage::bIsCombatAction.KeyName);
@@ -67,7 +71,7 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 	if (bIsCombatAction)
 		return EAIIntentState::Engage;
 
-	// Context
+	// Gather blackboard context for intent selection.
 	AActor* target = Cast<AActor>(InBlackboard->GetValueAsObject(CAIKey::Targeting::TargetActor.KeyName));
 
 	const bool bHasTarget = IsValid(target);
@@ -81,7 +85,6 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 	const bool bInAlertRange = InBlackboard->GetValueAsBool(CAIKey::Alert::bInAlertRange.KeyName);
 	const ECombatRole combatRole = static_cast<ECombatRole>(InBlackboard->GetValueAsEnum(CAIKey::Engage::CombatRole.KeyName));
 
-	// Intent Decision
 	// No awareness: investigate only when requested or already active.
 	if (!bHasAwareness)
 	{
@@ -108,6 +111,8 @@ EAIIntentState UCBTService_UpdateAIIntentState::DecideNextAIIntentState(UBlackbo
 	return EAIIntentState::Observe;
 }
 
+// Intent Transition
+
 bool UCBTService_UpdateAIIntentState::ChangeAIIntentState(UBlackboardComponent* InBlackboardComp, EAIIntentState InNextAIIntentState)
 {
 	const uint8 currentAIIntentState = static_cast<uint8>(InBlackboardComp->GetValueAsEnum(CAIKey::State::AIIntentState.KeyName));
@@ -121,12 +126,11 @@ bool UCBTService_UpdateAIIntentState::ChangeAIIntentState(UBlackboardComponent* 
 	return true;
 }
 
-// Cleanup handles unexpected intent-state exits.
 void UCBTService_UpdateAIIntentState::UpdateAIIntentStateTransition(UBlackboardComponent* InBlackboardComp, EAIIntentState InCurrentAIIntentState, EAIIntentState InNextAIIntentState)
 {
 	if (!IsValid(InBlackboardComp)) return;
 
-	// Engage -> Non-Engage
+	// Clear Engage context when leaving Engage unexpectedly.
 	if (InCurrentAIIntentState == EAIIntentState::Engage && InNextAIIntentState != EAIIntentState::Engage)
 	{
 		CAIBlackboardValueHelper::SetBoolIfChanged(InBlackboardComp, CAIKey::Engage::bInEngageRange.KeyName, false);
@@ -138,7 +142,7 @@ void UCBTService_UpdateAIIntentState::UpdateAIIntentStateTransition(UBlackboardC
 		}
 	} 
 
-	// Investigate -> Non-Investigate
+	// Clear Investigate context when leaving Investigate unexpectedly.
 	if (InCurrentAIIntentState == EAIIntentState::Investigate && InNextAIIntentState != EAIIntentState::Investigate)
 	{
 		CAIBlackboardValueHelper::SetBoolIfChanged(InBlackboardComp, CAIKey::Investigate::bShouldInvestigate.KeyName, false);
@@ -149,6 +153,8 @@ void UCBTService_UpdateAIIntentState::UpdateAIIntentStateTransition(UBlackboardC
 		CAIBlackboardValueHelper::SetIntIfChanged(InBlackboardComp, CAIKey::Investigate::InvestigateIndex.KeyName, INDEX_NONE);
 	}
 }
+
+// Lifecycle
 
 void UCBTService_UpdateAIIntentState::ScheduleNextTick(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory)
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateAIIntentState.h
@@ -14,11 +14,15 @@ public:
 	UCBTService_UpdateAIIntentState();
 
 protected:
+	// Lifecycle
 	virtual void TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds) override;
 	virtual void ScheduleNextTick(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
 
 private:
+	// Intent Decision
 	EAIIntentState DecideNextAIIntentState(UBlackboardComponent* InBlackboardComp, float InCurrentTime);
 	bool ChangeAIIntentState(UBlackboardComponent* InBlackboardComp, EAIIntentState InNextAIIntentState);
+
+	// Intent Transition
 	void UpdateAIIntentStateTransition(UBlackboardComponent* InBlackboardComp, EAIIntentState InCurrentAIIntentState, EAIIntentState InNextAIIntentState);
 };

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.cpp
@@ -14,6 +14,8 @@
 #include "BehaviorTree/BehaviorTreeComponent.h"
 #include "BehaviorTree/BlackboardComponent.h"
 
+// Lifecycle
+
 UCBTService_UpdateEngageContext::UCBTService_UpdateEngageContext()
 {
 	NodeName = TEXT("Update Engage Context");
@@ -71,6 +73,8 @@ void UCBTService_UpdateEngageContext::ScheduleNextTick(UBehaviorTreeComponent& O
 	SetNextTickTime(NodeMemory, CBTServiceIntervalHelper::GetEngageContextInterval());
 }
 
+// Context Build
+
 EContextBuildResult UCBTService_UpdateEngageContext::BuildEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext& OutEngageContext)
 {
 	if (!IsValid(InOwnerPawn) || !IsValid(InBlackboardComp))
@@ -102,6 +106,8 @@ EContextBuildResult UCBTService_UpdateEngageContext::BuildEngageContext(APawn* I
 
 	return EContextBuildResult::Success;
 }
+
+// Context Compute
 
 EContextBuildResult UCBTService_UpdateEngageContext::ComputeEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext& InOutEngageContext)
 {
@@ -145,7 +151,7 @@ EContextBuildResult UCBTService_UpdateEngageContext::ComputeEngageContext(APawn*
 	InOutEngageContext.EngageInnerRange = engageInnerRange;
 	InOutEngageContext.DistanceToTarget = distanceToTarget;
 
-	// Result
+	// Store the computed engage result.
 	InOutEngageContext.bInEngageRange = bInEngageRange;
 	InOutEngageContext.bCanCombatAction = 
 		bInEngageRange				// for ActionRange Check
@@ -181,6 +187,8 @@ EContextBuildResult UCBTService_UpdateEngageContext::ComputeEngageContext(APawn*
 	return EContextBuildResult::Success;
 }
 
+// Blackboard Update
+
 void UCBTService_UpdateEngageContext::UpdateEngageContext(UBlackboardComponent* InBlackboardComp, FEngageContext& InEngageContext)
 {
 	if (!IsValid(InBlackboardComp)) return;
@@ -188,6 +196,8 @@ void UCBTService_UpdateEngageContext::UpdateEngageContext(UBlackboardComponent* 
 	CAIBlackboardValueHelper::SetBoolIfChanged(InBlackboardComp, CAIKey::Engage::bInEngageRange.KeyName, InEngageContext.bInEngageRange);
 	CAIBlackboardValueHelper::SetBoolIfChanged(InBlackboardComp, CAIKey::Engage::bCanCombatAction.KeyName, InEngageContext.bCanCombatAction);
 }
+
+// Blackboard Clear
 
 void UCBTService_UpdateEngageContext::ClearEngageContext(UBlackboardComponent* InBlackboardComp)
 {

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateEngageContext.h
@@ -14,18 +14,23 @@ public:
 	UCBTService_UpdateEngageContext();
 
 protected:
+	// Lifecycle
 	virtual void TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds) override;
 	virtual void ScheduleNextTick(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory) override;
 
 private:
+	// Context Build
 	EContextBuildResult BuildEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext& OutEngageContext);
 
 private:
+	// Context Compute
 	EContextBuildResult ComputeEngageContext(APawn* InOwnerPawn, UBlackboardComponent* InBlackboardComp, FEngageContext& InOutEngageContext);
 
 private:
+	// Blackboard Update
 	void UpdateEngageContext(UBlackboardComponent* InBlackboardComp, FEngageContext& InEngageContext);
 
 private:
+	// Blackboard Clear
 	void ClearEngageContext(UBlackboardComponent* InBlackboardComp);
 };

--- a/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateInvestigateContext.h
+++ b/Source/Portfolio/AI/BehaviorTree/Service/CBTService_UpdateInvestigateContext.h
@@ -13,5 +13,6 @@ public:
 	UCBTService_UpdateInvestigateContext();
 
 protected:
+	// Lifecycle
 	virtual void TickNode(UBehaviorTreeComponent& OwnerComp, uint8* NodeMemory, float DeltaSeconds) override;
 };

--- a/Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
+++ b/Source/Portfolio/AI/Blackboard/CAIBlackboardValueHelper.h
@@ -9,6 +9,7 @@
 
 namespace CAIBlackboardValueHelper
 {
+	// Value Set
 	static void SetBoolIfChanged(UBlackboardComponent* InBlackboardComp, const FName& InKeyName, bool InValue)
 	{
 		if (!IsValid(InBlackboardComp)) return;
@@ -57,6 +58,7 @@ namespace CAIBlackboardValueHelper
 		InBlackboardComp->SetValueAsObject(InKeyName, InValue);
 	}
 
+	// Initial Value Apply
 	static void ApplyFixedValue(UBlackboardComponent* InBlackboardComp, const FAIBlackboardKeySpec& InKeySpec)
 	{
 		if (!IsValid(InBlackboardComp)) return;
@@ -124,6 +126,7 @@ namespace CAIBlackboardValueHelper
 		}
 	}
 
+	// Custom Value Apply
 	static void MarkCustomKeyApplied(TSet<FName>& InOutPendingKeys, const FAIBlackboardKeySpec& InKeySpec, const UObject* InOwnerContext)
 	{
 		ensureMsgf(
@@ -181,6 +184,7 @@ namespace CAIBlackboardValueHelper
 		MarkCustomKeyApplied(InOutPendingKeys, InKeySpec, InOwnerContext);
 	}
 
+	// Validation
 	static bool ValidateCustomKeysApplied(const TSet<FName>& InPendingKeys, const UObject* InOwnerContext)
 	{
 		if (InPendingKeys.IsEmpty()) return true;
@@ -201,6 +205,7 @@ namespace CAIBlackboardValueHelper
 		return false;
 	}
 
+	// Clear
 	static void ClearValues(UBlackboardComponent* InBlackboardComp)
 	{
 		if (!IsValid(InBlackboardComp)) return;

--- a/Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.cpp
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.cpp
@@ -6,6 +6,7 @@
 
 namespace
 {
+	// Helper
 	bool IsAlwaysCombatCriticalIntentState(EAIIntentState InAIIntentState)
 	{
 		switch (InAIIntentState)
@@ -21,6 +22,8 @@ namespace
 	}
 }
 
+// Context Build
+
 FAIRuntimeLODTierContext FAIRuntimeLODTierResolver::BuildContext(const UBlackboardComponent& InBlackboardComp)
 {
 	FAIRuntimeLODTierContext context;
@@ -33,6 +36,8 @@ FAIRuntimeLODTierContext FAIRuntimeLODTierResolver::BuildContext(const UBlackboa
 
 	return context;
 }
+
+// Tier Resolve
 
 EAIRuntimeLODTier FAIRuntimeLODTierResolver::ResolveTier(const UBlackboardComponent& InBlackboardComp)
 {
@@ -57,6 +62,8 @@ EAIRuntimeLODTier FAIRuntimeLODTierResolver::ResolveTier(const FAIRuntimeLODTier
 		return InContext.bHasTargetAwareness ? EAIRuntimeLODTier::Awareness : EAIRuntimeLODTier::Background;
 	}
 }
+
+// String Conversion
 
 const TCHAR* FAIRuntimeLODTierResolver::LexToString(EAIRuntimeLODTier InTier)
 {

--- a/Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.h
+++ b/Source/Portfolio/AI/RuntimeLOD/CAIRuntimeLODTierResolver.h
@@ -26,9 +26,13 @@ struct FAIRuntimeLODTierContext
 class FAIRuntimeLODTierResolver
 {
 public:
+	// Context Build
 	static FAIRuntimeLODTierContext BuildContext(const UBlackboardComponent& InBlackboardComp);
+
+	// Tier Resolve
 	static EAIRuntimeLODTier ResolveTier(const UBlackboardComponent& InBlackboardComp);
 	static EAIRuntimeLODTier ResolveTier(const FAIRuntimeLODTierContext& InContext);
 
+	// String Conversion
 	static const TCHAR* LexToString(EAIRuntimeLODTier InTier);
 };

--- a/Source/Portfolio/Action/CAction.cpp
+++ b/Source/Portfolio/Action/CAction.cpp
@@ -97,13 +97,13 @@ bool UCAction::IsIncomingActionType(const FExecutionInterventionQuery& InQuery, 
 
 bool UCAction::CanResolveIndependentRelationship(const FExecutionDecisionQuery& InQuery) const
 {
-	// Idle && No ActivePart: Idle
+	// Idle state accepts independent action requests.
 	return InQuery.Snapshot.IsIdle() && !InQuery.HasActivePart();
 }
 
 bool UCAction::CanResolveExclusiveRelationship(const FExecutionDecisionQuery& InQuery) const
 {
-	// No Idle && Has ActivePart: Active Action OR Active Reaction
+	// Active state can accept exclusive requests against the current part.
 	return !InQuery.Snapshot.IsIdle() && InQuery.HasActivePart();
 }
 
@@ -111,7 +111,7 @@ bool UCAction::TryResolveIndependentOrExclusiveRelationship(const FExecutionDeci
 {
 	OutRelationship = EExecutionRelationship::None;
 
-	// Idle && No ActivePart: Idle
+	// Idle state resolves to an independent relationship.
 	if (CanResolveIndependentRelationship(InQuery))
 	{
 		OutRelationship = EExecutionRelationship::Independent;
@@ -589,12 +589,12 @@ void UCAction::ResolveObservableOverlayCondition(const FObservableOverlayQuery& 
 
 	if (!InQuery.DecisionQuery.IncomingPart.IsActionParticipant())
 	{
-		// Action only.
+		// Reject non-Action overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
 
-	// Default Action Case: No overlay cleanup.
+	// Default Action overlay handling accepts without cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }
 

--- a/Source/Portfolio/Action/CAction.cpp
+++ b/Source/Portfolio/Action/CAction.cpp
@@ -10,6 +10,8 @@
 #include "GameFramework/Character.h"
 #include "Animation/AnimInstance.h"
 
+// Component Reference
+
 void UCAction::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -39,6 +41,8 @@ bool UCAction::ValidateRequiredReferences() const
 
 	return bValid;
 }
+
+// Resolve
 
 FExecutionDecisionResult UCAction::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
@@ -122,6 +126,8 @@ bool UCAction::TryResolveIndependentOrExclusiveRelationship(const FExecutionDeci
 
 	return false;
 }
+
+// Lifecycle
 
 bool UCAction::Start(const FActionData& InData)
 {
@@ -319,6 +325,8 @@ void UCAction::CleanupRuntimeEffects()
 	}
 }
 
+// Montage Lifecycle
+
 bool UCAction::PlayMontage(const FActionData& InData)
 {
 	if (!IsValid(OwnerCharacter_Injected))
@@ -442,6 +450,8 @@ bool UCAction::CanHandleMontageEnd(UAnimMontage* InMontage, uint32 InSerial) con
 	return true;
 }
 
+// Notify
+
 void UCAction::HandleNotifyCommand(EActionNotifyCommand InCommand)
 {
 	switch (InCommand)
@@ -469,11 +479,15 @@ void UCAction::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 {
 }
 
+// Feedback
+
 void UCAction::HandleNotifyFeedback(EActionFeedbackTiming InTiming, FName InTriggerKey)
 {
 	const FActionFeedbackRequest feedbackRequest = BuildFeedbackRequest(InTiming, InTriggerKey);
 	PlayFeedbackRequest(feedbackRequest);
 }
+
+// Combat Signal
 
 bool UCAction::ResolveNotifyCombatSignalCue(FName InCueTag, FActionCombatSignalCueResolution& OutResolution) const
 {
@@ -508,6 +522,8 @@ FActionFeedbackRequest UCAction::BuildFeedbackRequest(EActionFeedbackTiming InTi
 	return request;
 }
 
+// Hit Source Action Key
+
 void UCAction::PushHitContext()
 {
 	if (!IsValid(WeaponComp_Injected))
@@ -530,6 +546,8 @@ void UCAction::ClearHitContext()
 	WeaponComp_Injected->ClearContext();
 }
 
+// Intervention Window
+
 void UCAction::OpenAllowInterventionWindow(FName InWindowKey)
 {
 	if (InWindowKey.IsNone()) return;
@@ -543,6 +561,8 @@ void UCAction::CloseAllowInterventionWindow(FName InWindowKey)
 
 	AllowInterventionWindowKeys.Remove(InWindowKey);
 }
+
+// Intervention Match
 
 bool UCAction::WantIntervention(const FExecutionInterventionQuery& InQuery) const
 {
@@ -561,6 +581,8 @@ bool UCAction::AllowIntervention(const FExecutionInterventionQuery& InQuery) con
 	return MatchesAllowInterventionRules(ActiveData_Cached.AllowInterventionRules, InQuery.IncomingPart);
 }
 
+// Observable Overlay Match
+
 void UCAction::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -575,6 +597,8 @@ void UCAction::ResolveObservableOverlayCondition(const FObservableOverlayQuery& 
 	// Default Action Case: No overlay cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }
+
+// Intervention Match Helper
 
 bool UCAction::MatchesWantInterventionRules(const TArray<FExecutionInterventionWantRule>& InRules, const FExecutionParticipant& InParticipant) const
 {
@@ -623,6 +647,8 @@ bool UCAction::MatchesAnyInterventionFilter(const TArray<FExecutionInterventionP
 
 	return false;
 }
+
+// Event
 
 void UCAction::EmitActionEvent(EActionEventType InEventType, int32 InActionIndex) const
 {

--- a/Source/Portfolio/Action/CAction.h
+++ b/Source/Portfolio/Action/CAction.h
@@ -65,7 +65,7 @@ public:
 	virtual void Tick(float InDeltaTime) {}
 
 public:
-	// State Query
+	// Query
 	bool IsActive() const { return bIsActive; }
 
 public:
@@ -155,6 +155,7 @@ public:
 	virtual void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const;
 
 private:
+	// Intervention Match Helper
 	bool MatchesWantInterventionRules(const TArray<FExecutionInterventionWantRule>& InRules, const FExecutionParticipant& InParticipant) const;
 	bool MatchesAllowInterventionRules(const TArray<FExecutionInterventionAllowRule>& InRules, const FExecutionParticipant& InParticipant) const;
 	bool IsAllowInterventionRuleTimingSatisfied(const FExecutionInterventionAllowRule& InRule) const;

--- a/Source/Portfolio/Action/CAction_ComboAttack.cpp
+++ b/Source/Portfolio/Action/CAction_ComboAttack.cpp
@@ -5,6 +5,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCAction_ComboAttack::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -51,6 +53,8 @@ FExecutionDecisionResult UCAction_ComboAttack::ResolveExecutionDecision(const FE
 	return result;
 }
 
+// Chain Reservation
+
 bool UCAction_ComboAttack::ReserveChain(const FActionData& InData)
 {
 	if (!CanReserveChain(InData)) return false;
@@ -62,6 +66,8 @@ bool UCAction_ComboAttack::ReserveChain(const FActionData& InData)
 	return true;
 }
 
+// Lifecycle
+
 void UCAction_ComboAttack::ClearRuntime()
 {
 	Super::ClearRuntime();
@@ -70,6 +76,8 @@ void UCAction_ComboAttack::ClearRuntime()
 	bHasReservingChain = false;
 	bReserveChainWindowOpened = false;
 }
+
+// Notify
 
 void UCAction_ComboAttack::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 {
@@ -92,6 +100,8 @@ void UCAction_ComboAttack::HandleSpecificNotifyCommand(EActionNotifyCommand InCo
 	}
 }
 
+// Chain Window
+
 void UCAction_ComboAttack::OpenReserveChainWindow()
 {
 	if (!bIsActive) return;
@@ -109,6 +119,8 @@ void UCAction_ComboAttack::CloseReserveChainWindow()
 
 	EmitActionEvent(EActionEventType::ReserveChainWindowClosed, ActiveDataKey_Cached.ActionIndex);
 }
+
+// Chain Consume
 
 void UCAction_ComboAttack::ConsumeChain()
 {
@@ -142,7 +154,7 @@ void UCAction_ComboAttack::ConsumeChain()
 
 	if (IsValid(ActionComp_Injected))
 	{
-		// Sync with ActionComponent
+		// Keep the owning action component synchronized with the consumed chain.
 		if (!ActionComp_Injected->HandleApplyActionConsumed(this, nextData))
 		{
 			Stop(EActionStopReason::Ignored);
@@ -154,6 +166,8 @@ void UCAction_ComboAttack::ConsumeChain()
 	PlayFeedbackRequest(feedbackRequest);
 	EmitActionEvent(EActionEventType::ActionChained, ActiveDataKey_Cached.ActionIndex);
 }
+
+// Chain Query
 
 bool UCAction_ComboAttack::CanResolveChain(const FExecutionDecisionQuery& InQuery) const
 {

--- a/Source/Portfolio/Action/CAction_ComboAttack.h
+++ b/Source/Portfolio/Action/CAction_ComboAttack.h
@@ -22,23 +22,29 @@ private:
 	FActionData ReservingChainData = FActionData();
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 public:
+	// Chain Reservation
 	bool ReserveChain(const FActionData& InData) override;
 	void ConsumeChain() override;
 
 protected:
+	// Lifecycle
 	void ClearRuntime() override;
 
 protected:
+	// Notify
 	void HandleSpecificNotifyCommand(EActionNotifyCommand InCommand) override;
 
 public:
+	// Chain Window
 	void OpenReserveChainWindow();
 	void CloseReserveChainWindow();
 
 private:
+	// Chain Query
 	bool CanResolveChain(const FExecutionDecisionQuery& InQuery) const;	// CheckTiming: Input
 	bool CanReserveChain(const FActionData& InData) const;				// CheckTiming: Reserve
 	bool CanConsumeChain(const FActionData& InData) const;				// CheckTiming: Consume

--- a/Source/Portfolio/Action/CAction_Dodge.cpp
+++ b/Source/Portfolio/Action/CAction_Dodge.cpp
@@ -4,6 +4,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCAction_Dodge::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -33,6 +35,8 @@ FExecutionDecisionResult UCAction_Dodge::ResolveExecutionDecision(const FExecuti
 	return result;
 }
 
+// Observable Overlay
+
 void UCAction_Dodge::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -40,12 +44,12 @@ void UCAction_Dodge::ResolveObservableOverlayCondition(const FObservableOverlayQ
 	const bool bIsDodge = IsIncomingActionType(InQuery.DecisionQuery, EActionType::Dodge);
 	if (!bIsDodge)
 	{
-		// Dodge only.
+		// Reject non-Dodge overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
 
-	// GuardState Case: clear Guard before Dodge.
+	// Dodge clears an active Guard state before it starts.
 	const bool bHasGuardState = InQuery.DecisionQuery.Snapshot.ObservableOverlay.Guard.HasGuardRuntimeState();
 	if (bHasGuardState)
 	{
@@ -54,9 +58,11 @@ void UCAction_Dodge::ResolveObservableOverlayCondition(const FObservableOverlayQ
 		return;
 	}
 
-	// Another Case: No overlay cleanup.
+	// Dodge can start without overlay cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }
+
+// Intervention
 
 bool UCAction_Dodge::WantIntervention(const FExecutionInterventionQuery& InQuery) const
 {

--- a/Source/Portfolio/Action/CAction_Dodge.h
+++ b/Source/Portfolio/Action/CAction_Dodge.h
@@ -10,9 +10,13 @@ class PORTFOLIO_API UCAction_Dodge : public UCAction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
+
+	// Observable Overlay
 	void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const override;
 
 public:
+	// Intervention
 	bool WantIntervention(const FExecutionInterventionQuery& InQuery) const override;
 };

--- a/Source/Portfolio/Action/CAction_Equip.cpp
+++ b/Source/Portfolio/Action/CAction_Equip.cpp
@@ -6,6 +6,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCAction_Equip::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -45,6 +47,8 @@ FExecutionDecisionResult UCAction_Equip::ResolveExecutionDecision(const FExecuti
 	return result;
 }
 
+// Notify
+
 void UCAction_Equip::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 {
 	switch (InCommand)
@@ -57,6 +61,8 @@ void UCAction_Equip::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 		return;
 	}
 }
+
+// Weapon
 
 void UCAction_Equip::AttachWeapon()
 {

--- a/Source/Portfolio/Action/CAction_Equip.h
+++ b/Source/Portfolio/Action/CAction_Equip.h
@@ -10,11 +10,14 @@ class PORTFOLIO_API UCAction_Equip : public UCAction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 protected:
+	// Notify
 	void HandleSpecificNotifyCommand(EActionNotifyCommand InCommand) override;
 
 private:
+	// Weapon
 	void AttachWeapon();
 };

--- a/Source/Portfolio/Action/CAction_Guard.cpp
+++ b/Source/Portfolio/Action/CAction_Guard.cpp
@@ -9,6 +9,9 @@
 
 // CAction_Guard only owns Guard In/Out transition actions.
 // Guard Hold is an idle overlay state owned by UCDefenseComponent.
+
+// Lifecycle
+
 bool UCAction_Guard::Start(const FActionData& InData)
 {
 	const bool bStarted = Super::Start(InData);
@@ -106,6 +109,8 @@ void UCAction_Guard::Complete()
 		break;
 	}
 }
+
+// Decision
 
 FExecutionDecisionResult UCAction_Guard::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
@@ -206,6 +211,8 @@ bool UCAction_Guard::TryResolveDeferredConsumeKey(const FExecutionDecisionQuery&
 	return false;
 }
 
+// Observable Overlay
+
 void UCAction_Guard::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -263,6 +270,8 @@ void UCAction_Guard::ResolveObservableOverlayCondition(const FObservableOverlayQ
 	OutDecision.Decision = EExecutionDecision::Reject;
 }
 
+// Notify
+
 void UCAction_Guard::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 {
 	if (!IsValid(ActionComp_Injected)) return;
@@ -281,6 +290,8 @@ void UCAction_Guard::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 		break;
 	}
 }
+
+// Intervention
 
 bool UCAction_Guard::WantIntervention(const FExecutionInterventionQuery& InQuery) const
 {
@@ -347,6 +358,8 @@ bool UCAction_Guard::AllowIntervention(const FExecutionInterventionQuery& InQuer
 
 	return false;
 }
+
+// Guard State Cleanup
 
 void UCAction_Guard::ClearDeferredGuardActions() const
 {

--- a/Source/Portfolio/Action/CAction_Guard.cpp
+++ b/Source/Portfolio/Action/CAction_Guard.cpp
@@ -183,7 +183,7 @@ bool UCAction_Guard::TryResolveDeferredConsumeKey(const FExecutionDecisionQuery&
 	
 	if (!InQuery.HasActivePart()) return false;
 
-	// Case 1. Guard-In -> Guard-Out
+	// Guard-Out can be deferred until active Guard-In completes.
 	if (InQuery.ActivePart.IsActionParticipant())
 	{
 		const FActionExecutionContext& activeContext = InQuery.ActivePart.GetActionContext();
@@ -196,7 +196,7 @@ bool UCAction_Guard::TryResolveDeferredConsumeKey(const FExecutionDecisionQuery&
 		}
 	}
 
-	// Case 2. Guard-Block -> Guard-Out
+	// Guard-Out can be deferred until active Guard-Block reaction completes.
 	if (InQuery.ActivePart.IsReactionParticipant())
 	{
 		const FReactionExecutionContext& activeContext = InQuery.ActivePart.GetReactionContext();
@@ -220,7 +220,7 @@ void UCAction_Guard::ResolveObservableOverlayCondition(const FObservableOverlayQ
 	const bool bIsGuard = IsIncomingActionType(InQuery.DecisionQuery, EActionType::Guard);
 	if (!bIsGuard)
 	{
-		// Guard only.
+		// Reject non-Guard overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
@@ -230,7 +230,7 @@ void UCAction_Guard::ResolveObservableOverlayCondition(const FObservableOverlayQ
 
 	const FGuardObservableOverlaySnapshot& guardOverlaySnapshot = InQuery.DecisionQuery.Snapshot.ObservableOverlay.Guard;
 
-	// Case Guard-in: check condition
+	// Guard-In starts only when Guard is not already active.
 	if (incomingGuardPhase == EGuardActionPhase::In)
 	{
 		const bool bCanStartGuardIn = !guardOverlaySnapshot.bIsGuardingPose && guardOverlaySnapshot.bCanStartGuard;
@@ -251,7 +251,7 @@ void UCAction_Guard::ResolveObservableOverlayCondition(const FObservableOverlayQ
 		return;
 	}
 
-	// Case Guard-out: check condition
+	// Guard-Out clears an active Guard pose if one exists.
 	if (incomingGuardPhase == EGuardActionPhase::Out)
 	{
 		if (!guardOverlaySnapshot.bIsGuardingPose)

--- a/Source/Portfolio/Action/CAction_Guard.h
+++ b/Source/Portfolio/Action/CAction_Guard.h
@@ -10,23 +10,30 @@ class PORTFOLIO_API UCAction_Guard : public UCAction
 	GENERATED_BODY()
 
 public:
+	// Lifecycle
 	bool Start(const FActionData& InData) override;
 	void Interrupt(const FExecutionInterventionDirective& InDirective) override;
 	void Complete() override;
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 	bool TryResolveDeferredConsumeKey(const FExecutionDecisionQuery& InQuery, EDeferredActionConsumeKey& OutConsumeKey) const override;
+
+	// Observable Overlay
 	void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const override;
 
+protected:
+	// Notify
+	void HandleSpecificNotifyCommand(EActionNotifyCommand InCommand) override;
+
 public:
+	// Intervention
 	bool WantIntervention(const FExecutionInterventionQuery& InQuery) const override;
 	bool AllowIntervention(const FExecutionInterventionQuery& InQuery) const override;
 
-protected:
-	void HandleSpecificNotifyCommand(EActionNotifyCommand InCommand) override;
-
 private:
+	// Guard State Cleanup
 	void ClearDeferredGuardActions() const;
 	void ClearGuardState() const;
 };

--- a/Source/Portfolio/Action/CAction_Unequip.cpp
+++ b/Source/Portfolio/Action/CAction_Unequip.cpp
@@ -6,6 +6,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCAction_Unequip::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -45,6 +47,8 @@ FExecutionDecisionResult UCAction_Unequip::ResolveExecutionDecision(const FExecu
 	return result;
 }
 
+// Notify
+
 void UCAction_Unequip::HandleSpecificNotifyCommand(EActionNotifyCommand InCommand)
 {
 	switch (InCommand)
@@ -57,6 +61,8 @@ void UCAction_Unequip::HandleSpecificNotifyCommand(EActionNotifyCommand InComman
 		return;
 	}
 }
+
+// Weapon
 
 void UCAction_Unequip::DetachWeapon()
 {

--- a/Source/Portfolio/Action/CAction_Unequip.h
+++ b/Source/Portfolio/Action/CAction_Unequip.h
@@ -10,11 +10,14 @@ class PORTFOLIO_API UCAction_Unequip : public UCAction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 protected:
+	// Notify
 	void HandleSpecificNotifyCommand(EActionNotifyCommand InCommand) override;
 
 private:
+	// Weapon
 	void DetachWeapon();
 };

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -272,8 +272,6 @@ void ACEnemy::UpdateRuntimeLODActorTickMode()
 	RuntimeLODActorTickState.AppliedMode = requestedActorTickMode;
 }
 
-// Actor Tick State
-
 void ACEnemy::CacheRuntimeLODActorTickOriginalState()
 {
 	if (RuntimeLODActorTickState.bOriginalStateCached) return;
@@ -326,6 +324,8 @@ void ACEnemy::Tick(float DeltaTime)
 	UpdateRuntimeLODMeshMode();
 	UpdateRuntimeLODActorTickMode();
 }
+
+// Input
 
 void ACEnemy::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
@@ -505,6 +505,8 @@ bool ACEnemy::TryStartRevive(float InReviveHP)
 {
 	return IsValid(HealthComponent) && HealthComponent->TryRevive(InReviveHP);
 }
+
+// Combat Action Query
 
 bool ACEnemy::IsCombatActionType(EActionType InActionType) const
 {

--- a/Source/Portfolio/Character/Enemy/CEnemy.cpp
+++ b/Source/Portfolio/Character/Enemy/CEnemy.cpp
@@ -105,6 +105,8 @@ ACEnemy::ACEnemy()
 	check(ReactionFeedbackComponent);
 }
 
+// Lifecycle
+
 void ACEnemy::PostInitializeComponents()
 {
 	Super::PostInitializeComponents();
@@ -152,6 +154,8 @@ void ACEnemy::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 	Super::EndPlay(EndPlayReason);
 }
+
+// Component Reference
 
 void ACEnemy::RecoverReferences()
 {
@@ -221,6 +225,8 @@ void ACEnemy::InjectReferences(const FCharacterComponentReferences& InReferences
 	FComponentReferenceHelper::InjectIfValid(ReactionFeedbackComponent, InReferences);
 }
 
+// Runtime LOD
+
 void ACEnemy::UpdateRuntimeLODMeshMode()
 {
 	const int32 requestedMeshMode = FMath::Clamp(CVarAIRuntimeLODEnemyMeshMode.GetValueOnGameThread(), 0, 1);
@@ -266,6 +272,8 @@ void ACEnemy::UpdateRuntimeLODActorTickMode()
 	RuntimeLODActorTickState.AppliedMode = requestedActorTickMode;
 }
 
+// Actor Tick State
+
 void ACEnemy::CacheRuntimeLODActorTickOriginalState()
 {
 	if (RuntimeLODActorTickState.bOriginalStateCached) return;
@@ -309,6 +317,8 @@ void ACEnemy::DisableRuntimeLODActorTick()
 	SetActorTickEnabled(false);
 }
 
+// Tick
+
 void ACEnemy::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
@@ -321,6 +331,8 @@ void ACEnemy::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);
 }
+
+// Damage
 
 float ACEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
@@ -343,6 +355,8 @@ float ACEnemy::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, A
 
 	return finalDamage;
 }
+
+// Combat Result
 
 void ACEnemy::ReceiveCombatResultPacket(const FCombatResultPacket& InCombatResultPacket)
 {
@@ -389,6 +403,8 @@ bool ACEnemy::TryRequestParryStaggerReaction(const FCombatResultPacket& InCombat
 
 	return bStarted;
 }
+
+// AI Movement Intent
 
 FActionRequestResult ACEnemy::HandleAIWalk()
 {
@@ -450,6 +466,8 @@ FActionRequestResult ACEnemy::HandleAIStopJump()
 	return ActionOrchestratorComponent->RequestMovementAction(request);
 }
 
+// AI Action Intent
+
 FActionRequestResult ACEnemy::HandleAIEquipmentAction(EEquipmentActionIntent InEquipmentActionIntent)
 {
 	if (!IsValid(ActionOrchestratorComponent)) return FActionRequestResult();
@@ -473,6 +491,8 @@ FActionRequestResult ACEnemy::HandleAICombatAction(ECombatActionIntent InCombatA
 
 	return ActionOrchestratorComponent->RequestCombatAction(request);
 }
+
+// Runtime State
 
 bool ACEnemy::TryStartKill()
 {
@@ -498,6 +518,8 @@ bool ACEnemy::IsCombatActionType(EActionType InActionType) const
 		return false; // Idle / Equip / Unequip etc..
 	}
 }
+
+// Action Event Routing
 
 void ACEnemy::OnActionTypeChanged(ACharacter* InOwnerCharacter, EActionType InPreviousActionType, EActionType InNewActionType)
 {
@@ -526,7 +548,6 @@ void ACEnemy::OnActionEvent(ACharacter* InOwnerCharacter, EActionType InActionTy
 	}
 }
 
-// Chain Combat Request
 void ACEnemy::RequestChainCombatAction(EActionType InActionType, int32 InActionIndex)
 {
 	const ECombatActionIntent combatActionIntent = ResolveChainCombatIntent(InActionType, InActionIndex);
@@ -536,7 +557,6 @@ void ACEnemy::RequestChainCombatAction(EActionType InActionType, int32 InActionI
 	if (!actionRequestResult.IsReservedResult()) return;
 }
 
-// Chain Intent Mapping
 ECombatActionIntent ACEnemy::ResolveChainCombatIntent(EActionType InActionType, int32 InActionIndex) const
 {
 	switch (InActionType)

--- a/Source/Portfolio/Character/Enemy/CEnemy.h
+++ b/Source/Portfolio/Character/Enemy/CEnemy.h
@@ -172,12 +172,14 @@ private:
 	void DisableRuntimeLODActorTick();
 
 public:
+	// Tick
 	void Tick(float DeltaTime) override;
 
 public:
 	void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 
 public:
+	// Query
 	FORCEINLINE UCMovementComponent* GetMovementComp() const { return MovementComponent; }
 	FORCEINLINE UCWeaponComponent* GetWeaponComp() const { return WeaponComponent; }
 	FORCEINLINE UCStateComponent* GetStateComp() const { return StateComponent; }
@@ -221,9 +223,11 @@ public:
 	FORCEINLINE float GetCombatActionCooldown() const { return CombatActionCooldown; }
 
 public:
+	// Damage
 	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, class AController* EventInstigator, class AActor* DamageCauser) override;
 
 public:
+	// Combat Result
 	void ReceiveCombatResultPacket(const FCombatResultPacket& InCombatResultPacket) override;
 
 private:
@@ -231,6 +235,7 @@ private:
 	bool TryRequestParryStaggerReaction(const FCombatResultPacket& InCombatResultPacket);
 
 public:
+	// AI Movement Intent
 	FActionRequestResult HandleAIWalk();
 	FActionRequestResult HandleAIRun();
 	FActionRequestResult HandleAISprint();
@@ -238,14 +243,17 @@ public:
 	FActionRequestResult HandleAIJump();
 	FActionRequestResult HandleAIStopJump();
 
+	// AI Action Intent
 	FActionRequestResult HandleAIEquipmentAction(EEquipmentActionIntent InEquipmentActionIntent);
 	FActionRequestResult HandleAICombatAction(ECombatActionIntent InCombatActionIntent);
 
 public:
+	// Runtime State
 	bool TryStartKill();
 	bool TryStartRevive(float InReviveHP);
 
 private:
+	// Query
 	bool IsCombatActionType(EActionType InActionType) const;
 
 private:

--- a/Source/Portfolio/Character/Enemy/CEnemy.h
+++ b/Source/Portfolio/Character/Enemy/CEnemy.h
@@ -156,18 +156,10 @@ private:
 	// Runtime LOD
 	void UpdateRuntimeLODMeshMode();
 	void UpdateRuntimeLODActorTickMode();
-
-	// Lifecycle
 	void CacheRuntimeLODActorTickOriginalState();
-
-	// Dispatch
 	void ApplyRuntimeLODActorTickMode(int32 InActorTickMode);
-
-	// Actor Tick Mode
 	void ApplyRuntimeLODActorTickDefault();
 	void ApplyRuntimeLODActorTickDisabled();
-
-	// Actor Tick State
 	void RestoreRuntimeLODActorTick();
 	void DisableRuntimeLODActorTick();
 
@@ -176,10 +168,11 @@ public:
 	void Tick(float DeltaTime) override;
 
 public:
+	// Input
 	void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 
 public:
-	// Query
+	// Component Query
 	FORCEINLINE UCMovementComponent* GetMovementComp() const { return MovementComponent; }
 	FORCEINLINE UCWeaponComponent* GetWeaponComp() const { return WeaponComponent; }
 	FORCEINLINE UCStateComponent* GetStateComp() const { return StateComponent; }
@@ -195,6 +188,7 @@ public:
 	FORCEINLINE UCActionFeedbackComponent* GetActionFeedbackComp() const { return ActionFeedbackComponent; }
 
 public:
+	// AI Config Query
 	FORCEINLINE bool ShouldUsePatrol() const { return bUsePatrol; }
 	FORCEINLINE ACPatrolPath* GetPatrolPath() const { return PatrolPath; }
 	FORCEINLINE EPatrolMode GetPatrolMode() const { return PatrolMode; }
@@ -253,7 +247,7 @@ public:
 	bool TryStartRevive(float InReviveHP);
 
 private:
-	// Query
+	// Combat Action Query
 	bool IsCombatActionType(EActionType InActionType) const;
 
 private:

--- a/Source/Portfolio/Character/Player/CPlayer.cpp
+++ b/Source/Portfolio/Character/Player/CPlayer.cpp
@@ -107,6 +107,8 @@ ACPlayer::ACPlayer()
 	check(ReactionFeedbackComponent);
 }
 
+// Lifecycle
+
 void ACPlayer::PostInitializeComponents()
 {
 	Super::PostInitializeComponents();
@@ -137,6 +139,8 @@ void ACPlayer::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 	Super::EndPlay(EndPlayReason);
 }
+
+// Component Reference
 
 void ACPlayer::RecoverReferences()
 {
@@ -209,10 +213,14 @@ void ACPlayer::InjectReferences(const FCharacterComponentReferences& InReference
 	FComponentReferenceHelper::InjectIfValid(ReactionFeedbackComponent, InReferences);
 }
 
+// Input
+
 void ACPlayer::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 {
 	Super::SetupPlayerInputComponent(PlayerInputComponent);
 }
+
+// Damage
 
 float ACPlayer::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
@@ -235,6 +243,8 @@ float ACPlayer::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, 
 
 	return finalDamage;
 }
+
+// Combat Result
 
 void ACPlayer::ReceiveCombatResultPacket(const FCombatResultPacket& InCombatResultPacket)
 {
@@ -281,6 +291,8 @@ bool ACPlayer::TryRequestParryStaggerReaction(const FCombatResultPacket& InComba
 
 	return bStarted;
 }
+
+// Movement Intent
 
 FActionRequestResult ACPlayer::HandleMove(const FVector2D& InAxis2D)
 {
@@ -354,6 +366,8 @@ FActionRequestResult ACPlayer::HandleStopJump()
 
 	return ActionOrchestratorComponent->RequestMovementAction(request);
 }
+
+// Action Intent
 
 FActionRequestResult ACPlayer::HandleEquipmentAction(EEquipmentActionIntent InEquipmentActionIntent)
 {

--- a/Source/Portfolio/Character/Player/CPlayer.h
+++ b/Source/Portfolio/Character/Player/CPlayer.h
@@ -92,9 +92,11 @@ private:
 	void InjectReferences(const FCharacterComponentReferences& InReferences);
 
 public:
+	// Input
 	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 
 public:
+	// Query
 	FORCEINLINE UCMovementComponent* GetMovementComp() const { return MovementComponent; }
 	FORCEINLINE UCWeaponComponent* GetWeaponComp() const { return WeaponComponent; }
 	FORCEINLINE UCStateComponent* GetStateComp() const { return StateComponent; }
@@ -111,9 +113,11 @@ public:
 	FORCEINLINE UCActionFeedbackComponent* GetActionFeedbackComp() const { return ActionFeedbackComponent; }
 
 public:
+	// Damage
 	virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, class AController* EventInstigator, class AActor* DamageCauser) override;
 
 public:
+	// Combat Result
 	void ReceiveCombatResultPacket(const FCombatResultPacket& InCombatResultPacket) override;
 
 private:
@@ -125,9 +129,11 @@ public:
 	int GetTargetPriority() const override { return Priority; }
 
 public:
+	// Movement Intent
 	FActionRequestResult HandleMove(const FVector2D& InAxis2D);
 
 public:
+	// Action Intent
 	FActionRequestResult HandleWalk();
 	FActionRequestResult HandleRun();
 	FActionRequestResult HandleSprint();

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -570,8 +570,7 @@ void UCActionComponent::BuildActionDataMap(bool bRebuildAll)
 {
 	if (!IsValid(OwnerCharacter_Injected)) return;
 
-	// bRebuildAll == true: Rebuild 
-	// bRebuildAll == false: Append
+	// Rebuild clears stale action data; append keeps the existing map.
 
 	if (bRebuildAll)
 	{
@@ -609,8 +608,7 @@ void UCActionComponent::BuildActionExecutorMap(bool bRebuildAll)
 {
 	if (!IsValid(OwnerCharacter_Injected)) return;
 
-	// bRebuildAll == true: Rebuild 
-	// bRebuildAll == false: Append
+	// Rebuild clears stale action executors; append keeps existing cache entries.
 
 	if (bRebuildAll)
 	{

--- a/Source/Portfolio/Component/CActionComponent.cpp
+++ b/Source/Portfolio/Component/CActionComponent.cpp
@@ -213,11 +213,11 @@ bool UCActionComponent::ResolveActionData(const FActionDataKey& InDataKey, FActi
 
 UCAction* UCActionComponent::ResolveActionExecutor(const FActionData& InData)
 {
-	// 1) Try reuse cached Action; return if valid
+	// Preferred: reuse cached action executor.
 	UCAction* found = FindActionExecutor(InData.ActionExecutorKey.Get());
 	if (IsValid(found)) return found;
 
-	// 2) Try add and cache Action; return if valid.
+	// Fallback: create and cache action executor.
 	UCAction* add = AddActionExecutor(InData.ActionExecutorKey);
 	if (IsValid(add)) return add;
 
@@ -624,14 +624,14 @@ void UCActionComponent::BuildActionExecutorMap(bool bRebuildAll)
 		UClass* executorKey = actionData.ActionExecutorKey.Get();
 		if (!IsValid(executorKey)) continue;
 
-		// 1) Find existing cached Reaction
+		// Preferred: keep existing cached action executor.
 		if (!bRebuildAll)
 		{
 			const UCAction* found = FindActionExecutor(executorKey);
 			if (IsValid(found)) continue;
 		}
 
-		// 2) Add cached Reaction
+		// Fallback: create cached action executor.
 		UCAction* add = AddActionExecutor(executorKey);
 		if (!IsValid(add))
 		{

--- a/Source/Portfolio/Component/CActionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CActionFeedbackComponent.cpp
@@ -17,6 +17,8 @@ UCActionFeedbackComponent::UCActionFeedbackComponent()
 {
 }
 
+// Component Reference
+
 void UCActionFeedbackComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -43,6 +45,8 @@ bool UCActionFeedbackComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+// Entry
+
 void UCActionFeedbackComponent::PlayFeedback(const FActionFeedbackRequest& InActionFeedbackRequest)
 {
 	if (!CanPlayActionFeedback(InActionFeedbackRequest)) return;
@@ -67,6 +71,8 @@ void UCActionFeedbackComponent::ClearRuntimeFeedback()
 	ToggleTrailActive(false);
 }
 
+// Query
+
 bool UCActionFeedbackComponent::CanPlayActionFeedback(const FActionFeedbackRequest& InActionFeedbackRequest) const
 {
 	if (!IsValid(OwnerCharacter_Injected))
@@ -87,6 +93,8 @@ bool UCActionFeedbackComponent::CanPlayActionFeedback(const FActionFeedbackReque
 
 	return true;
 }
+
+// Matching
 
 EActionFeedbackMatchTier UCActionFeedbackComponent::CalculateMatchTier(const FActionFeedbackMatchKey& InDataKey, EActionFeedbackTiming InDataTiming, FName InDataTriggerKey, const FActionFeedbackRequest& InActionFeedbackRequest) const
 {
@@ -114,6 +122,8 @@ EActionFeedbackMatchTier UCActionFeedbackComponent::CalculateMatchTier(const FAc
 	return EActionFeedbackMatchTier::None;
 }
 
+// Runtime Key / Playback Key
+
 FActionVFXPlaybackKey UCActionFeedbackComponent::BuildActionVFXPlaybackKey(const FActionVFXFeedbackData& InActionVFXFeedbackData) const
 {
 	FActionVFXPlaybackKey playbackKey;
@@ -137,6 +147,8 @@ FActionSFXPlaybackKey UCActionFeedbackComponent::BuildActionSFXPlaybackKey(const
 
 	return playbackKey;
 }
+
+// Execution
 
 void UCActionFeedbackComponent::ExecuteTrailFeedbacks(const FActionFeedbackRequest& InActionFeedbackRequest)
 {
@@ -271,6 +283,8 @@ void UCActionFeedbackComponent::ExecuteSFXFeedbacks(const FActionFeedbackRequest
 		PlayActionSFX(*data);
 	}
 }
+
+// Playback
 
 void UCActionFeedbackComponent::PlayActionVFX(const FActionVFXFeedbackData& InActionVFXFeedbackData)
 {

--- a/Source/Portfolio/Component/CActionFeedbackComponent.h
+++ b/Source/Portfolio/Component/CActionFeedbackComponent.h
@@ -40,25 +40,31 @@ private:
 	bool ValidateRequiredComponentReferences() const;
 
 public:
+	// Entry
 	void PlayFeedback(const FActionFeedbackRequest& InActionFeedbackRequest);
 	void ClearRuntimeFeedback();
 
 private:
+	// Query
 	bool CanPlayActionFeedback(const FActionFeedbackRequest& InActionFeedbackRequest) const;
 
 private:
+	// Matching
 	EActionFeedbackMatchTier CalculateMatchTier(const FActionFeedbackMatchKey& InDataKey, EActionFeedbackTiming InDataTiming, FName InDataTriggerKey, const FActionFeedbackRequest& InActionFeedbackRequest) const;
 
 private:
+	// Runtime Key / Playback Key
 	FActionVFXPlaybackKey BuildActionVFXPlaybackKey(const FActionVFXFeedbackData& InActionVFXFeedbackData) const;
 	FActionSFXPlaybackKey BuildActionSFXPlaybackKey(const FActionSFXFeedbackData& InActionSFXFeedbackData) const;
 
 private:
+	// Execution
 	void ExecuteTrailFeedbacks(const FActionFeedbackRequest& InActionFeedbackRequest);
 	void ExecuteVFXFeedbacks(const FActionFeedbackRequest& InActionFeedbackRequest);
 	void ExecuteSFXFeedbacks(const FActionFeedbackRequest& InActionFeedbackRequest);
 
 private:
+	// Playback
 	void PlayActionVFX(const FActionVFXFeedbackData& InActionVFXFeedbackData);
 	void PlayActionSFX(const FActionSFXFeedbackData& InActionSFXFeedbackData);
 	void ToggleTrailActive(bool bActive);

--- a/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
+++ b/Source/Portfolio/Component/CActionOrchestratorComponent.cpp
@@ -520,7 +520,7 @@ FExecutionParticipant UCActionOrchestratorComponent::BuildActiveExecutionPartici
 		return participant;
 	}
 
-	// 01. Active Reaction Case
+	// Preferred: active reaction participant.
 	if (bHasActiveReaction)
 	{
 		FReactionData activeData;
@@ -544,7 +544,7 @@ FExecutionParticipant UCActionOrchestratorComponent::BuildActiveExecutionPartici
 		}
 	}
 
-	// 02. Active Action Case
+	// Fallback: active action participant.
 	if (bHasActiveAction)
 	{
 		FActionData activeData;

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -185,51 +185,49 @@ bool UCCombatSignalSourceComponent::ValidateRequest(const FHitContext& InHitCont
 {
 	const FOverlapContext& overlapContext = InHitContext.OverlapContext;
 
-	// V1: Validate core actors (OwnerActor / DamageCauser / OtherActor)
+	// Gate: core actors must be valid.
 	if (!overlapContext.IsValidMinimal())
 	{
 		FCombatSignalDebug::RecordSourceHitRequestRejectedForAudit(InHitContext, TEXT("InvalidMinimalOverlapContext"));
 		return false;
 	}
 
-	// V2: Check Valid Hit Window
+	// Gate: hit window must be open.
 	if (overlapContext.HitWindowId == INDEX_NONE)
 	{
 		FCombatSignalDebug::RecordSourceHitRequestRejectedForAudit(InHitContext, TEXT("InvalidHitWindow"));
 		return false;
 	}
 
-	// V3: Check Valid Object
-	// 3-1): Validate Components (current policy)
+	// Gate: overlap components must be valid.
 	if (!IsValid(overlapContext.OverlappedComponent) || !IsValid(overlapContext.OtherComponent))
 	{
 		FCombatSignalDebug::RecordSourceHitRequestRejectedForAudit(InHitContext, TEXT("InvalidOverlapComponent"));
 		return false;
 	}
 
-	// 3-2): Attack collision must be ShapeComponent (current policy)
+	// Gate: attack collision must be a shape component.
 	if (!IsValid(overlapContext.OverlapShape))
 	{
 		FCombatSignalDebug::RecordSourceHitRequestRejectedForAudit(InHitContext, TEXT("InvalidOverlapShape"));
 		return false;
 	}
 
-	// V4: Check ownership
-	 // 4-1) DamageCauser must be owned by the attacker
+	// Gate: damage causer must be owned by the attacker.
 	if (overlapContext.DamageCauser->GetOwner() != overlapContext.OwnerActor)
 	{
 		FCombatSignalDebug::RecordSourceHitRequestRejectedForAudit(InHitContext, TEXT("DamageCauserOwnerMismatch"));
 		return false;
 	}
 
-	// 4-2) OverlappedComponent must belong to the DamageCauser
+	// Gate: overlapped component must belong to the damage causer.
 	if (overlapContext.OverlappedComponent->GetOwner() != overlapContext.DamageCauser)
 	{
 		FCombatSignalDebug::RecordSourceHitRequestRejectedForAudit(InHitContext, TEXT("OverlappedComponentOwnerMismatch"));
 		return false;
 	}
 
-	// 4-3) OtherComponent must belong to the target actor
+	// Gate: other component must belong to the target actor.
 	if (overlapContext.OtherComponent->GetOwner() != overlapContext.OtherActor)
 	{
 		FCombatSignalDebug::RecordSourceHitRequestRejectedForAudit(InHitContext, TEXT("OtherComponentOwnerMismatch"));
@@ -499,11 +497,11 @@ AController* UCCombatSignalSourceComponent::ResolveInstigatorController(AActor* 
 {
 	if (IsValid(InAttacker))
 	{
-		// 1) Preferred: attacker-provided instigator
+		// Preferred: attacker-provided instigator.
 		if (AController* attackerInstigator = InAttacker->GetInstigatorController())
 			return attackerInstigator;
 
-		// 2) Fallback: attacker is a pawn/character
+		// Fallback: attacker pawn controller.
 		if (APawn* attackerPawn = Cast<APawn>(InAttacker))
 		{
 			if (AController* attackerController = attackerPawn->GetController())
@@ -513,17 +511,17 @@ AController* UCCombatSignalSourceComponent::ResolveInstigatorController(AActor* 
 
 	if (IsValid(InDamageCauser))
 	{
-		// 3) Fallback: causer-provided instigator
+		// Fallback: causer-provided instigator.
 		if (AController* causerInstigator = InDamageCauser->GetInstigatorController())
 			return causerInstigator;
 
 		if (AActor* causerOwner = InDamageCauser->GetOwner())
 		{
-			// 4) Fallback: owner of the causer provides the instigator
+			// Fallback: causer owner-provided instigator.
 			if (AController* ownerInstigator = causerOwner->GetInstigatorController())
 				return ownerInstigator;
 
-			// 5) Final fallback: owner of the causer is a pawn/character
+			// Final fallback: causer owner pawn controller.
 			if (APawn* ownerPawn = Cast<APawn>(causerOwner))
 			{
 				if (AController* ownerController = ownerPawn->GetController())

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -53,7 +53,7 @@ bool UCCombatSignalSourceComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
-// HitWindow
+// Hit Window
 
 void UCCombatSignalSourceComponent::NotifyHitWindowOpened(AActor* InDamageCauser, int32 InHitWindowId)
 {
@@ -106,7 +106,7 @@ bool UCCombatSignalSourceComponent::RequestCombatSignalCue(AActor* InTargetActor
 	return SendCueSignal(combatSignal);
 }
 
-// Entry for AI
+// AI Entry
 
 bool UCCombatSignalSourceComponent::RequestAICombatSignalCue(FName InCueTag)
 {

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.cpp
@@ -27,6 +27,8 @@ UCCombatSignalSourceComponent::UCCombatSignalSourceComponent()
 {
 }
 
+// Component Reference
+
 void UCCombatSignalSourceComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -51,6 +53,8 @@ bool UCCombatSignalSourceComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+// HitWindow
+
 void UCCombatSignalSourceComponent::NotifyHitWindowOpened(AActor* InDamageCauser, int32 InHitWindowId)
 {
 	if (!IsValid(InDamageCauser)) return;
@@ -60,7 +64,7 @@ void UCCombatSignalSourceComponent::NotifyHitWindowOpened(AActor* InDamageCauser
 	hitWindowKey.DamageCauser = InDamageCauser;
 	hitWindowKey.HitWindowId = InHitWindowId;
 
-	// Reset stale record for the same hit window key
+	// Reset stale record for the same hit window key.
 	DamagedTargetContainer.Remove(hitWindowKey);
 	DamagedTargetContainer.FindOrAdd(hitWindowKey);
 }
@@ -76,6 +80,8 @@ void UCCombatSignalSourceComponent::NotifyHitWindowClosed(AActor* InDamageCauser
 
 	DamagedTargetContainer.Remove(hitWindowKey);
 }
+
+// Entry
 
 void UCCombatSignalSourceComponent::RequestCombatSignalSource(const FHitContext& InHitContext)
 {
@@ -100,6 +106,8 @@ bool UCCombatSignalSourceComponent::RequestCombatSignalCue(AActor* InTargetActor
 	return SendCueSignal(combatSignal);
 }
 
+// Entry for AI
+
 bool UCCombatSignalSourceComponent::RequestAICombatSignalCue(FName InCueTag)
 {
 	FCombatCollisionProfilingCounters::RecordAICombatSignalCueRequest();
@@ -117,6 +125,8 @@ bool UCCombatSignalSourceComponent::RequestAICombatSignalCue(FName InCueTag)
 
 	return RequestCombatSignalCue(targetActor, InCueTag, cueLocation, cueDirection, OwnerCharacter_Injected);
 }
+
+// Entry
 
 void UCCombatSignalSourceComponent::ProcessCombatSignalSource(const FHitContext& InHitContext)
 {
@@ -180,6 +190,8 @@ bool UCCombatSignalSourceComponent::ShouldSkipEnemyHitProcessingForProfiling() c
 {
 	return FCombatCollisionProfiling::ShouldSkipEnemyHitProcessing(OwnerCharacter_Injected);
 }
+
+// Receive
 
 bool UCCombatSignalSourceComponent::ValidateRequest(const FHitContext& InHitContext) const
 {
@@ -267,6 +279,8 @@ FCombatSignalSourceContext UCCombatSignalSourceComponent::BuildContext(const FCo
 
 	return combatSignalSourceContext;
 }
+
+// Resolve
 
 bool UCCombatSignalSourceComponent::ValidateContext(FCombatSignalSourceContext& InOutCombatSignalSourceContext) const
 {
@@ -390,6 +404,8 @@ FCombatSignalSourceResult UCCombatSignalSourceComponent::BuildResult(const FComb
 	return combatSignalSourceResult;
 }
 
+// Send
+
 void UCCombatSignalSourceComponent::CommitCombatSignalSource(FCombatSignalSourceContext& InOutCombatSignalSourceContext)
 {
 	FCombatCollisionProfilingCounters::RecordCombatSignal();
@@ -460,6 +476,8 @@ bool UCCombatSignalSourceComponent::SendCueSignal(const FCombatSignal& InCombatS
 	FCombatSignalDebug::RecordCueAcceptedForAudit(InCombatSignal);
 	return true;
 }
+
+// Cache
 
 void UCCombatSignalSourceComponent::CacheDamagedTargetInWindow(const FCombatSignalSourceContext& InCombatSignalSourceContext)
 {

--- a/Source/Portfolio/Component/CCombatSignalSourceComponent.h
+++ b/Source/Portfolio/Component/CCombatSignalSourceComponent.h
@@ -37,7 +37,7 @@ private:
 	bool ValidateRequiredComponentReferences() const;
 
 public:
-	// HitWindow
+	// Hit Window
 	void NotifyHitWindowOpened(AActor* InDamageCauser, int32 InHitWindowId);
 	void NotifyHitWindowClosed(AActor* InDamageCauser, int32 InHitWindowId);
 
@@ -47,7 +47,7 @@ public:
 	bool RequestCombatSignalCue(AActor* InTargetActor, FName InCueTag, const FVector& InCueLocation = FVector::ZeroVector, const FVector& InDirection = FVector::ZeroVector, AActor* InSignalCauser = nullptr);
 
 public:
-	// Entry for AI
+	// AI Entry
 	bool RequestAICombatSignalCue(FName InCueTag);
 
 private:

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -311,7 +311,7 @@ bool UCCombatSignalTargetComponent::ValidateContext(FCombatSignalTargetContext& 
 
 bool UCCombatSignalTargetComponent::CanReceiveCombatSignal(FCombatSignalTargetContext& InOutCombatSignalTargetContext) const
 {
-	// Gate 1: already dead
+	// Gate: already dead.
 	if (InOutCombatSignalTargetContext.DeadState_Before != EDeadState::Alive)
 	{
 		InOutCombatSignalTargetContext.bAccepted = false;
@@ -320,7 +320,7 @@ bool UCCombatSignalTargetComponent::CanReceiveCombatSignal(FCombatSignalTargetCo
 		return false;
 	}
 
-	// Gate 2: Parry window intercepts incoming damage before damage commit.
+	// Gate: parry window intercepts incoming damage before damage commit.
 	if (IsValid(DefenseComp_Injected) && DefenseComp_Injected->CanParry())
 	{
 		InOutCombatSignalTargetContext.bAccepted = true;
@@ -510,33 +510,33 @@ void UCCombatSignalTargetComponent::DispatchCombatResultToReceiver(const FCombat
 
 AController* UCCombatSignalTargetComponent::ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const
 {
-	// 1) Best case: engine provided instigator
+	// Preferred: engine-provided instigator.
 	if (IsValid(EventInstigator))
 		return EventInstigator;
 
-	// 2) Fallback needs a valid causer
+	// Gate: fallback requires a valid causer.
 	if (!IsValid(DamageCauser))
 		return nullptr;
 
-	// 2-1) Case 01: Explicit instigator set on the causer (ex. projectile / weaponActor / trap)
+	// Fallback: causer-provided instigator.
 	if (AController* causerInstigator = DamageCauser->GetInstigatorController())
 		return causerInstigator;
 
-	// 2-2) Case 02: Direct hit (the causer itself is a Pawn/Character)
+	// Fallback: causer pawn controller.
 	if (APawn* causerPawn = Cast<APawn>(DamageCauser))
 	{
 		if (AController* causerController = causerPawn->GetController())
 			return causerController;
 	}
 
-	// 2-3) Case 03: Proxy case (projectile / trap / weaponActor owned by another actor)
+	// Fallback: proxy causer owner.
 	if (AActor* causerOwner = DamageCauser->GetOwner())
 	{
-		// 2-3-1) Case 03-01: Owner is the carrier and holds the correct instigator (ex. projectile / weaponActor / trap)
+		// Fallback: causer owner-provided instigator.
 		if (AController* ownerInstigator = causerOwner->GetInstigatorController())
 			return ownerInstigator;
 
-		// 2-3-1) Case 03-02: Fallback (Owner is Pawn/Character)
+		// Final fallback: causer owner pawn controller.
 		if (APawn* ownerPawn = Cast<APawn>(causerOwner))
 		{
 			if (AController* ownerController = ownerPawn->GetController())

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -181,7 +181,7 @@ bool UCCombatSignalTargetComponent::HandleTimingCueSignal(const FCombatSignal& I
 		return true;
 	}
 
-	// V1 hook only. Blink / Repulse evaluation and effects are added in separate branches.
+	// Only Blink and Repulse timing cues are supported in this pass.
 	FCombatSignalDebug::RecordTimingCueRejectedForAudit(InCombatSignal, TEXT("UnknownCueTag"));
 	return false;
 }

--- a/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
+++ b/Source/Portfolio/Component/CCombatSignalTargetComponent.cpp
@@ -27,6 +27,8 @@ UCCombatSignalTargetComponent::UCCombatSignalTargetComponent()
 {
 }
 
+// Component Reference
+
 void UCCombatSignalTargetComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -57,6 +59,8 @@ bool UCCombatSignalTargetComponent::ValidateRequiredComponentReferences() const
 
 	return bValid;
 }
+
+// Entry
 
 float UCCombatSignalTargetComponent::RequestCombatSignalTarget(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
@@ -182,6 +186,8 @@ bool UCCombatSignalTargetComponent::HandleTimingCueSignal(const FCombatSignal& I
 	return false;
 }
 
+// Receive
+
 bool UCCombatSignalTargetComponent::ValidateRequest(const FDefaultDamageEvent& InDefaultDamageEvent, AController* InDamageInstigator, AActor* InDamageCauser)
 {
 	if (!IsValid(OwnerCharacter_Injected))
@@ -268,6 +274,8 @@ FCombatSignalTargetContext UCCombatSignalTargetComponent::BuildContext(const FCo
 
 	return combatSignalTargetContext;
 }
+
+// Evaluate
 
 bool UCCombatSignalTargetComponent::ValidateContext(FCombatSignalTargetContext& InOutCombatSignalTargetContext)
 {
@@ -413,6 +421,8 @@ FCombatSignalTargetResult UCCombatSignalTargetComponent::BuildResult(const FComb
 	return combatSignalTargetResult;
 }
 
+// Apply
+
 void UCCombatSignalTargetComponent::CommitCombatSignalTarget(FCombatSignalTargetContext& InOutCombatSignalTargetContext)
 {
 	if (!IsValid(HealthComp_Injected)) return;
@@ -425,6 +435,8 @@ void UCCombatSignalTargetComponent::CommitCombatSignalTarget(FCombatSignalTarget
 	InOutCombatSignalTargetContext.HealthPointAfter = HealthComp_Injected->GetCurrentHP();
 }
 
+// Packet
+
 FCombatSignalTargetPacket UCCombatSignalTargetComponent::BuildPacket(const FCombatSignalTargetPayload& InCombatSignalTargetPayload, const FCombatSignalTargetContext& InCombatSignalTargetContext, const FCombatSignalTargetResult& InCombatSignalTargetResult) const
 {
 	FCombatSignalTargetPacket combatSignalTargetPacket;
@@ -435,6 +447,8 @@ FCombatSignalTargetPacket UCCombatSignalTargetComponent::BuildPacket(const FComb
 
 	return combatSignalTargetPacket;
 }
+
+// Notify
 
 void UCCombatSignalTargetComponent::DispatchAcceptedCombatResult(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const
 {
@@ -491,6 +505,8 @@ void UCCombatSignalTargetComponent::DispatchCombatResultToReceiver(const FCombat
 
 	FCombatSignalDebug::RecordCombatResultDispatchForAudit(InCombatSignalTargetPacket, combatResultPacket, receiverActor, TEXT("Delivered"));
 }
+
+// Helper
 
 AController* UCCombatSignalTargetComponent::ResolveInstigatorController(AController* EventInstigator, AActor* DamageCauser) const
 {

--- a/Source/Portfolio/Component/CDefenseComponent.cpp
+++ b/Source/Portfolio/Component/CDefenseComponent.cpp
@@ -11,6 +11,8 @@ UCDefenseComponent::UCDefenseComponent()
 	PrimaryComponentTick.bCanEverTick = false;
 }
 
+// Component Reference
+
 void UCDefenseComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;

--- a/Source/Portfolio/Component/CHealthComponent.cpp
+++ b/Source/Portfolio/Component/CHealthComponent.cpp
@@ -10,6 +10,8 @@ UCHealthComponent::UCHealthComponent()
 {
 }
 
+// Component Reference
+
 void UCHealthComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -34,6 +36,8 @@ bool UCHealthComponent::ValidateRequiredComponentReferences() const
 
 	return bValid;
 }
+
+// State Transition
 
 void UCHealthComponent::InitializeHealth(float InInitMaxHP, float InInitCurrentHP, EMaxHPUpdatePolicy InUpdatePolicy)
 {
@@ -128,6 +132,8 @@ bool UCHealthComponent::TryUpdateMaxHP(float InNewMaxHP, EMaxHPUpdatePolicy InUp
 	return true;
 }
 
+// Health Change
+
 float UCHealthComponent::TakeDamage(float InTakeDamageAmount)
 {
 	if (!IsAlive()) return 0.f;
@@ -173,6 +179,8 @@ float UCHealthComponent::TakeHeal(float InTakeHealAmount)
 	return takenHeal;
 }
 
+// Query
+
 bool UCHealthComponent::IsAlive() const
 {
 	return DeadState == EDeadState::Alive;
@@ -193,6 +201,8 @@ bool UCHealthComponent::CanRevive() const
 	return IsDead();
 }
 
+// State Transition
+
 void UCHealthComponent::EnterDeadState()
 {
 	ChangeDeadState(EDeadState::Dead);
@@ -202,6 +212,8 @@ void UCHealthComponent::EnterAliveState()
 {
 	ChangeDeadState(EDeadState::Alive);
 }
+
+// Notify Routing
 
 void UCHealthComponent::HandleDeadStateNotify(EDeadState InDeadState)
 {

--- a/Source/Portfolio/Component/CHealthComponent.h
+++ b/Source/Portfolio/Component/CHealthComponent.h
@@ -55,9 +55,6 @@ private:
 	bool ValidateRequiredComponentReferences() const;
 
 public:
-	void InitializeHealth(float InInitMaxHP, float InInitCurrentHP, EMaxHPUpdatePolicy InUpdatePolicy);
-
-public:
 	// State Transition
 	void InitializeHealth(float InInitMaxHP, float InInitCurrentHP, EMaxHPUpdatePolicy InUpdatePolicy);
 	bool TryKill();

--- a/Source/Portfolio/Component/CHealthComponent.h
+++ b/Source/Portfolio/Component/CHealthComponent.h
@@ -59,12 +59,14 @@ public:
 
 public:
 	// State Transition
+	void InitializeHealth(float InInitMaxHP, float InInitCurrentHP, EMaxHPUpdatePolicy InUpdatePolicy);
 	bool TryKill();
 	bool TryRevive(float InReviveHP);
 	bool TryCancelRevive();
 	bool TryUpdateMaxHP(float InNewMaxHP, EMaxHPUpdatePolicy InUpdatePolicy);
 
 public:
+	// Health Change
 	float TakeDamage(float InTakeDamageAmount);
 	float TakeHeal(float InTakeHealAmount);
 
@@ -82,6 +84,7 @@ public:
 	EDeadState GetDeadState() const { return DeadState; }
 
 public:
+	// State Transition
 	void EnterDeadState();
 	void EnterAliveState();
 

--- a/Source/Portfolio/Component/CHitFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CHitFeedbackComponent.cpp
@@ -19,6 +19,8 @@ UCHitFeedbackComponent::UCHitFeedbackComponent()
 {
 }
 
+// Component Reference
+
 void UCHitFeedbackComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -43,6 +45,8 @@ bool UCHitFeedbackComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+// Entry
+
 void UCHitFeedbackComponent::PlayHitFeedback(const FCombatSignalTargetPacket& InCombatSignalTargetPacket)
 {
 	if (!CanPlayHitFeedback(InCombatSignalTargetPacket)) return;
@@ -63,6 +67,8 @@ void UCHitFeedbackComponent::PlayHitFeedback(const FCombatSignalTargetPacket& In
 	PlayHitSFX(InCombatSignalTargetPacket);
 	PlayCameraShake(InCombatSignalTargetPacket);
 }
+
+// Playback
 
 void UCHitFeedbackComponent::PlayHitStop(const FCombatSignalTargetPacket& InCombatSignalTargetPacket)
 {
@@ -149,6 +155,8 @@ void UCHitFeedbackComponent::PlayCameraShake(const FCombatSignalTargetPacket& In
 
 	feedbackSubsystem->RequestCameraShake(cameraShakeRequest);
 }
+
+// Query
 
 bool UCHitFeedbackComponent::CanPlayHitFeedback(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const
 {
@@ -245,6 +253,8 @@ bool UCHitFeedbackComponent::CanPlayCameraShake(const FCombatSignalTargetPacket&
 	return true;
 }
 
+// Resolve
+
 FVector UCHitFeedbackComponent::ResolveHitFeedbackLocation(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const
 {
 	const FHitImpactContext& damageHitInfo = InCombatSignalTargetPacket.Context.HitImpactContext;
@@ -268,6 +278,8 @@ FRotator UCHitFeedbackComponent::ResolveHitFeedbackRotation(const FCombatSignalT
 
 	return IsValid(OwnerCharacter_Injected) ? OwnerCharacter_Injected->GetActorRotation() : FRotator::ZeroRotator;
 }
+
+// Request
 
 FHitStopRequest UCHitFeedbackComponent::BuildHitStopRequest(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const
 {

--- a/Source/Portfolio/Component/CHitFeedbackComponent.h
+++ b/Source/Portfolio/Component/CHitFeedbackComponent.h
@@ -56,24 +56,29 @@ private:
 	bool ValidateRequiredComponentReferences() const;
 
 public:
+	// Entry
 	void PlayHitFeedback(const FCombatSignalTargetPacket& InCombatSignalTargetPacket);
 
 private:
+	// Playback
 	void PlayHitStop(const FCombatSignalTargetPacket& InCombatSignalTargetPacket);
 	void PlayHitVFX(const FCombatSignalTargetPacket& InCombatSignalTargetPacket);
 	void PlayHitSFX(const FCombatSignalTargetPacket& InCombatSignalTargetPacket);
 	void PlayCameraShake(const FCombatSignalTargetPacket& InCombatSignalTargetPacket);
 
 private:
+	// Query
 	bool CanPlayHitFeedback(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const;
 	bool CanPlayHitStop(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const;
 	bool CanPlayCameraShake(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const;
 
 private:
+	// Resolve
 	FVector ResolveHitFeedbackLocation(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const;
 	FRotator ResolveHitFeedbackRotation(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const;
 
 private:
+	// Request
 	FHitStopRequest BuildHitStopRequest(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const;
 	FCameraShakeRequest BuildCameraShakeRequest(const FCombatSignalTargetPacket& InCombatSignalTargetPacket) const;
 };

--- a/Source/Portfolio/Component/CMovementComponent.cpp
+++ b/Source/Portfolio/Component/CMovementComponent.cpp
@@ -413,7 +413,7 @@ void UCMovementComponent::CalculateDirection()
 		float angleRad = FMath::Acos(FVector::DotProduct(forwardNormal, velocityNormal));
 		float angleDeg = FMath::RadiansToDegrees(angleRad);
 
-		// determine left or right
+		// Determine left or right from the movement input basis.
 		FVector crossProduct = FVector::CrossProduct(forwardNormal, velocityNormal);
 		if (crossProduct.Z < 0)
 		{

--- a/Source/Portfolio/Component/CMovementComponent.cpp
+++ b/Source/Portfolio/Component/CMovementComponent.cpp
@@ -16,6 +16,8 @@ UCMovementComponent::UCMovementComponent()
 	PrimaryComponentTick.bStartWithTickEnabled = true;
 }
 
+// Component Reference
+
 void UCMovementComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -44,6 +46,8 @@ bool UCMovementComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+// Lifecycle
+
 void UCMovementComponent::BeginPlay()
 {
 	Super::BeginPlay();
@@ -64,6 +68,8 @@ void UCMovementComponent::TickComponent(float DeltaTime, ELevelTick TickType, FA
 
 	bIsFalling = CharacterMovementComp_Injected->IsFalling();
 }
+
+// Runtime LOD
 
 void UCMovementComponent::UpdateRuntimeLODMovementMode()
 {
@@ -141,6 +147,8 @@ void UCMovementComponent::DisableRuntimeLODMovementStateRefresh()
 	SetComponentTickEnabled(false);
 }
 
+// Movement State
+
 void UCMovementComponent::AllowRuntimeLODMovementIntent()
 {
 	if (bRuntimeLODMovementIntentBlocked)
@@ -170,6 +178,8 @@ void UCMovementComponent::StopRuntimeLODActiveMovement()
 	aiController->StopMovement();
 }
 
+// Movement Arbitration
+
 // Final movement gate for axis input accepted by the orchestrator.
 bool UCMovementComponent::CanAcceptMoveInput() const
 {
@@ -197,6 +207,8 @@ void UCMovementComponent::ClearMovementIntentBlockForRuntimeLOD()
 {
 	bRuntimeLODMovementIntentBlocked = false;
 }
+
+// Movement Input
 
 void UCMovementComponent::OnMove(const FVector2D& InAxis2D)
 {
@@ -283,6 +295,8 @@ void UCMovementComponent::OnStopJump()
 
 	OwnerCharacter_Injected->StopJumping();
 }
+
+// Movement Policy
 
 void UCMovementComponent::ApplyMovementOverride(EMovementGait InGait, EMovementRotationMode InRotationMode)
 {
@@ -372,6 +386,8 @@ void UCMovementComponent::ApplyRotationMode(EMovementRotationMode InRotationMode
 		break;
 	}
 }
+
+// Runtime State
 
 void UCMovementComponent::CalculateSpeed()
 {

--- a/Source/Portfolio/Component/CMovementComponent.h
+++ b/Source/Portfolio/Component/CMovementComponent.h
@@ -81,19 +81,11 @@ protected:
 private:
 	// Runtime LOD
 	void UpdateRuntimeLODMovementMode();
-
-	// Lifecycle
 	void EnsureRuntimeLODMovementOriginalStateCached();
-
-	// Dispatch
 	void ApplyRuntimeLODMovementMode(int32 InMovementMode);
-
-	// Movement Mode
 	void ApplyRuntimeLODMovementDefault();
 	void ApplyRuntimeLODMovementStateRefreshDisabled();
 	void ApplyRuntimeLODMovementIntentBlocked();
-
-	// Movement State
 	void RestoreRuntimeLODMovementStateRefresh();
 	void DisableRuntimeLODMovementStateRefresh();
 	void AllowRuntimeLODMovementIntent();
@@ -101,14 +93,10 @@ private:
 	void StopRuntimeLODActiveMovement();
 
 public:
-	// Check / Query
-	FORCEINLINE bool CheckCurrentMovementGait(EMovementGait InNewMovementGait) const { return CurrentMovementGait == InNewMovementGait; }
-
-public:
 	// Query
+	FORCEINLINE bool CheckCurrentMovementGait(EMovementGait InNewMovementGait) const { return CurrentMovementGait == InNewMovementGait; }
 	FORCEINLINE EMovementGait GetCurrentMovementGait() const { return CurrentMovementGait; }
 
-public:
 	FORCEINLINE bool CanMove() const { return bCanMove; }
 	FORCEINLINE bool IsFalling() const { return bIsFalling; }
 	FORCEINLINE float GetCurrentSpeed() const { return CurrentSpeed; }

--- a/Source/Portfolio/Component/CMovementComponent.h
+++ b/Source/Portfolio/Component/CMovementComponent.h
@@ -132,6 +132,7 @@ public:
 	void ClearMovementIntentBlockForRuntimeLOD();
 
 public:
+	// Movement Input
 	void OnMove(const FVector2D& InAxis2D);
 
 public:

--- a/Source/Portfolio/Component/CObservableOverlayComponent.cpp
+++ b/Source/Portfolio/Component/CObservableOverlayComponent.cpp
@@ -10,6 +10,8 @@ UCObservableOverlayComponent::UCObservableOverlayComponent()
 {
 }
 
+// Component Reference
+
 void UCObservableOverlayComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -36,6 +38,8 @@ bool UCObservableOverlayComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+// Overlay Snapshot
+
 void UCObservableOverlayComponent::WriteOverlaySnapshot(FObservableOverlaySnapshot& OutSnapshot)
 {
 	RefreshPolicyRegistry();
@@ -49,6 +53,8 @@ void UCObservableOverlayComponent::WriteOverlaySnapshot(FObservableOverlaySnapsh
 		overlayPolicy->WriteOverlaySnapshot(OutSnapshot);
 	}
 }
+
+// Overlay Event
 
 bool UCObservableOverlayComponent::ApplyOverlayEvent(const FObservableOverlayEventContext& InContext)
 {
@@ -67,6 +73,8 @@ bool UCObservableOverlayComponent::ApplyOverlayEvent(const FObservableOverlayEve
 
 	return false;
 }
+
+// Overlay Handling
 
 bool UCObservableOverlayComponent::ApplyOverlayHandlings(const TArray<EObservableOverlayHandling>& InHandlings)
 {
@@ -101,6 +109,8 @@ bool UCObservableOverlayComponent::ApplyOverlayHandling(EObservableOverlayHandli
 	FObservableOverlayDebug::RecordOverlayHandlingRejectedForAudit(OwnerCharacter_Injected, this, InHandling, TEXT("NoPolicyAccepted"));
 	return false;
 }
+
+// Policy Registry
 
 void UCObservableOverlayComponent::MarkPolicyRegistryDirty()
 {

--- a/Source/Portfolio/Component/CObservableOverlayComponent.h
+++ b/Source/Portfolio/Component/CObservableOverlayComponent.h
@@ -34,12 +34,18 @@ private:
 	bool ValidateRequiredComponentReferences() const;
 
 public:
+	// Overlay Snapshot
 	void WriteOverlaySnapshot(FObservableOverlaySnapshot& OutSnapshot);
+
+	// Overlay Event
 	bool ApplyOverlayEvent(const FObservableOverlayEventContext& InContext);
+
+	// Overlay Handling
 	bool ApplyOverlayHandlings(const TArray<EObservableOverlayHandling>& InHandlings);
 	bool ApplyOverlayHandling(EObservableOverlayHandling InHandling);
 
 private:
+	// Policy Registry
 	void MarkPolicyRegistryDirty();
 	void RefreshPolicyRegistry();
 	void RebuildPolicyRegistry();

--- a/Source/Portfolio/Component/CPlayerFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CPlayerFeedbackComponent.cpp
@@ -12,6 +12,8 @@ UCPlayerFeedbackComponent::UCPlayerFeedbackComponent()
 {
 }
 
+// Component Reference
+
 void UCPlayerFeedbackComponent::InitializeReferences(APlayerController* InOwnerPlayerController)
 {
 	OwnerPlayerController_Injected = InOwnerPlayerController;
@@ -35,6 +37,8 @@ bool UCPlayerFeedbackComponent::ValidateRequiredComponentReferences() const
 
 	return bValid;
 }
+
+// Lifecycle
 
 void UCPlayerFeedbackComponent::BeginPlay()
 {
@@ -61,6 +65,8 @@ void UCPlayerFeedbackComponent::EndPlay(const EEndPlayReason::Type EndPlayReason
 
 	Super::EndPlay(EndPlayReason);
 }
+
+// Camera Shake
 
 void UCPlayerFeedbackComponent::HandleCameraShakeRequest(const FCameraShakeRequest& InCameraShakeRequest)
 {

--- a/Source/Portfolio/Component/CPlayerFeedbackComponent.h
+++ b/Source/Portfolio/Component/CPlayerFeedbackComponent.h
@@ -24,11 +24,6 @@ private:
 	UPROPERTY(Transient)
 	class APlayerController* OwnerPlayerController_Injected = nullptr;
 
-protected:
-	// Lifecycle
-	virtual void BeginPlay() override;
-	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
-
 public:
 	// Component Reference
 	void InitializeReferences(class APlayerController* InOwnerPlayerController);
@@ -36,7 +31,13 @@ public:
 private:
 	bool ValidateRequiredComponentReferences() const;
 
+protected:
+	// Lifecycle
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
 public:
+	// Camera Shake
 	void HandleCameraShakeRequest(const FCameraShakeRequest& InCameraShakeRequest);
 
 private:

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -200,11 +200,11 @@ bool UCReactionComponent::ResolveReactionData(const FReactionDataKey& InDataKey,
 
 UCReaction* UCReactionComponent::ResolveReactionExecutor(const FReactionData& InData)
 {
-	// 1) Try reuse cached Reaction; return if valid
+	// Preferred: reuse cached reaction executor.
 	UCReaction* found = FindReactionExecutor(InData.ReactionExecutorKey.Get());
 	if (IsValid(found)) return found;
 
-	// 2) Try add and cache Reaction; return if valid.
+	// Fallback: create and cache reaction executor.
 	UCReaction* add = AddReactionExecutor(InData.ReactionExecutorKey);
 	if (IsValid(add)) return add;
 
@@ -512,14 +512,14 @@ void UCReactionComponent::BuildReactionExecutorMap(bool bRebuildAll)
 		UClass* executorKey = reactionData.ReactionExecutorKey.Get();
 		if (!IsValid(executorKey)) continue;
 
-		// 1) Find existing cached Reaction
+		// Preferred: keep existing cached reaction executor.
 		if (!bRebuildAll)
 		{
 			const UCReaction* found = FindReactionExecutor(executorKey);
 			if (IsValid(found)) continue;
 		}
 
-		// 2) Add cached Reaction
+		// Fallback: create cached reaction executor.
 		UCReaction* add = AddReactionExecutor(executorKey);
 		if (!IsValid(add))
 		{
@@ -578,17 +578,17 @@ void UCReactionComponent::BuildCandidateSpecKeys(const FDamageSpecKey& InSpecKey
 {
 	OutSpecKeys.Reset();
 
-	// 1) Exact: Weapon + Action + Index
+	// Exact: weapon, action, and index.
 	OutSpecKeys.Add(InSpecKey);
 
-	// 2) Any Index: Weapon + Action + AnyIndex
+	// Fallback: weapon and action with any index.
 	{
 		FDamageSpecKey candidateKey = InSpecKey;
 		candidateKey.ActionIndex = INDEX_NONE;
 		OutSpecKeys.Add(candidateKey);
 	}
 
-	// 3) Any Action: Weapon + AnyAction + AnyIndex
+	// Fallback: weapon with any action and any index.
 	{
 		FDamageSpecKey candidateKey = InSpecKey;
 		candidateKey.ActionType = EActionType::All;
@@ -596,7 +596,7 @@ void UCReactionComponent::BuildCandidateSpecKeys(const FDamageSpecKey& InSpecKey
 		OutSpecKeys.Add(candidateKey);
 	}
 
-	// 4) Any Weapon: AnyWeapon + AnyAction + AnyIndex
+	// Final fallback: any weapon, any action, and any index.
 	{
 		FDamageSpecKey candidateKey = InSpecKey;
 		candidateKey.WeaponType = EWeaponType::All;

--- a/Source/Portfolio/Component/CReactionComponent.cpp
+++ b/Source/Portfolio/Component/CReactionComponent.cpp
@@ -168,7 +168,7 @@ bool UCReactionComponent::ResolveReactionData(const FReactionDataKey& InDataKey,
 	TArray<FDamageSpecKey> candidateKeys;
 	EReactionType reactionType = InDataKey.ReactionType;
 	
-	// Candidate SpecKey
+	// Resolve candidate spec keys before data lookup.
 	BuildCandidateSpecKeys(InDataKey.DamageSpecKey, candidateKeys);
 
 	for (int32 candidateIndex = 0; candidateIndex < candidateKeys.Num(); ++candidateIndex)
@@ -458,8 +458,7 @@ void UCReactionComponent::BuildReactionDataMap(bool bRebuildAll)
 {
 	if (!IsValid(OwnerCharacter_Injected)) return;
 
-	// bRebuildAll == true: Rebuild 
-	// bRebuildAll == false: Append
+	// Rebuild clears stale reaction data; append keeps the existing map.
 
 	if (bRebuildAll)
 	{
@@ -497,8 +496,7 @@ void UCReactionComponent::BuildReactionExecutorMap(bool bRebuildAll)
 {
 	if (!IsValid(OwnerCharacter_Injected)) return;
 
-	// bRebuildAll == true: Rebuild 
-	// bRebuildAll == false: Append
+	// Rebuild clears stale reaction executors; append keeps existing cache entries.
 
 	if (bRebuildAll)
 	{

--- a/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
@@ -27,6 +27,8 @@ UCReactionFeedbackComponent::UCReactionFeedbackComponent()
 {
 }
 
+// Component Reference
+
 void UCReactionFeedbackComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -51,6 +53,8 @@ bool UCReactionFeedbackComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+// Entry
+
 void UCReactionFeedbackComponent::PlayFeedback(const FReactionFeedbackRequest& InReactionFeedbackRequest)
 {
 	if (!CanPlayReactionFeedback(InReactionFeedbackRequest)) return;
@@ -72,6 +76,8 @@ void UCReactionFeedbackComponent::PlayFeedback(const FReactionFeedbackRequest& I
 void UCReactionFeedbackComponent::ClearRuntimeFeedback()
 {
 }
+
+// Query
 
 bool UCReactionFeedbackComponent::CanPlayReactionFeedback(const FReactionFeedbackRequest& InReactionFeedbackRequest) const
 {
@@ -104,6 +110,8 @@ bool UCReactionFeedbackComponent::CanPlayReactionFeedback(const FReactionFeedbac
 
 	return true;
 }
+
+// Matching
 
 bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedbackMatchKey& InDataKey, EReactionFeedbackTiming InDataTiming, FName InDataTriggerKey, const FReactionFeedbackRequest& InReactionFeedbackRequest, int32& OutScore) const
 {
@@ -156,6 +164,8 @@ bool UCReactionFeedbackComponent::TryCalculateMatchScore(const FReactionFeedback
 	return true;
 }
 
+// Runtime Key / Playback Key
+
 FReactionVFXPlaybackKey UCReactionFeedbackComponent::BuildReactionVFXPlaybackKey(const FReactionVFXFeedbackData& InReactionVFXFeedbackData) const
 {
 	FReactionVFXPlaybackKey playbackKey;
@@ -179,6 +189,8 @@ FReactionSFXPlaybackKey UCReactionFeedbackComponent::BuildReactionSFXPlaybackKey
 
 	return playbackKey;
 }
+
+// Execution
 
 void UCReactionFeedbackComponent::ExecuteVFXFeedbacks(const FReactionFeedbackRequest& InReactionFeedbackRequest)
 {
@@ -297,6 +309,8 @@ void UCReactionFeedbackComponent::ExecuteSFXFeedbacks(const FReactionFeedbackReq
 		PlayReactionSFX(*matchedData);
 	}
 }
+
+// Playback
 
 void UCReactionFeedbackComponent::PlayReactionVFX(const FReactionVFXFeedbackData& InReactionVFXFeedbackData)
 {

--- a/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
@@ -11,7 +11,7 @@
 #include "NiagaraFunctionLibrary.h"
 #include "Sound/SoundBase.h"
 
-// Internal linkage
+// Helper
 namespace
 {
 	namespace ReactionFeedbackScore

--- a/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
+++ b/Source/Portfolio/Component/CReactionFeedbackComponent.cpp
@@ -208,7 +208,7 @@ void UCReactionFeedbackComponent::ExecuteVFXFeedbacks(const FReactionFeedbackReq
 
 		if (matchScore < bestScore) continue;
 
-		// New-High score: Reset and Update List
+		// Preferred: replace matches with the new highest score.
 		if (matchScore > bestScore)
 		{
 			bestScore = matchScore;
@@ -217,7 +217,7 @@ void UCReactionFeedbackComponent::ExecuteVFXFeedbacks(const FReactionFeedbackReq
 			continue;
 		}
 
-		// Tie score: Add to list
+		// Tie: keep all matches with the current best score.
 		matchedDatas.Add(&data);
 	}
 
@@ -267,7 +267,7 @@ void UCReactionFeedbackComponent::ExecuteSFXFeedbacks(const FReactionFeedbackReq
 
 		if (matchScore < bestScore) continue;
 
-		// New-High score: Reset and Update List
+		// Preferred: replace matches with the new highest score.
 		if (matchScore > bestScore)
 		{
 			bestScore = matchScore;
@@ -276,7 +276,7 @@ void UCReactionFeedbackComponent::ExecuteSFXFeedbacks(const FReactionFeedbackReq
 			continue;
 		}
 
-		// Tie score: Add to list
+		// Tie: keep all matches with the current best score.
 		matchedDatas.Add(&data);
 	}
 

--- a/Source/Portfolio/Component/CReactionFeedbackComponent.h
+++ b/Source/Portfolio/Component/CReactionFeedbackComponent.h
@@ -34,24 +34,30 @@ private:
 	bool ValidateRequiredComponentReferences() const;
 
 public:
+	// Entry
 	void PlayFeedback(const FReactionFeedbackRequest& InReactionFeedbackRequest);
 	void ClearRuntimeFeedback();
 
 private:
+	// Query
 	bool CanPlayReactionFeedback(const FReactionFeedbackRequest& InReactionFeedbackRequest) const;
 
 private:
+	// Matching
 	bool TryCalculateMatchScore(const FReactionFeedbackMatchKey& InDataKey, EReactionFeedbackTiming InDataTiming, FName InDataTriggerKey, const FReactionFeedbackRequest& InReactionFeedbackRequest, int32& OutScore) const;
 
 private:
+	// Runtime Key / Playback Key
 	FReactionVFXPlaybackKey BuildReactionVFXPlaybackKey(const FReactionVFXFeedbackData& InReactionVFXFeedbackData) const;
 	FReactionSFXPlaybackKey BuildReactionSFXPlaybackKey(const FReactionSFXFeedbackData& InReactionSFXFeedbackData) const;
 
 private:
+	// Execution
 	void ExecuteVFXFeedbacks(const FReactionFeedbackRequest& InReactionFeedbackRequest);
 	void ExecuteSFXFeedbacks(const FReactionFeedbackRequest& InReactionFeedbackRequest);
 
 private:
+	// Playback
 	void PlayReactionVFX(const FReactionVFXFeedbackData& InReactionVFXFeedbackData);
 	void PlayReactionSFX(const FReactionSFXFeedbackData& InReactionSFXFeedbackData);
 };

--- a/Source/Portfolio/Component/CReactionOrchestratorComponent.cpp
+++ b/Source/Portfolio/Component/CReactionOrchestratorComponent.cpp
@@ -333,7 +333,7 @@ FExecutionParticipant UCReactionOrchestratorComponent::BuildActiveExecutionParti
 		return participant;
 	}
 
-	// 01. Active Reaction Case
+	// Preferred: active reaction participant.
 	if (bHasActiveReaction)
 	{
 		FReactionData activeData;
@@ -357,7 +357,7 @@ FExecutionParticipant UCReactionOrchestratorComponent::BuildActiveExecutionParti
 		}
 	}
 
-	// 02. Active Action Case
+	// Fallback: active action participant.
 	if (bHasActiveAction)
 	{
 		FActionData activeData;

--- a/Source/Portfolio/Component/CReactionOrchestratorComponent.cpp
+++ b/Source/Portfolio/Component/CReactionOrchestratorComponent.cpp
@@ -275,7 +275,7 @@ UCReaction* UCReactionOrchestratorComponent::ResolveReactionExecutor(const FReac
 	if (!IsValid(ReactionComp_Injected)) return nullptr;
 	if (!InIncomingData.IsValidMinimal()) return nullptr;
 
-	// Resolve Executor
+	// Resolve the executor from the selected reaction data.
 	return ReactionComp_Injected->ResolveReactionExecutor(InIncomingData);
 }
 

--- a/Source/Portfolio/Component/CStateComponent.cpp
+++ b/Source/Portfolio/Component/CStateComponent.cpp
@@ -11,6 +11,7 @@ UCStateComponent::UCStateComponent()
 {
 }
 
+// Component Reference
 void UCStateComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -35,7 +36,7 @@ bool UCStateComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
-// Sync Health 'dead-state' changes into the 'execution state'.
+// Health State Sync
 void UCStateComponent::OnDeadStateChanged(EDeadState InPrevDeadState, EDeadState InNewDeadState)
 {
 	if (!IsValid(OwnerCharacter_Injected)) return;
@@ -70,6 +71,7 @@ void UCStateComponent::OnDeadStateChanged(EDeadState InPrevDeadState, EDeadState
 	}
 }
 
+// Mutation
 void UCStateComponent::SetIdleState()
 {
 	if (!IsValid(OwnerCharacter_Injected)) return;

--- a/Source/Portfolio/Component/CStateComponent.h
+++ b/Source/Portfolio/Component/CStateComponent.h
@@ -36,14 +36,11 @@ private:
 	bool ValidateRequiredComponentReferences() const;
 
 public:
+	// Health State Sync
 	void OnDeadStateChanged(EDeadState InPrevDeadState, EDeadState InNewDeadState);
 
-public:
-	// Check / Query
-	FORCEINLINE bool CheckCurExecutionState(EExecutionState InNewExecutionState) const { return CurrentExecutionState == InNewExecutionState; }
-
-public:
 	// Query
+	FORCEINLINE bool CheckCurExecutionState(EExecutionState InNewExecutionState) const { return CurrentExecutionState == InNewExecutionState; }
 	FORCEINLINE EExecutionState GetCurrentExecutionState() const { return CurrentExecutionState; }
 
 public:

--- a/Source/Portfolio/Component/CWeaponComponent.cpp
+++ b/Source/Portfolio/Component/CWeaponComponent.cpp
@@ -15,6 +15,8 @@ UCWeaponComponent::UCWeaponComponent()
 {
 }
 
+// Component Reference
+
 void UCWeaponComponent::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -52,6 +54,8 @@ bool UCWeaponComponent::ValidateRequiredComponentReferences() const
 	return bValid;
 }
 
+// Lifecycle
+
 void UCWeaponComponent::BeginPlay()
 {
 	Super::BeginPlay();
@@ -72,10 +76,14 @@ void UCWeaponComponent::UninitializeWeaponRuntime()
 	DestroyWeaponActor();
 }
 
+// Query
+
 ACWeaponActor* UCWeaponComponent::GetWeaponActor() const
 {
 	return IsValid(WeaponActor) ? WeaponActor : nullptr;
 }
+
+// Mutation
 
 void UCWeaponComponent::AttachWeaponToHand()
 {

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -68,6 +68,7 @@ public:
 	class ACWeaponActor* GetWeaponActor() const;
 
 public:
+	// Mutation
 	void AttachWeaponToHand();
 	void AttachWeaponToHolster();
 

--- a/Source/Portfolio/Component/CWeaponComponent.h
+++ b/Source/Portfolio/Component/CWeaponComponent.h
@@ -57,14 +57,10 @@ protected:
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 public:
-	// Check / Query
-	FORCEINLINE bool CheckCurrentWeaponType(EWeaponType InNewWeaponType) const { return CurrentWeaponType == InNewWeaponType; }
-
-public:
 	// Query
+	FORCEINLINE bool CheckCurrentWeaponType(EWeaponType InNewWeaponType) const { return CurrentWeaponType == InNewWeaponType; }
 	FORCEINLINE EWeaponType GetCurrentWeaponType() const { return CurrentWeaponType; }
 
-public:
 	class ACWeaponActor* GetWeaponActor() const;
 
 public:

--- a/Source/Portfolio/Controller/CAIController.cpp
+++ b/Source/Portfolio/Controller/CAIController.cpp
@@ -26,7 +26,7 @@ ACAIController::ACAIController()
 {
 	CurrentRuntimeLODTier = EAIRuntimeLODTier::Background;
 
-	// Init AIPerceptionComp
+	// Initialize AI perception component.
 	AIPerceptionComp = CreateDefaultSubobject<UAIPerceptionComponent>(TEXT("AIPerception"));
 	check(AIPerceptionComp);
 
@@ -228,22 +228,22 @@ void ACAIController::InitializeCustomBlackboardValues(UBlackboardComponent* InBl
 	const ACEnemy* enemy = Cast<ACEnemy>(InOwnerPawn);
 	if (!IsValid(enemy)) return;
 
-	// Patrol custom values
+	// Apply patrol blackboard values.
 	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::bUsePatrol, enemy->ShouldUsePatrol(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomObject(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolPath, enemy->GetPatrolPath(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomEnum(InBlackboardComp, InOutPendingKeys, CAIKey::Patrol::PatrolMode, static_cast<uint8>(enemy->GetPatrolMode()), ControlledPawn_Cached);
 
-	// Investigate custom values
+	// Apply investigate blackboard values.
 	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::bUseInvestigate, enemy->ShouldUseInvestigate(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateDuration, enemy->GetInvestigateDuration(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomInt(InBlackboardComp, InOutPendingKeys, CAIKey::Investigate::InvestigateMaxIndex, enemy->GetInvestigateMaxIndex(), ControlledPawn_Cached);
 
-	// Chase custom values
+	// Apply chase blackboard values.
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseOffsetRange, enemy->GetChaseOffsetRange(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseEnterBuffer, enemy->GetChaseEnterBuffer(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Chase::ChaseExitBuffer, enemy->GetChaseExitBuffer(), ControlledPawn_Cached);
 
-	// Alert custom values
+	// Apply alert blackboard values.
 	CAIBlackboardValueHelper::ApplyCustomBool(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::bUseAlertStep, enemy->ShouldUseAlertStep(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepForwardDistance, enemy->GetStepForwardDistance(), ControlledPawn_Cached);
 	CAIBlackboardValueHelper::ApplyCustomFloat(InBlackboardComp, InOutPendingKeys, CAIKey::Alert::StepSideDistance, enemy->GetStepSideDistance(), ControlledPawn_Cached);

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -85,7 +85,7 @@ private:
 	// Blackboard Setup
 	bool SetupBlackboardComponent();
 
-	// Blackboard Value
+	// Blackboard Runtime Value
 	bool InitializeBlackboardValues();
 	void InitializeCustomBlackboardValues(class UBlackboardComponent* InBlackboardComp, const class APawn* InOwnerPawn, TSet<FName>& InOutPendingKeys) const;
 

--- a/Source/Portfolio/Controller/CAIController.h
+++ b/Source/Portfolio/Controller/CAIController.h
@@ -116,7 +116,7 @@ public:
 	bool RefreshRuntimeLODTierFromBlackboard();
 
 public:
-	// Profiling Event Sink
+	// Perception Audit Event Sink
 	void RecordPerceptionContextBuiltForAudit(class AActor* InTargetActor);
 	void RecordBlackboardTargetSetForAudit(class AActor* InTargetActor);
 	void RecordEngageRequestSubmittedForAudit(class AActor* InTargetActor);
@@ -132,19 +132,13 @@ private:
 	// Runtime LOD Snapshot
 	void InitializeRuntimeLODTierSnapshot();
 	void ClearRuntimeLODTierSnapshot();
-
-	// Mutation
 	void SetCurrentRuntimeLODTier(EAIRuntimeLODTier InTier);
 
 private:
 	// Perception Profiling Gate
 	void InitializePerceptionStateForProfiling();
 	void ClearPerceptionStateForProfiling();
-
-	// Condition
 	bool ShouldDisableEnemyPerceptionForProfiling() const;
-
-	// Mutation
 	void DisableEnemyPerceptionForProfiling();
 	void EnableEnemyPerceptionForProfiling();
 	void SetPerceptionSenseEnabledForProfiling(bool bEnabled);
@@ -153,11 +147,7 @@ private:
 	// Perception Candidate Audit
 	void InitializePerceptionCandidateAudit();
 	void ClearPerceptionCandidateAudit();
-
-	// Condition
 	bool ShouldAuditPerceptionCandidates() const;
-
-	// Record
 	void RecordRawPerceptionCandidate(class AActor* InActor);
 	void RecordValidTargetProvider(class AActor* InActor);
 	void RecordInvalidTargetProvider(class AActor* InActor);
@@ -167,8 +157,6 @@ private:
 	// Blackboard / Engage Latency Audit
 	void InitializeBlackboardEngageLatencyAudit();
 	void ClearBlackboardEngageLatencyAudit();
-
-	// Condition
 	bool ShouldAuditBlackboardEngageLatency() const;
 
 };

--- a/Source/Portfolio/Controller/CPlayerController.cpp
+++ b/Source/Portfolio/Controller/CPlayerController.cpp
@@ -14,6 +14,8 @@ ACPlayerController::ACPlayerController()
 	check(PlayerFeedbackComponent);
 }
 
+// Lifecycle
+
 void ACPlayerController::PostInitializeComponents()
 {
 	Super::PostInitializeComponents();
@@ -54,6 +56,8 @@ void ACPlayerController::SetupInputComponent()
 	InputComponent->BindAction("Dodge", EInputEvent::IE_Pressed, this, &ACPlayerController::PressDodge);
 }
 
+// Look Input
+
 void ACPlayerController::InputLookYaw(float InAxisValue)
 {
 	AddYawInput(InAxisValue);
@@ -63,6 +67,8 @@ void ACPlayerController::InputLookPitch(float InAxisValue)
 {
 	AddPitchInput(InAxisValue);
 }
+
+// Move Input
 
 void ACPlayerController::InputMoveForward(float InAxisValue)
 {
@@ -74,6 +80,8 @@ void ACPlayerController::InputMoveRight(float InAxisValue)
 	CachedMoveAxis2D.X = InAxisValue;
 }
 
+// Movement Dispatch
+
 void ACPlayerController::FlushMoveInput()
 {
 	if (CachedMoveAxis2D.IsNearlyZero()) return;
@@ -83,6 +91,8 @@ void ACPlayerController::FlushMoveInput()
 
 	FActionRequestResult result = player->HandleMove(CachedMoveAxis2D);
 }
+
+// Action Input
 
 void ACPlayerController::PressWalk()
 {

--- a/Source/Portfolio/Controller/CPlayerController.h
+++ b/Source/Portfolio/Controller/CPlayerController.h
@@ -26,14 +26,21 @@ protected:
 	virtual void SetupInputComponent() override;
 
 protected:
+	// Look Input
 	void InputLookYaw(float InAxisValue);
 	void InputLookPitch(float InAxisValue);
 
 protected:
+	// Move Input
 	void InputMoveForward(float InAxisValue);
 	void InputMoveRight(float InAxisValue);
 
 protected:
+	// Movement Dispatch
+	void FlushMoveInput();
+
+protected:
+	// Action Input
 	void PressWalk();
 	void ReleaseWalk();
 
@@ -45,7 +52,4 @@ protected:
 	void PressGuard();
 	void ReleaseGuard();
 	void PressDodge();
-
-protected:
-	void FlushMoveInput();
 };

--- a/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIAnimationProfiling.cpp
@@ -14,6 +14,8 @@ namespace
 #endif
 }
 
+// Gate
+
 bool FAIAnimationProfiling::ShouldAuditAnimationRefresh()
 {
 #if !UE_BUILD_SHIPPING
@@ -22,6 +24,8 @@ bool FAIAnimationProfiling::ShouldAuditAnimationRefresh()
 	return false;
 #endif
 }
+
+// Counter
 
 void FAIAnimationProfiling::RecordAnimationRefreshAttempt()
 {

--- a/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIBehaviorTreeProfiling.cpp
@@ -2,6 +2,8 @@
 
 #include "ProfilingDebugging/CsvProfiler.h"
 
+// Service Tick Counter
+
 void FAIBehaviorTreeProfiling::RecordUpdateAIContextTick()
 {
 #if !UE_BUILD_SHIPPING
@@ -22,6 +24,8 @@ void FAIBehaviorTreeProfiling::RecordUpdateEngageContextTick()
 	CSV_CUSTOM_STAT_GLOBAL(PortfolioAI_BT_UpdateEngageContext_Count, 1, ECsvCustomStatOp::Accumulate);
 #endif
 }
+
+// Interval Preset Counter
 
 void FAIBehaviorTreeProfiling::RecordAIIntentIntervalPreset(EBTServiceIntervalPreset InPreset)
 {

--- a/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIPerceptionProfiling.cpp
@@ -15,6 +15,8 @@ namespace
 #endif
 }
 
+// Gate
+
 bool FAIPerceptionProfiling::ShouldDisableEnemyPerception(const AActor* InOwnerActor)
 {
 #if !UE_BUILD_SHIPPING

--- a/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CAIStateRuntimeLODProfiling.cpp
@@ -14,6 +14,8 @@ namespace
 #endif
 }
 
+// Gate
+
 bool FAIStateRuntimeLODProfiling::ShouldAuditStateRuntimeLOD()
 {
 #if !UE_BUILD_SHIPPING
@@ -22,6 +24,8 @@ bool FAIStateRuntimeLODProfiling::ShouldAuditStateRuntimeLOD()
 	return false;
 #endif
 }
+
+// Counter
 
 void FAIStateRuntimeLODProfiling::RecordResolvedTier(EAIRuntimeLODTier InTier)
 {

--- a/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.cpp
+++ b/Source/Portfolio/Core/Profiling/CCombatCollisionProfiling.cpp
@@ -26,6 +26,8 @@ namespace
 	}
 }
 
+// Gate
+
 bool FCombatCollisionProfiling::ShouldSkipEnemyHitProcessing(const AActor* InOwnerActor)
 {
 #if !UE_BUILD_SHIPPING

--- a/Source/Portfolio/Reaction/CReaction.cpp
+++ b/Source/Portfolio/Reaction/CReaction.cpp
@@ -8,6 +8,8 @@
 
 #include "GameFramework/Character.h"
 
+// Component Reference
+
 void UCReaction::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -35,6 +37,8 @@ bool UCReaction::ValidateRequiredReferences() const
 
 	return bValid;
 }
+
+// Decision
 
 FExecutionDecisionResult UCReaction::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
@@ -114,6 +118,9 @@ bool UCReaction::TryResolveIndependentOrExclusiveRelationship(const FExecutionDe
 
 	return false;
 }
+
+// Lifecycle
+
 bool UCReaction::Start(const FReactionData& InData)
 {
 	if (!InData.IsValidMinimal())
@@ -286,6 +293,8 @@ void UCReaction::CleanupRuntimeEffects()
 	}
 }
 
+// Montage Lifecycle
+
 bool UCReaction::PlayMontage(const FReactionData& InData)
 {
 	if (!IsValid(OwnerCharacter_Injected))
@@ -406,6 +415,8 @@ bool UCReaction::CanHandleMontageEnd(UAnimMontage* InMontage, uint32 InSerial) c
 	return true;
 }
 
+// Notify
+
 void UCReaction::HandleNotifyCommand(EReactionNotifyCommand InCommand)
 {
 	switch (InCommand)
@@ -424,6 +435,8 @@ void UCReaction::HandleNotifyCommand(EReactionNotifyCommand InCommand)
 void UCReaction::HandleSpecificNotifyCommand(EReactionNotifyCommand InCommand)
 {
 }
+
+// Feedback
 
 void UCReaction::HandleNotifyFeedback(EReactionFeedbackTiming InTiming, FName InTriggerKey)
 {
@@ -456,6 +469,8 @@ FReactionFeedbackRequest UCReaction::BuildFeedbackRequest(EReactionFeedbackTimin
 	return request;
 }
 
+// Cross-System Dispatch
+
 void UCReaction::RequestConsumeDeferredAction(EDeferredActionConsumeKey InConsumeKey) const
 {
 	if (!IsValid(ReactionComp_Injected))
@@ -466,6 +481,8 @@ void UCReaction::RequestConsumeDeferredAction(EDeferredActionConsumeKey InConsum
 
 	ReactionComp_Injected->RequestConsumeDeferredAction(InConsumeKey);
 }
+
+// Intervention Window
 
 void UCReaction::OpenAllowInterventionWindow(FName InWindowKey)
 {
@@ -489,6 +506,8 @@ void UCReaction::CloseAllowInterventionWindow(FName InWindowKey)
 	AllowInterventionWindowKeys.Remove(InWindowKey);
 }
 
+// Intervention Match
+
 bool UCReaction::WantIntervention(const FExecutionInterventionQuery& InQuery) const
 {
 	if (!InQuery.IsValidMinimal()) return false;
@@ -506,6 +525,8 @@ bool UCReaction::AllowIntervention(const FExecutionInterventionQuery& InQuery) c
 	return MatchesAllowInterventionRules(ActiveData_Cached.AllowInterventionRules, InQuery.IncomingPart);
 }
 
+// Observable Overlay Match
+
 void UCReaction::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -520,6 +541,8 @@ void UCReaction::ResolveObservableOverlayCondition(const FObservableOverlayQuery
 	// Default Reaction Case: No overlay cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }
+
+// Intervention Match Helper
 
 bool UCReaction::MatchesWantInterventionRules(const TArray<FExecutionInterventionWantRule>& InRules, const FExecutionParticipant& InParticipant) const
 {

--- a/Source/Portfolio/Reaction/CReaction.cpp
+++ b/Source/Portfolio/Reaction/CReaction.cpp
@@ -89,13 +89,13 @@ bool UCReaction::IsIncomingReactionType(const FExecutionInterventionQuery& InQue
 
 bool UCReaction::CanResolveIndependentRelationship(const FExecutionDecisionQuery& InQuery) const
 {
-	// Idle && No ActivePart: Idle
+	// Idle state accepts independent reaction requests.
 	return InQuery.Snapshot.IsIdle() && !InQuery.HasActivePart();
 }
 
 bool UCReaction::CanResolveExclusiveRelationship(const FExecutionDecisionQuery& InQuery) const
 {
-	// No Idle && Has ActivePart: Active Action OR Active Reaction
+	// Active state can accept exclusive requests against the current part.
 	return !InQuery.Snapshot.IsIdle() && InQuery.HasActivePart();
 }
 
@@ -103,7 +103,7 @@ bool UCReaction::TryResolveIndependentOrExclusiveRelationship(const FExecutionDe
 {
 	OutRelationship = EExecutionRelationship::None;
 
-	// Idle && No ActivePart: Idle
+	// Idle state resolves to an independent relationship.
 	if (CanResolveIndependentRelationship(InQuery))
 	{
 		OutRelationship = EExecutionRelationship::Independent;
@@ -533,12 +533,12 @@ void UCReaction::ResolveObservableOverlayCondition(const FObservableOverlayQuery
 
 	if (!InQuery.DecisionQuery.IncomingPart.IsReactionParticipant())
 	{
-		// Reaction only.
+		// Reject non-Reaction overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
 
-	// Default Reaction Case: No overlay cleanup.
+	// Default Reaction overlay handling accepts without cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }
 

--- a/Source/Portfolio/Reaction/CReaction.h
+++ b/Source/Portfolio/Reaction/CReaction.h
@@ -63,7 +63,7 @@ public:
 	virtual void Tick(float InDeltaTime) {};
 
 public:
-	// State Query
+	// Query
 	bool IsActive() const { return bIsActive; }
 
 public:
@@ -143,6 +143,7 @@ public:
 	virtual void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const;
 
 private:
+	// Intervention Match Helper
 	bool MatchesWantInterventionRules(const TArray<FExecutionInterventionWantRule>& InRules, const FExecutionParticipant& InParticipant) const;
 	bool MatchesAllowInterventionRules(const TArray<FExecutionInterventionAllowRule>& InRules, const FExecutionParticipant& InParticipant) const;
 	bool IsAllowInterventionRuleTimingSatisfied(const FExecutionInterventionAllowRule& InRule) const;

--- a/Source/Portfolio/Reaction/CReaction_BlockHit.cpp
+++ b/Source/Portfolio/Reaction/CReaction_BlockHit.cpp
@@ -4,6 +4,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCReaction_BlockHit::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -39,6 +41,8 @@ FExecutionDecisionResult UCReaction_BlockHit::ResolveExecutionDecision(const FEx
 	return result;
 }
 
+// Lifecycle
+
 void UCReaction_BlockHit::Complete()
 {
 	Super::Complete();
@@ -46,6 +50,8 @@ void UCReaction_BlockHit::Complete()
 	RequestConsumeDeferredAction(EDeferredActionConsumeKey::AfterGuardBlockReaction);
 	RequestConsumeDeferredAction(EDeferredActionConsumeKey::AfterGuardInAction);
 }
+
+// Intervention
 
 bool UCReaction_BlockHit::WantIntervention(const FExecutionInterventionQuery& InQuery) const
 {
@@ -67,6 +73,8 @@ bool UCReaction_BlockHit::WantIntervention(const FExecutionInterventionQuery& In
 	return false;
 }
 
+// Observable Overlay
+
 void UCReaction_BlockHit::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -74,7 +82,7 @@ void UCReaction_BlockHit::ResolveObservableOverlayCondition(const FObservableOve
 	const bool bIsBlockHitReaction = IsIncomingReactionType(InQuery.DecisionQuery, EReactionType::BlockHit);
 	if (!bIsBlockHitReaction)
 	{
-		// BlockHit only.
+		// Reject non-BlockHit overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
@@ -82,11 +90,11 @@ void UCReaction_BlockHit::ResolveObservableOverlayCondition(const FObservableOve
 	const FGuardObservableOverlaySnapshot& guardSnapshot = InQuery.DecisionQuery.Snapshot.ObservableOverlay.Guard;
 	if (guardSnapshot.bCanGuard)
 	{
-		// Guard Case: keep Guard during BlockHit.
+		// BlockHit keeps Guard while an active Guard window can block it.
 		OutDecision.Decision = EExecutionDecision::Accept;
 		return;
 	}
 
-	// Another Case: BlockHit requires an active Guard window.
+	// BlockHit requires an active Guard window.
 	OutDecision.Decision = EExecutionDecision::Reject;
 }

--- a/Source/Portfolio/Reaction/CReaction_BlockHit.h
+++ b/Source/Portfolio/Reaction/CReaction_BlockHit.h
@@ -10,12 +10,17 @@ class PORTFOLIO_API UCReaction_BlockHit : public UCReaction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 public:
+	// Lifecycle
 	void Complete() override;
 
 public:
+	// Intervention
 	bool WantIntervention(const FExecutionInterventionQuery& InQuery) const override;
+
+	// Observable Overlay
 	void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const override;
 };

--- a/Source/Portfolio/Reaction/CReaction_Dead.cpp
+++ b/Source/Portfolio/Reaction/CReaction_Dead.cpp
@@ -4,6 +4,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCReaction_Dead::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -33,6 +35,8 @@ FExecutionDecisionResult UCReaction_Dead::ResolveExecutionDecision(const FExecut
 	return result;
 }
 
+// Observable Overlay
+
 void UCReaction_Dead::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -40,7 +44,7 @@ void UCReaction_Dead::ResolveObservableOverlayCondition(const FObservableOverlay
 	const bool bIsDeadReaction = IsIncomingReactionType(InQuery.DecisionQuery, EReactionType::Dead);
 	if (!bIsDeadReaction)
 	{
-		// Dead only.
+		// Reject non-Dead overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
@@ -48,15 +52,17 @@ void UCReaction_Dead::ResolveObservableOverlayCondition(const FObservableOverlay
 	const bool bHasGuardState = InQuery.DecisionQuery.Snapshot.ObservableOverlay.Guard.HasGuardRuntimeState();
 	if (bHasGuardState)
 	{
-		// GuardState Case: clear Guard before Dead.
+		// Dead clears an active Guard state before it starts.
 		OutDecision.Decision = EExecutionDecision::Accept;
 		OutDecision.Handlings.AddUnique(EObservableOverlayHandling::ClearGuardState);
 		return;
 	}
 
-	// Another Case: No overlay cleanup.
+	// Dead can start without overlay cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }
+
+// Intervention
 
 bool UCReaction_Dead::AllowIntervention(const FExecutionInterventionQuery& InQuery) const
 {

--- a/Source/Portfolio/Reaction/CReaction_Dead.h
+++ b/Source/Portfolio/Reaction/CReaction_Dead.h
@@ -10,11 +10,14 @@ class PORTFOLIO_API UCReaction_Dead : public UCReaction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 public:
+	// Observable Overlay
 	void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const override;
 
 public:
+	// Intervention
 	bool AllowIntervention(const FExecutionInterventionQuery& InQuery) const override;
 };

--- a/Source/Portfolio/Reaction/CReaction_Hit.cpp
+++ b/Source/Portfolio/Reaction/CReaction_Hit.cpp
@@ -4,6 +4,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCReaction_Hit::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -39,6 +41,8 @@ FExecutionDecisionResult UCReaction_Hit::ResolveExecutionDecision(const FExecuti
 	return result;
 }
 
+// Observable Overlay
+
 void UCReaction_Hit::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -46,7 +50,7 @@ void UCReaction_Hit::ResolveObservableOverlayCondition(const FObservableOverlayQ
 	const bool bIsHitReaction = IsIncomingReactionType(InQuery.DecisionQuery, EReactionType::Hit);
 	if (!bIsHitReaction)
 	{
-		// Hit only.
+		// Reject non-Hit overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
@@ -54,12 +58,12 @@ void UCReaction_Hit::ResolveObservableOverlayCondition(const FObservableOverlayQ
 	const bool bHasGuardState = InQuery.DecisionQuery.Snapshot.ObservableOverlay.Guard.HasGuardRuntimeState();
 	if (bHasGuardState)
 	{
-		// GuardState Case: clear Guard before Hit.
+		// Hit clears an active Guard state before it starts.
 		OutDecision.Decision = EExecutionDecision::Accept;
 		OutDecision.Handlings.AddUnique(EObservableOverlayHandling::ClearGuardState);
 		return;
 	}
 
-	// Another Case: No overlay cleanup.
+	// Hit can start without overlay cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }

--- a/Source/Portfolio/Reaction/CReaction_Hit.h
+++ b/Source/Portfolio/Reaction/CReaction_Hit.h
@@ -10,8 +10,10 @@ class PORTFOLIO_API UCReaction_Hit : public UCReaction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 public:
+	// Observable Overlay
 	void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const override;
 };

--- a/Source/Portfolio/Reaction/CReaction_Parry.cpp
+++ b/Source/Portfolio/Reaction/CReaction_Parry.cpp
@@ -4,6 +4,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCReaction_Parry::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -37,6 +39,8 @@ FExecutionDecisionResult UCReaction_Parry::ResolveExecutionDecision(const FExecu
 	return result;
 }
 
+// Intervention
+
 bool UCReaction_Parry::WantIntervention(const FExecutionInterventionQuery& InQuery) const
 {
 	if (!InQuery.IsValidMinimal()) return false;
@@ -57,6 +61,8 @@ bool UCReaction_Parry::WantIntervention(const FExecutionInterventionQuery& InQue
 	return false;
 }
 
+// Observable Overlay
+
 void UCReaction_Parry::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -64,7 +70,7 @@ void UCReaction_Parry::ResolveObservableOverlayCondition(const FObservableOverla
 	const bool bIsParryReaction = IsIncomingReactionType(InQuery.DecisionQuery, EReactionType::Parry);
 	if (!bIsParryReaction)
 	{
-		// Parry only.
+		// Reject non-Parry overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}

--- a/Source/Portfolio/Reaction/CReaction_Parry.h
+++ b/Source/Portfolio/Reaction/CReaction_Parry.h
@@ -10,9 +10,13 @@ class PORTFOLIO_API UCReaction_Parry : public UCReaction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 public:
+	// Intervention
 	bool WantIntervention(const FExecutionInterventionQuery& InQuery) const override;
+
+	// Observable Overlay
 	void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const override;
 };

--- a/Source/Portfolio/Reaction/CReaction_Stagger.cpp
+++ b/Source/Portfolio/Reaction/CReaction_Stagger.cpp
@@ -4,6 +4,8 @@
 
 #include "GameFramework/Character.h"
 
+// Decision
+
 FExecutionDecisionResult UCReaction_Stagger::ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const
 {
 	FExecutionDecisionResult result;
@@ -37,6 +39,8 @@ FExecutionDecisionResult UCReaction_Stagger::ResolveExecutionDecision(const FExe
 	return result;
 }
 
+// Intervention
+
 bool UCReaction_Stagger::WantIntervention(const FExecutionInterventionQuery& InQuery) const
 {
 	if (!InQuery.IsValidMinimal()) return false;
@@ -47,6 +51,8 @@ bool UCReaction_Stagger::WantIntervention(const FExecutionInterventionQuery& InQ
 	return InQuery.ActivePart.IsActionParticipant() || InQuery.ActivePart.IsReactionParticipant();
 }
 
+// Observable Overlay
+
 void UCReaction_Stagger::ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const
 {
 	OutDecision = FObservableOverlayExecutionDecision();
@@ -54,7 +60,7 @@ void UCReaction_Stagger::ResolveObservableOverlayCondition(const FObservableOver
 	const bool bIsStaggerReaction = IsIncomingReactionType(InQuery.DecisionQuery, EReactionType::Stagger);
 	if (!bIsStaggerReaction)
 	{
-		// Stagger only.
+		// Reject non-Stagger overlay queries.
 		OutDecision.Decision = EExecutionDecision::Reject;
 		return;
 	}
@@ -62,12 +68,12 @@ void UCReaction_Stagger::ResolveObservableOverlayCondition(const FObservableOver
 	const bool bHasGuardState = InQuery.DecisionQuery.Snapshot.ObservableOverlay.Guard.HasGuardRuntimeState();
 	if (bHasGuardState)
 	{
-		// GuardState Case: clear Guard before Stagger.
+		// Stagger clears an active Guard state before it starts.
 		OutDecision.Decision = EExecutionDecision::Accept;
 		OutDecision.Handlings.AddUnique(EObservableOverlayHandling::ClearGuardState);
 		return;
 	}
 
-	// Another Case: No overlay cleanup.
+	// Stagger can start without overlay cleanup.
 	OutDecision.Decision = EExecutionDecision::Accept;
 }

--- a/Source/Portfolio/Reaction/CReaction_Stagger.h
+++ b/Source/Portfolio/Reaction/CReaction_Stagger.h
@@ -10,9 +10,13 @@ class PORTFOLIO_API UCReaction_Stagger : public UCReaction
 	GENERATED_BODY()
 
 public:
+	// Decision
 	FExecutionDecisionResult ResolveExecutionDecision(const FExecutionDecisionQuery& InQuery) const override;
 
 public:
+	// Intervention
 	bool WantIntervention(const FExecutionInterventionQuery& InQuery) const override;
+
+	// Observable Overlay
 	void ResolveObservableOverlayCondition(const FObservableOverlayQuery& InQuery, FObservableOverlayExecutionDecision& OutDecision) const override;
 };

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -48,6 +48,8 @@ namespace
 	}
 }
 
+// Lifecycle
+
 void UCWorldSubsystem_CombatEngage::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
@@ -59,6 +61,8 @@ void UCWorldSubsystem_CombatEngage::Deinitialize()
 
 	Super::Deinitialize();
 }
+
+// Tick
 
 void UCWorldSubsystem_CombatEngage::Tick(float DeltaTime)
 {
@@ -165,6 +169,8 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 	AssignmentContainer = MoveTemp(nextAssignments);
 }
 
+// Assignment Build
+
 TMap<ACAIController*, FEngageRequestContext> UCWorldSubsystem_CombatEngage::ConsumeRequestSnapshot()
 {
 	TMap<ACAIController*, FEngageRequestContext> requestSnapshot = MoveTemp(RequestContainer);
@@ -205,6 +211,8 @@ void UCWorldSubsystem_CombatEngage::SortRequestContexts(TArray<FEngageRequestCon
 		});
 }
 
+// Assignment Warmup
+
 void UCWorldSubsystem_CombatEngage::StartAssignmentWarmupIfNeeded()
 {
 	if (bAssignmentWarmupCompleted) return;
@@ -233,6 +241,8 @@ float UCWorldSubsystem_CombatEngage::GetAssignmentWarmupElapsedTime() const
 
 	return FMath::Max(0.f, world->GetTimeSeconds() - AssignmentWarmupStartTime);
 }
+
+// Assignment Apply
 
 void UCWorldSubsystem_CombatEngage::PreserveExistingEngageAssignments(TMap<ACAIController*, FEngageAssignmentContext>& InOutNextAssignments, TMap<AActor*, FEngageAssignmentSlotState>& InOutSlotState, FEngageAssignmentRebuildDebugState& InOutDebugState) const
 {
@@ -388,6 +398,8 @@ void UCWorldSubsystem_CombatEngage::ApplyFreshRequestAssignments(const TMap<AAct
 		}
 	}
 }
+
+// Assignment Lease
 
 bool UCWorldSubsystem_CombatEngage::TryReserveAssignmentSlot(const FEngageAssignmentContext& InAssignment, TMap<AActor*, FEngageAssignmentSlotState>& InOutSlotState) const
 {

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatEngage.cpp
@@ -105,7 +105,7 @@ void UCWorldSubsystem_CombatEngage::SubmitRequest(const FEngageRequestContext& I
 
 	StartAssignmentWarmupIfNeeded();
 
-	// Override Request
+	// Keep the latest request for the same controller.
 	RequestContainer.FindOrAdd(InEngageRequestContext.RequestController) = InEngageRequestContext;
 
 	UWorld* world = GetWorld();
@@ -120,7 +120,7 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 
 	++AssignmentRebuildId;
 
-	// Delay for Warmup
+	// Delay assignment rebuild until warmup has completed.
 	if (ShouldDelayAssignmentForWarmup())
 	{
 		FCombatEngageDebug::RecordEngageAssignmentWarmupDelayedForAudit(AssignmentRebuildId, RequestContainer.Num(), GetAssignmentWarmupElapsedTime(), GetEngageAssignmentWarmupTime());
@@ -130,7 +130,7 @@ void UCWorldSubsystem_CombatEngage::RebuildAssignments()
 
 	bool bCompletedWarmupThisRebuild = false;
 
-	// Flag Toggle
+	// Mark warmup completion on the first rebuild after the delay.
 	if (!bAssignmentWarmupCompleted)
 	{
 		if (GetEngageAssignmentWarmupTime() > 0.f && AssignmentWarmupStartTime < 0.f) return;

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
@@ -5,6 +5,8 @@
 
 #include "GameFramework/Actor.h"
 
+// Lifecycle
+
 void UCWorldSubsystem_CombatFeedback::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.cpp
@@ -80,7 +80,7 @@ void UCWorldSubsystem_CombatFeedback::ApplyHitStop(AActor* InActor, float InDura
 		CachedTimeDilationMap.Add(actorKey, InActor->CustomTimeDilation);
 	}
 
-	// Slow InActor
+	// Apply slowdown to the requested actor.
 	InActor->CustomTimeDilation = InDilation;
 	FCombatFeedbackDebug::RecordCombatFeedbackHitStopAppliedForAudit(InActor, InDuration, InDilation);
 
@@ -105,7 +105,7 @@ void UCWorldSubsystem_CombatFeedback::RestoreHitStop(TWeakObjectPtr<AActor> InAc
 		InActor->CustomTimeDilation = cachedDilation ? *cachedDilation : 1.f;
 	}
 
-	// Restore InActor
+	// Restore runtime records for the requested actor.
 	ActiveHitStopMap.Remove(InActorKey);
 	CachedTimeDilationMap.Remove(InActorKey);
 }
@@ -135,7 +135,7 @@ void UCWorldSubsystem_CombatFeedback::ClearHitStop()
 	CachedTimeDilationMap.Reset();
 }
 
-// CameraShake
+// Camera Shake
 
 void UCWorldSubsystem_CombatFeedback::ClearCameraShake()
 {

--- a/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
+++ b/Source/Portfolio/System/Combat/CWorldSubsystem_CombatFeedback.h
@@ -37,7 +37,7 @@ private:
 	void ClearHitStop();
 
 private:
-	// CameraShake
+	// Camera Shake
 	void ClearCameraShake();
 
 private:

--- a/Source/Portfolio/Type/CAIBehaviorTreeTypes.h
+++ b/Source/Portfolio/Type/CAIBehaviorTreeTypes.h
@@ -2,6 +2,8 @@
 
 #include "CoreMinimal.h"
 
+// Enum
+
 enum class EBTServiceIntervalPreset : uint8
 {
 	Default,

--- a/Source/Portfolio/Type/CActionDataTypes.h
+++ b/Source/Portfolio/Type/CActionDataTypes.h
@@ -5,6 +5,8 @@
 #include "Type/CExecutionRuleTypes.h"
 #include "CActionDataTypes.generated.h"
 
+// Data / Config
+
 USTRUCT(BlueprintType)
 struct FActionData
 {
@@ -44,6 +46,8 @@ public:
 public:
 	bool IsValidMinimal() const;
 };
+
+// Runtime Context
 
 USTRUCT(BlueprintType)
 struct FActionExecutionContext

--- a/Source/Portfolio/Type/CActionKeyTypes.h
+++ b/Source/Portfolio/Type/CActionKeyTypes.h
@@ -4,6 +4,8 @@
 #include "Type/CActionTypes.h"
 #include "CActionKeyTypes.generated.h"
 
+// Key / Identifier
+
 USTRUCT(BlueprintType)
 struct FActionDataKey
 {
@@ -26,6 +28,8 @@ public:
 			&& ActionIndex == InOther.ActionIndex;
 	}
 };
+
+// Helper API
 
 FORCEINLINE uint32 GetTypeHash(const FActionDataKey& InKey)
 {

--- a/Source/Portfolio/Type/CActionTypes.h
+++ b/Source/Portfolio/Type/CActionTypes.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CActionTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EActionType : uint8
 {

--- a/Source/Portfolio/Type/CCharacterComponentReferenceTypes.h
+++ b/Source/Portfolio/Type/CCharacterComponentReferenceTypes.h
@@ -19,6 +19,8 @@ class UCReactionOrchestratorComponent;
 class UCStateComponent;
 class UCWeaponComponent;
 
+// Runtime Context
+
 struct FCharacterComponentReferences
 {
 	ACharacter* OwnerCharacter = nullptr;

--- a/Source/Portfolio/Type/CCombatDamageTypes.h
+++ b/Source/Portfolio/Type/CCombatDamageTypes.h
@@ -8,6 +8,8 @@
 #include "Type/CCombatHitTypes.h"
 #include "CCombatDamageTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EDamageDefenseOutcome : uint8
 {
@@ -18,6 +20,8 @@ enum class EDamageDefenseOutcome : uint8
 
 	Max,
 };
+
+// Key / Identifier
 
 USTRUCT(BlueprintType)
 struct FDamageSpecKey
@@ -68,6 +72,8 @@ FORCEINLINE uint32 GetTypeHash(const FDamageSpecKey& InOther)
 
 // Global GetTypeHash keeps ADL available for this map key.
 
+// Data / Config
+
 USTRUCT(BlueprintType)
 struct FDamageSpec
 {
@@ -81,6 +87,8 @@ public:
 	FDamageSpec() = default;
 };
 
+// Request
+
 USTRUCT(BlueprintType)
 struct FDamageRequestAmount
 {
@@ -93,6 +101,8 @@ public:
 public:
 	FDamageRequestAmount() = default;
 };
+
+// Packet
 
 USTRUCT(BlueprintType)
 struct FDefaultDamageEvent : public FDamageEvent

--- a/Source/Portfolio/Type/CCombatFeedbackTypes.h
+++ b/Source/Portfolio/Type/CCombatFeedbackTypes.h
@@ -7,6 +7,8 @@ class AActor;
 
 #include "CCombatFeedbackTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EFeedbackAudience : uint8
 {
@@ -15,6 +17,8 @@ enum class EFeedbackAudience : uint8
 	Target,
 	Both
 };
+
+// Request
 
 USTRUCT(BlueprintType)
 struct FHitStopRequest

--- a/Source/Portfolio/Type/CCombatHitTypes.h
+++ b/Source/Portfolio/Type/CCombatHitTypes.h
@@ -5,6 +5,8 @@
 #include "Type/CActionKeyTypes.h"
 #include "CCombatHitTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EHitImpactContextSource : uint8
 {
@@ -15,6 +17,8 @@ enum class EHitImpactContextSource : uint8
 
 	Max,
 };
+
+// Runtime Context
 
 USTRUCT(BlueprintType)
 struct FOverlapContext
@@ -107,6 +111,8 @@ public:
 public:
 	FHitContext() = default;
 };
+
+// Key / Identifier
 
 USTRUCT()
 struct FCombatSignalHitWindowKey

--- a/Source/Portfolio/Type/CCombatResultTypes.h
+++ b/Source/Portfolio/Type/CCombatResultTypes.h
@@ -4,6 +4,8 @@
 #include "Type/CCombatDamageTypes.h"
 #include "CCombatResultTypes.generated.h"
 
+// Packet
+
 USTRUCT(BlueprintType)
 struct FCombatResultPacket
 {

--- a/Source/Portfolio/Type/CCombatSignalSourceTypes.h
+++ b/Source/Portfolio/Type/CCombatSignalSourceTypes.h
@@ -5,6 +5,8 @@
 #include "Type/CCombatDamageTypes.h"
 #include "CCombatSignalSourceTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class ECombatSignalSourceRejectReason : uint8
 {
@@ -27,6 +29,8 @@ enum class ECombatSignalSourceRejectReason : uint8
 	DuplicateHitInWindow,
 	FriendlyTarget,
 };
+
+// Payload
 
 USTRUCT(BlueprintType)
 struct FCombatSignalSourcePayload
@@ -58,6 +62,8 @@ public:
 public:
 	FCombatSignalSourcePayload() = default;
 };
+
+// Runtime Context
 
 USTRUCT(BlueprintType)
 struct FCombatSignalSourceContext
@@ -107,6 +113,8 @@ public:
 public:
 	FCombatSignalSourceContext() = default;
 };
+
+// Result
 
 USTRUCT(BlueprintType)
 struct FCombatSignalSourceResult

--- a/Source/Portfolio/Type/CCombatSignalTargetTypes.h
+++ b/Source/Portfolio/Type/CCombatSignalTargetTypes.h
@@ -6,6 +6,8 @@
 #include "Type/CHealthTypes.h"
 #include "CCombatSignalTargetTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class ECombatSignalTargetRejectReason : uint8
 {
@@ -20,6 +22,8 @@ enum class ECombatSignalTargetRejectReason : uint8
 
 	UnknownCueTag,
 };
+
+// Payload
 
 USTRUCT(BlueprintType)
 struct FCombatSignalTargetPayload
@@ -57,6 +61,8 @@ public:
 public:
 	FCombatSignalTargetPayload() = default;
 };
+
+// Runtime Context
 
 USTRUCT(BlueprintType)
 struct FCombatSignalTargetContext
@@ -122,6 +128,8 @@ public:
 	FCombatSignalTargetContext() = default;
 };
 
+// Result
+
 USTRUCT(BlueprintType)
 struct FCombatSignalTargetResult
 {
@@ -164,6 +172,8 @@ public:
 public:
 	FCombatSignalTargetResult() = default;
 };
+
+// Packet
 
 USTRUCT(BlueprintType)
 struct FCombatSignalTargetPacket

--- a/Source/Portfolio/Type/CCombatSignalTypes.h
+++ b/Source/Portfolio/Type/CCombatSignalTypes.h
@@ -6,6 +6,8 @@ class AActor;
 
 #include "CCombatSignalTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class ECombatSignalType : uint8
 {
@@ -46,6 +48,8 @@ enum class ECombatSignalResultType : uint8
 
 	Max,
 };
+
+// Packet
 
 USTRUCT(BlueprintType)
 struct FCombatSignalHeader
@@ -125,6 +129,8 @@ public:
 			&& SignalTag != NAME_None;
 	}
 };
+
+// Reserved Pipeline Scaffold
 
 USTRUCT(BlueprintType)
 struct FCombatSignalContext

--- a/Source/Portfolio/Type/CExecutionRuleTypes.cpp
+++ b/Source/Portfolio/Type/CExecutionRuleTypes.cpp
@@ -4,6 +4,7 @@
 
 namespace
 {
+	// Helper API
 	bool IsValidExecutionDomain(EExecutionDomain InDomain)
 	{
 		return InDomain != EExecutionDomain::None && InDomain != EExecutionDomain::Max;
@@ -34,6 +35,8 @@ namespace
 		return InPattern == EReactionType::All || InPattern == InValue;
 	}
 }
+
+// Data / Config
 
 bool FExecutionInterventionParticipantFilter::IsValidMinimal() const
 {

--- a/Source/Portfolio/Type/CExecutionRuleTypes.h
+++ b/Source/Portfolio/Type/CExecutionRuleTypes.h
@@ -7,6 +7,8 @@
 
 struct FExecutionParticipant;
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EExecutionDomain : uint8
 {
@@ -28,6 +30,8 @@ enum class EExecutionInterventionTiming : uint8
 
 	Max,
 };
+
+// Key / Identifier
 
 USTRUCT(BlueprintType)
 struct FExecutionInterventionParticipantFilter
@@ -64,6 +68,8 @@ public:
 			&& Index == InOther.Index;
 	}
 };
+
+// Data / Config
 
 USTRUCT(BlueprintType)
 struct FExecutionInterventionWantRule

--- a/Source/Portfolio/Type/CExecutionTypes.cpp
+++ b/Source/Portfolio/Type/CExecutionTypes.cpp
@@ -3,6 +3,8 @@
 #include "Action/CAction.h"
 #include "Reaction/CReaction.h"
 
+// Runtime State
+
 bool FExecutionParticipant::IsValidMinimal() const
 {
 	if (!bIsValid) return false;

--- a/Source/Portfolio/Type/CExecutionTypes.h
+++ b/Source/Portfolio/Type/CExecutionTypes.h
@@ -8,6 +8,8 @@
 #include "Type/CStateTypes.h"
 #include "CExecutionTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EExecutionDecision : uint8
 {
@@ -81,6 +83,8 @@ enum class EExecutionAfterStopAction : uint8
 	Max,
 };
 
+// Runtime State
+
 USTRUCT(BlueprintType)
 struct FExecutionSnapshot
 {
@@ -124,6 +128,8 @@ public:
 	}
 };
 
+// Runtime Context
+
 USTRUCT(BlueprintType)
 struct FExecutionParticipant
 {
@@ -153,6 +159,8 @@ public:
 	UObject* GetExecutor() const;
 	int32 GetPriority() const;
 };
+
+// Request
 
 USTRUCT(BlueprintType)
 struct FObservableOverlayExecutionDecision
@@ -212,6 +220,8 @@ public:
 	UPROPERTY(Transient)
 	EExecutionApplyMode ApplyMode = EExecutionApplyMode::None;
 };
+
+// Result
 
 USTRUCT(BlueprintType)
 struct FExecutionDecisionResult

--- a/Source/Portfolio/Type/CHealthTypes.h
+++ b/Source/Portfolio/Type/CHealthTypes.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CHealthTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EDeadState : uint8
 {

--- a/Source/Portfolio/Type/CMovementTypes.h
+++ b/Source/Portfolio/Type/CMovementTypes.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CMovementTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EMovementGait : uint8
 {

--- a/Source/Portfolio/Type/CObservableOverlayTypes.h
+++ b/Source/Portfolio/Type/CObservableOverlayTypes.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CObservableOverlayTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EObservableOverlayHandling : uint8
 {
@@ -34,6 +36,8 @@ enum class EObservableOverlayEventType : uint8
 	Max,
 };
 
+// Runtime Context
+
 USTRUCT(BlueprintType)
 struct FObservableOverlayEventContext
 {
@@ -57,6 +61,8 @@ public:
 		return EventType != EObservableOverlayEventType::None && EventType != EObservableOverlayEventType::Max;
 	}
 };
+
+// Runtime State
 
 USTRUCT(BlueprintType)
 struct FGuardObservableOverlaySnapshot

--- a/Source/Portfolio/Type/CReactionDataTypes.h
+++ b/Source/Portfolio/Type/CReactionDataTypes.h
@@ -5,6 +5,8 @@
 #include "Type/CExecutionRuleTypes.h"
 #include "CReactionDataTypes.generated.h"
 
+// Data / Config
+
 USTRUCT(BlueprintType)
 struct FReactionData
 {
@@ -44,6 +46,8 @@ public:
 public:
 	bool IsValidMinimal() const;
 };
+
+// Runtime Context
 
 USTRUCT(BlueprintType)
 struct FReactionExecutionContext

--- a/Source/Portfolio/Type/CReactionKeyTypes.h
+++ b/Source/Portfolio/Type/CReactionKeyTypes.h
@@ -5,6 +5,8 @@
 #include "Type/CCombatDamageTypes.h"
 #include "CReactionKeyTypes.generated.h"
 
+// Key / Identifier
+
 USTRUCT(BlueprintType)
 struct FReactionDataKey
 {
@@ -30,6 +32,8 @@ public:
 			&& DamageSpecKey == InOther.DamageSpecKey;
 	}
 };
+
+// Helper API
 
 FORCEINLINE uint32 GetTypeHash(const FReactionDataKey& InKey)
 {

--- a/Source/Portfolio/Type/CReactionTypes.h
+++ b/Source/Portfolio/Type/CReactionTypes.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CReactionTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EReactionType : uint8
 {

--- a/Source/Portfolio/Type/CStateTypes.h
+++ b/Source/Portfolio/Type/CStateTypes.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CStateTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EExecutionState : uint8
 {

--- a/Source/Portfolio/Type/CWeaponTypes.h
+++ b/Source/Portfolio/Type/CWeaponTypes.h
@@ -3,6 +3,8 @@
 #include "CoreMinimal.h"
 #include "CWeaponTypes.generated.h"
 
+// Enum
+
 UENUM(BlueprintType)
 enum class EWeaponType : uint8
 {
@@ -15,6 +17,8 @@ enum class EWeaponType : uint8
 
 	Max,		// Sentinel
 };
+
+// Runtime Context
 
 USTRUCT(BlueprintType)
 struct FWeaponContext

--- a/Source/Portfolio/Type/DamageEventId.h
+++ b/Source/Portfolio/Type/DamageEventId.h
@@ -2,6 +2,8 @@
 
 #include "CoreTypes.h"
 
+// Enum
+
 enum class EDamageEventTypeId : int32
 {
 	DefaultDamage = 0x1001,

--- a/Source/Portfolio/Weapon/CWeaponActor.cpp
+++ b/Source/Portfolio/Weapon/CWeaponActor.cpp
@@ -29,6 +29,8 @@ ACWeaponActor::ACWeaponActor()
 	TrailComponent->bAutoActivate = false;
 }
 
+// Component Reference
+
 void ACWeaponActor::InitializeReferences(const FCharacterComponentReferences& InReferences)
 {
 	OwnerCharacter_Injected = InReferences.OwnerCharacter;
@@ -55,11 +57,15 @@ bool ACWeaponActor::ValidateRequiredReferences() const
 	return bValid;
 }
 
+// Initial State
+
 void ACWeaponActor::ApplyInitialWeaponState(EWeaponType InWeaponType)
 {
 	ChangeWeaponType(InWeaponType);
 	AttachToHolsterSocket();
 }
+
+// Lifecycle
 
 void ACWeaponActor::BeginPlay()
 {
@@ -81,6 +87,8 @@ void ACWeaponActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 	Super::EndPlay(EndPlayReason);
 }
+
+// Collision Component
 
 void ACWeaponActor::InitializeCollisionComponents()
 {
@@ -118,6 +126,8 @@ void ACWeaponActor::ClearCollisionComponents()
 	Collisions_Cached.Empty();
 }
 
+// Trail
+
 void ACWeaponActor::InitializeTrailState()
 {
 	if (!bDisableTrailOnBeginPlay) return;
@@ -129,6 +139,8 @@ void ACWeaponActor::ClearTrailState()
 {
 	ToggleTrailActive(false);
 }
+
+// Hit Context Provider Query
 
 const FOverlapContext& ACWeaponActor::GetLastOverlapContext() const
 {
@@ -145,6 +157,8 @@ const FActionDataKey& ACWeaponActor::GetLastActionDataKey() const
 	return LastActionDataKey_Cached;
 }
 
+// Hit Context Provider Mutation
+
 void ACWeaponActor::SetLastOverlapContext(const FOverlapContext& InOverlapContext)
 {
 	LastOverlapContext_Cached = InOverlapContext;
@@ -159,6 +173,8 @@ void ACWeaponActor::SetLastActionDataKey(const FActionDataKey& InActionDataKey)
 {
 	LastActionDataKey_Cached = InActionDataKey;
 }
+
+// Mutation
 
 void ACWeaponActor::ChangeWeaponType(EWeaponType InWeaponType)
 {
@@ -181,6 +197,8 @@ void ACWeaponActor::ToggleTrailActive(bool bEnable)
 	}
 }
 
+// Equip Notify Events
+
 void ACWeaponActor::AttachToHandSocket()
 {
 	AttachToOwnerSocket(SocketName_Hand);
@@ -190,6 +208,8 @@ void ACWeaponActor::AttachToHolsterSocket()
 {
 	AttachToOwnerSocket(SocketName_Holster);
 }
+
+// Collision Notify Events
 
 void ACWeaponActor::CollisionEnabled(FName InName)
 {
@@ -322,6 +342,8 @@ void ACWeaponActor::CollisionDisabled()
 		TEXT("CollisionDisabled"));
 }
 
+// Engine Delegate Events
+
 void ACWeaponActor::OnComponentBeginOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
 {
 	UShapeComponent* overlapComp = Cast<UShapeComponent>(OverlappedComponent);
@@ -396,6 +418,8 @@ void ACWeaponActor::OnComponentEndOverlap(UPrimitiveComponent* OverlappedCompone
 	if (OnWeaponActorEndOverlap.IsBound())
 		OnWeaponActorEndOverlap.Broadcast(OwnerCharacter_Injected, OtherActor);
 }
+
+// Helper
 
 FOverlapContext ACWeaponActor::BuildOverlapContext(AActor* InOwnerActor, AActor* InDamageCauser, UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult) const
 {

--- a/Source/Portfolio/Weapon/CWeaponActor.cpp
+++ b/Source/Portfolio/Weapon/CWeaponActor.cpp
@@ -234,7 +234,7 @@ void ACWeaponActor::CollisionEnabled(FName InName)
 		}
 	}
 
-	// Early-Return
+	// Reject empty collision enable requests.
 	if (collisionsToEnable.IsEmpty())
 	{
 		FCombatSignalDebug::RecordWeaponCollisionWindowForAudit(
@@ -329,7 +329,7 @@ void ACWeaponActor::CollisionDisabled()
 			TEXT("MissingCombatSignalSourceComponentOrInvalidHitWindow"));
 	}
 
-	// Legacy delegate
+	// Notify legacy collision disabled listeners.
 	if (OnWeaponActorCollisionDisabled.IsBound())
 		OnWeaponActorCollisionDisabled.Broadcast();
 
@@ -379,7 +379,7 @@ void ACWeaponActor::OnComponentBeginOverlap(UPrimitiveComponent* OverlappedCompo
 	FCombatSignalDebug::RecordWeaponOverlapAcceptedForAudit(hitContext, TEXT("BeginOverlap"));
 	FCombatSignalDebug::PrintWeaponHitContextDebug(hitContext);
 
-	// Legacy delegate
+	// Notify legacy overlap listeners before forwarding the combat signal.
 	if (OnWeaponActorBeginOverlap.IsBound())
 		OnWeaponActorBeginOverlap.Broadcast(OwnerCharacter_Injected, this, overlapComp, OtherActor, OtherComp, OtherBodyIndex, bFromSweep, SweepResult);
 
@@ -414,7 +414,7 @@ void ACWeaponActor::OnComponentEndOverlap(UPrimitiveComponent* OverlappedCompone
 		return;
 	}
 
-	// Legacy delegate
+	// Notify legacy overlap listeners after validating the end overlap.
 	if (OnWeaponActorEndOverlap.IsBound())
 		OnWeaponActorEndOverlap.Broadcast(OwnerCharacter_Injected, OtherActor);
 }
@@ -445,7 +445,7 @@ FHitImpactContext ACWeaponActor::BuildHitImpactContext(const FOverlapContext& In
 
 	if (!IsValid(InOverlapContext.OverlappedComponent) || !IsValid(InOverlapContext.OtherComponent))
 	{
-		// Invalid
+		// Invalid overlap context cannot produce hit impact data.
 		return hitImpactContext;
 	}
 
@@ -465,7 +465,7 @@ FHitImpactContext ACWeaponActor::BuildHitImpactContext(const FOverlapContext& In
 
 	if (distance < 0.f)
 	{
-		// Invalid
+		// Invalid closest-point query cannot produce hit impact data.
 		return hitImpactContext;
 	}
 

--- a/Source/Portfolio/Weapon/CWeaponActor.h
+++ b/Source/Portfolio/Weapon/CWeaponActor.h
@@ -150,6 +150,7 @@ public:
 	void OnComponentEndOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex);
 
 private:
+	// Helper
 	FOverlapContext BuildOverlapContext(AActor* InOwnerActor, AActor* InDamageCauser, UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult) const;
 	FHitImpactContext BuildHitImpactContext(const FOverlapContext& InOverlapContext) const;
 	FHitContext BuildHitContext(const FOverlapContext& InOverlapContext) const;


### PR DESCRIPTION
# UE5 Portfolio Pull Request

## 제목

**P50: Section Comment Consistency**

## 날짜

**2026.07.25**

## 상태

- [x] 섹션 주석 판단 규칙 문서화
- [x] 파일군별 section policy 정리
- [x] `.h / .cpp` 책임 섹션 동기화 기준 반영
- [x] Action / Reaction / Component / Controller / System / Weapon 섹션 정리
- [x] BT Service / RuntimeLOD / Core Profiling / Type 구현 cpp 섹션 정리
- [x] 단계형 / Case / 로컬 설명형 주석 정리
- [x] 예외 파일군 판단 기준 문서화
- [x] 큰 파일 무섹션 후보 재스캔 완료
- [x] `git diff --check` 통과
- [x] `PortfolioEditor Win64 Development` build 통과
- [x] PIE smoke 확인

## 브랜치

- `refactor/section-comment-consistency`

## 요약

이번 PR은 W05 코드 품질 정리 흐름의 후속 작업으로, `Source/Portfolio`의 섹션 주석 체계와 파일군별 판단 기준을 정리한다.

핵심 기준은 모든 파일에 같은 섹션을 강제하는 것이 아니라, 같은 성격 / 책임 / 파일 패턴을 가진 파일군끼리 같은 섹션 체계를 쓰는 것이다. 짧은 UE adapter, Interface, Type helper처럼 함수 자체가 구조를 설명하는 파일은 섹션 생략을 허용하고, Component / Controller / Action / Reaction / BT Service처럼 책임이 반복되는 파일군은 공통 섹션명을 우선 사용한다.

코드 동작, 타입명, 함수명, 시그니처, UPROPERTY, UFUNCTION, Blueprint 노출 계약은 변경하지 않았다.

## 변경 배경

기존 코드에는 다음 문제가 섞여 있었다.

```text
-> 같은 책임인데 파일마다 섹션명이 다름
-> .h에는 섹션이 있지만 .cpp에는 대응 섹션이 없음
-> .cpp에는 구현 흐름 섹션이 있지만 .h 책임 구조와 연결이 약함
-> Case 1, Another Case, Result, Context 같은 로컬 설명이 섹션처럼 보임
-> 짧은 파일과 큰 파일에 같은 기준을 적용할지 판단 기준이 불명확함
```

이번 PR에서는 이를 한 번에 같은 규칙으로 정리했다.

```text
1. 같은 파일군은 같은 책임 섹션을 사용한다.
2. 파일 고유 책임은 고유 섹션으로 허용한다.
3. .h / .cpp는 함수 1:1이 아니라 책임 그룹 기준으로 동기화한다.
4. 로컬 흐름 설명은 섹션이 아니라 문장형 주석으로 작성한다.
5. 짧고 단일 책임인 UE adapter / Interface / Type cpp는 섹션을 생략할 수 있다.
```

## 변경 범위

### 1. 섹션 주석 정책 문서화

무엇

W05 comment / section cleanup 문서에 파일군별 section policy를 추가했다.

어떻게

다음 파일군을 독립 판단 대상으로 정리했다.

```text
-> Action / Reaction Base
-> Action / Reaction Derived
-> Component
-> Controller
-> Behavior Tree Service / Task / Decorator
-> AI RuntimeLOD Policy
-> Character
-> System
-> Weapon
-> Type
-> Core Debug / Profiling
-> Notify / Interface / Blackboard / Patrol / Module
```

결과

`Source/Portfolio` 상위 계열 전체가 섹션 주석 판단 규칙 안에 들어왔다.

### 2. Action / Reaction 계열 섹션 정리

무엇

Action / Reaction base와 파생 클래스의 섹션명을 계열 기준으로 맞췄다.

어떻게

공통 책임은 아래 이름을 우선 사용했다.

```text
-> Decision
-> Lifecycle
-> Notify
-> Observable Overlay
-> Intervention
-> State Transition
```

파일 고유 책임은 고유 섹션으로 유지했다.

```text
-> Chain Reservation
-> Chain Window
-> Chain Query
-> Weapon
-> Guard State Cleanup
```

결과

`CAction_ComboAttack`, `CAction_Dodge`, `CAction_Guard`, `CAction_Equip`, `CAction_Unequip`, `CReaction_Hit`, `CReaction_Dead`, `CReaction_Stagger`, `CReaction_Parry`, `CReaction_BlockHit`의 책임 구분이 base class와 같은 기준으로 정리됐다.

### 3. Component / Controller / Character / System / Weapon 섹션 정리

무엇

큰 gameplay 파일과 runtime service 파일의 `.h / .cpp` 책임 섹션을 동기화했다.

어떻게

Component 계열은 다음 공통 섹션을 우선 사용했다.

```text
-> Component Reference
-> Lifecycle
-> Runtime Lifecycle
-> Query
-> Mutation
-> Runtime State
-> State Transition
-> Request / Entry
-> Receive
-> Resolve
-> Apply
-> Packet
-> Notify
-> Helper
```

도메인 고유 섹션은 유지했다.

```text
-> Movement Arbitration
-> Movement Input
-> Movement Policy
-> Hit Window
-> AI Entry
-> Camera Shake
-> Assignment Build
-> Assignment Warmup
-> Engine Delegate Events
```

결과

Component / Controller / Character / System / Weapon 계열의 공통 책임 섹션이 같은 이름으로 정리됐고, 파일 고유 책임은 필요한 곳에만 남았다.

### 4. BT Service / RuntimeLOD / Core Profiling / Type cpp 정리

무엇

BT Service, RuntimeLOD resolver, Core Profiling, Type implementation cpp의 섹션 기준을 보강했다.

어떻게

BT Service는 context / blackboard 흐름 기준으로 정리했다.

```text
-> Lifecycle
-> Context Build
-> Context Compute
-> Blackboard Update
-> Blackboard Clear
-> Intent Decision
-> Intent Transition
```

Core Profiling은 profiling 책임 기준으로 정리했다.

```text
-> Gate
-> Counter
-> Service Tick Counter
-> Interval Preset Counter
```

Type cpp는 헤더 taxonomy와 맞는 최소 섹션만 추가했다.

```text
-> Helper API
-> Data / Config
-> Runtime State
```

결과

BT Service / RuntimeLOD / Core Profiling / Type 구현 파일의 책임 구분이 문서 규칙과 코드 양쪽에서 맞춰졌다.

### 5. 단계형 / Case / 로컬 설명 주석 정리

무엇

섹션처럼 보이던 로컬 설명 주석을 문장형 설명으로 바꿨다.

어떻게

다음 패턴을 정리했다.

```text
-> Case 1 / Case 2
-> GuardState Case / Another Case
-> Default Action Case / Default Reaction Case
-> Idle && No ActivePart / No Idle && Has ActivePart
-> Based OwnerPawn / Based Perception / Based TargetActor
-> Absolute States / Context / Result
-> Resolve Executor / Candidate SpecKey
-> Delay for Warmup / Flag Toggle
-> Slow InActor / Restore InActor
-> Early-Return / Invalid / Legacy delegate
-> V1 hook only
```

결과

섹션 주석과 로컬 흐름 설명의 경계가 분리됐다.

### 6. 예외 파일군 기준 정리

무엇

무조건 섹션을 넣지 않아도 되는 파일군을 명시했다.

어떻게

다음 파일군은 짧거나, framework adapter 성격이 강하거나, 자체 구조가 명확하면 섹션 생략을 허용한다.

```text
-> BT Task / Decorator
-> Notify
-> Interface
-> AI Blackboard
-> AI Patrol
-> 짧은 Type cpp
-> Module / Global
```

결과

일관성과 파일 고유성 사이의 판단 기준이 문서화됐다.

## 주요 처리 흐름

```text
섹션 주석 정책 문서화
-> 파일군별 판단 기준 정리
-> Type header taxonomy 재확인
-> Action / Reaction 계열 섹션 정리
-> Component / Controller / Character / System / Weapon 섹션 정리
-> BT Service / RuntimeLOD / Core Profiling / Type cpp 섹션 정리
-> 단계형 / Case / 로컬 설명 주석 정리
-> 예외 파일군 기준 정리
-> 큰 파일 무섹션 후보 재스캔
-> git diff --check
-> PortfolioEditor Win64 Development build
-> PIE smoke
```

## 구현 결과

```text
main...HEAD
-> 107 files changed, 1626 insertions(+), 195 deletions(-)

commit range
-> 5fd828bf docs(style): define section comment consistency rules
-> d7c6e9a8b docs(style): define section comment workflow rules
-> d0cc14ce style(type): add section taxonomy comments
-> 2903361a style(combat): sync source section comments
-> 85e4f83f style(feedback): sync header and source sections
-> 24d7b073 style(combat): normalize signal step comments
-> d82750d3 style(core): sync remaining header and source sections
-> 5480b14f style(component): normalize remaining step comments
-> 06fce7c3 style(comments): align controller blackboard section label
-> c20b2107 style(comments): standardize section comment layout
-> ee6f1b86 docs(comments): clarify section synchronization rules
-> ca6c7cf8 refactor(style): align section comment policy
-> 10c68dc3 refactor(style): align section comment policy
```

변경함:

```text
-> 섹션 주석 정책 문서화
-> 파일군별 section policy 추가
-> .h / .cpp 책임 섹션 동기화
-> Action / Reaction / Component / Controller / Character / System / Weapon 섹션 정리
-> BT Service / RuntimeLOD / Core Profiling / Type cpp 섹션 보강
-> 단계형 / Case / 로컬 설명 주석 정리
-> AI Blackboard helper 섹션 보강
-> CHealthComponent.h 중복 InitializeHealth 선언 제거
```

변경하지 않음:

```text
-> 타입명
-> 함수명
-> enum entry
-> UPROPERTY
-> UFUNCTION / Blueprint 노출 signature
-> delegate signature
-> override signature
-> gameplay logic
-> CombatSignal reserved scaffold
-> Feedback key model
```

## 테스트 방법

```text
1. 파일군별 section policy 문서 확인
2. 단계형 / Case / 흔들리는 로컬 라벨 패턴 재스캔
3. 큰 파일 무섹션 후보 재스캔
4. git diff --check
5. PortfolioEditor Win64 Development build
6. PIE smoke 실행
```

## 검증 결과

### Static check

```text
git diff --check
Result: Pass
```

### Pattern scan

```text
단계형 / Case / 흔들리는 로컬 라벨 후보
Result: 0건

큰 파일 무섹션 후보
Result: 0건

남은 Condition / Record
Result: CAnimInstance 유지 결정 범위

남은 Result
Result: Type taxonomy 섹션
```

### Build

```text
PortfolioEditor Win64 Development
Result: Pass
```

### PIE

```text
PIE smoke
Result: Pass
```

## 비고 / 후속 작업

- 이번 PR은 주석 / 섹션 / 문서 정책 정리이며 gameplay behavior 변경 PR이 아니다.
- Notify / Interface / BT Task / Decorator / 짧은 Type cpp는 파일이 커지거나 책임이 나뉘는 시점에만 섹션을 추가한다.
- 향후 AI 작업 시스템은 `File Family Section Policy`를 기준으로 같은 파일군의 섹션명을 우선 맞춘다.

## 관련 문서

- Work List: `W05_UE5_Portfolio_Work_List.md`
- Section Cleanup Work Plan: `W05_Comment_Section_Cleanup_Work_Plan.md`
- AI Workflow Rule: `02_Project_Stella_Working_Rule_Prompt (KR).md`
- Previous PR: `P49_UE5_Portfolio_Pull_Request.md`

## 정리

이번 PR은 파일군별 섹션 주석 판단 기준을 문서화하고, 주요 코드 파일의 섹션명을 같은 책임 단위로 정리했다.

결과적으로 `Source/Portfolio`의 모든 상위 파일군은 section policy 안에서 판단 가능해졌고, 섹션 주석과 로컬 흐름 설명의 경계도 분리됐다.
